### PR TITLE
Use new URL for API client

### DIFF
--- a/docs/apify_client_js.md
+++ b/docs/apify_client_js.md
@@ -1,6 +1,7 @@
 ---
 title: JavaScript API client
 description: Simplified access to the Apify API from any JavaScript or Node.js application. Manage your actors, tasks and storage via API with the apify-client NPM package.
+externalSourceUrl: https://raw.githubusercontent.com/apify/apify-client-js/master/README.md
 category: developer tools
 menuWeight: 14
 paths:

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,7 +1,7 @@
 ---
 title: Command-line interface
 description: Create new actors from your computer's command line. Run actors locally or deploy them to the Apify platform. View the Apify CLI's command reference.
-externalSourceUrl: https://raw.githubusercontent.com/apifytech/apify-cli/master/README.md
+externalSourceUrl: https://raw.githubusercontent.com/apify/apify-client-js/master/README.md
 menuWeight: 15
 category: developer tools
 paths:

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,7 +1,7 @@
 ---
 title: Command-line interface
 description: Create new actors from your computer's command line. Run actors locally or deploy them to the Apify platform. View the Apify CLI's command reference.
-externalSourceUrl: https://raw.githubusercontent.com/apify/apify-client-js/master/README.md
+externalSourceUrl: https://raw.githubusercontent.com/apifytech/apify-cli/master/README.md
 menuWeight: 15
 category: developer tools
 paths:


### PR DESCRIPTION
Make API Client docs use externalSourceUrl like CLI docs do. The content is now in GitHub, not in S3.

This will involve removing the redirects on Web

Excuse the branch name, I always confuse the two.