### PR TITLE
Simplify linting

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,10 +16,8 @@ jobs:
         run: sudo gem install apiaryio
       - name: Install dependencies
         run: npm install
-      - name: Lint Markdown
-        run: npm run lint:md
-      - name: Lint code
-        run: npm run lint:code
+      - name: Lint
+        run: npm run lint:fix
       - name: Build documentation
         run: npm run build
       - name: Upload docs to AWS S3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,8 +16,10 @@ jobs:
         run: sudo gem install apiaryio
       - name: Install dependencies
         run: npm install
-      - name: Lint
-        run: npm run lint:fix
+      - name: Lint Markdown
+        run: npm run lint:md:fix
+      - name: Lint code
+        run: npm run lint:code:fix
       - name: Build documentation
         run: npm run build
       - name: Upload docs to AWS S3

--- a/package.json
+++ b/package.json
@@ -4,12 +4,10 @@
   "description": "This is a home of Apify documentation.",
   "main": "index.js",
   "scripts": {
-    "build": "npm run lint:md && npm run lint:code && node ./src/build.js",
+    "build": "npm run lint:fix && node ./src/build.js",
     "test": "npm run test",
-    "lint:md": "./node_modules/.bin/markdownlint '**/*.md'",
-    "lint:md:fix": "./node_modules/.bin/markdownlint '**/*.md' --fix",
-    "lint:code": "./node_modules/.bin/eslint . && eslint --ext js,md --fix .",
-    "lint:code:fix": "./node_modules/.bin/eslint . --ext .js,.jsx --fix && eslint --ext js,md --fix ."
+    "lint": "./node_modules/.bin/markdownlint '**/*.md' && ./node_modules/.bin/eslint . && eslint --ext js,md",
+    "lint:fix": "./node_modules/.bin/markdownlint '**/*.md' --fix && ./node_modules/.bin/eslint . --ext .js,.jsx --fix && eslint --ext js,md --fix ."
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "npm run lint:md && npm run lint:code && node ./src/build.js",
     "test": "npm run test",
-    "lint": "./node_modules/.bin/markdownlint '**/*.md' && ./node_modules/.bin/eslint . && eslint --ext js,md",
-    "lint:fix": "./node_modules/.bin/markdownlint '**/*.md' --fix && ./node_modules/.bin/eslint . --ext .js,.jsx --fix && eslint --ext js,md --fix .",
+    "lint": "npm run lint:md && npm run lint:code",
+    "lint:fix": "npm run lint:md:fix && npm run lint:code:fix",
     "lint:md": "./node_modules/.bin/markdownlint '**/*.md'",
     "lint:md:fix": "./node_modules/.bin/markdownlint '**/*.md' --fix",
     "lint:code": "./node_modules/.bin/eslint . && eslint --ext js,md",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,11 @@
     "build": "npm run lint:fix && node ./src/build.js",
     "test": "npm run test",
     "lint": "./node_modules/.bin/markdownlint '**/*.md' && ./node_modules/.bin/eslint . && eslint --ext js,md",
-    "lint:fix": "./node_modules/.bin/markdownlint '**/*.md' --fix && ./node_modules/.bin/eslint . --ext .js,.jsx --fix && eslint --ext js,md --fix ."
+    "lint:fix": "./node_modules/.bin/markdownlint '**/*.md' --fix && ./node_modules/.bin/eslint . --ext .js,.jsx --fix && eslint --ext js,md --fix .",
+    "lint:md": "./node_modules/.bin/markdownlint '**/*.md'",
+    "lint:md:fix": "./node_modules/.bin/markdownlint '**/*.md' --fix",
+    "lint:code": "./node_modules/.bin/eslint . && eslint --ext js,md",
+    "lint:code:fix": "./node_modules/.bin/eslint . --ext .js,.jsx --fix && eslint --ext js,md --fix ."
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "This is a home of Apify documentation.",
   "main": "index.js",
   "scripts": {
-    "build": "npm run lint:fix && node ./src/build.js",
+    "build": "npm run lint:md && npm run lint:code && node ./src/build.js",
     "test": "npm run test",
     "lint": "./node_modules/.bin/markdownlint '**/*.md' && ./node_modules/.bin/eslint . && eslint --ext js,md",
     "lint:fix": "./node_modules/.bin/markdownlint '**/*.md' --fix && ./node_modules/.bin/eslint . --ext .js,.jsx --fix && eslint --ext js,md --fix .",


### PR DESCRIPTION
I tried to separate linting for Markdown and JS but turned out to be pretty annoying to specify which one to lint each time.

Joining all the lint commands into one