### PR TITLE
Change page title for "Publishing actors"

### DIFF
--- a/docs/actors/publishing.md
+++ b/docs/actors/publishing.md
@@ -1,6 +1,7 @@
 ---
 title: Publishing
 description: Learn how to make your actor available to the public or keep it private. Prepare your actor for Apify Store with a description and README file.
+menuTitle: Publishing
 menuWeight: 7.6
 paths:
 # NOTE: IF ADDING A NEW PATH, LEAVE THE OLD ONES FOR REDIRECTS

--- a/docs/actors/publishing.md
+++ b/docs/actors/publishing.md
@@ -1,5 +1,5 @@
 ---
-title: Publishing
+title: Publishing actors
 description: Learn how to make your actor available to the public or keep it private. Prepare your actor for Apify Store with a description and README file.
 menuTitle: Publishing
 menuWeight: 7.6


### PR DESCRIPTION
I'd like to add a more descriptive page title for Google, but keep the simpler one in the menu. For example, I’d like to have page title “Publishing actors” on google, but keep just “Publishing” in the menu.

@m-murasovs is this the right way?