### PR TITLE
Add authentication bearer info for API requests

### DIFF
--- a/docs/api_v2/api_v2_reference.apib
+++ b/docs/api_v2/api_v2_reference.apib
@@ -26,7 +26,15 @@ from services that can only send GET requests.
 You can find your API token on the
 [Integrations](https://my.apify.com/account#/integrations) page in the Apify app.
 
-Add the token as the `token` parameter to your request URL.
+To use your token in a request, either:
+- Add the token to your request's `Authorization` header as `Bearer <token>`.
+E.g., `Authorization: Bearer y373yssyyT66`.
+[More info](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Authorization). (Recommended).
+- Add it as the `token` parameter to your request URL. (Less secure).
+
+Using your token in the request header is more secure than using it as a URL parameter because URLs are often stored
+in browser history and server logs. This creates a chance for someone unauthorized to access
+your API token.
 
 **Do not share your API token or password with untrusted parties.**
 
@@ -40,7 +48,7 @@ To run an actor, send a POST request to the [Run actor](#reference/actors/run-co
 
 If the actor is not runnable anonymously, you will receive a 401 or 403
 [response code](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status).
-This means you need to append your [secret API token](https://my.apify.com/account#/integrations) as a query parameter `?token=[your_token]`.
+This means you need to add your [secret API token](https://my.apify.com/account#/integrations) to the request's `Authorization` header ([recommended](https://docs.apify.com/api/v2#/introduction/authentication)) or as a URL query parameter `?token=[your_token]` (less secure).
 
 Optionally, you can include the query parameters described in the [Run actor](#reference/actors/run-collection/run-actor) section to customize your run.
 

--- a/docs/api_v2/api_v2_reference.apib
+++ b/docs/api_v2/api_v2_reference.apib
@@ -28,7 +28,7 @@ You can find your API token on the
 
 To use your token in a request, either:
 - Add the token to your request's `Authorization` header as `Bearer <token>`.
-E.g., `Authorization: Bearer y373yssyyT66`.
+E.g., `Authorization: Bearer xxxxxxx`.
 [More info](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Authorization). (Recommended).
 - Add it as the `token` parameter to your request URL. (Less secure).
 
@@ -48,7 +48,7 @@ To run an actor, send a POST request to the [Run actor](#reference/actors/run-co
 
 If the actor is not runnable anonymously, you will receive a 401 or 403
 [response code](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status).
-This means you need to add your [secret API token](https://my.apify.com/account#/integrations) to the request's `Authorization` header ([recommended](https://docs.apify.com/api/v2#/introduction/authentication)) or as a URL query parameter `?token=[your_token]` (less secure).
+This means you need to add your [secret API token](https://my.apify.com/account#/integrations) to the request's `Authorization` header ([recommended](#introduction/authentication)) or as a URL query parameter `?token=[your_token]` (less secure).
 
 Optionally, you can include the query parameters described in the [Run actor](#reference/actors/run-collection/run-actor) section to customize your run.
 
@@ -470,6 +470,8 @@ The response is the full actor object as returned by the
 
 The request needs to specify the `Content-Type: application/json` HTTP header!
 
+When providing your API authentication token, we recommend using the request's `Authorization` header, rather than the URL. ([More info](#introduction/authentication)).
+
 + Request (application/json)
 
     + Attributes(ActUpdate)
@@ -616,6 +618,8 @@ passed as JSON in the POST payload.
 If the object does not define a specific property, its value will not be updated.
 
 The request needs to specify the `Content-Type: application/json` HTTP header!
+
+When providing your API authentication token, we recommend using the request's `Authorization` header, rather than the URL. ([More info](#introduction/authentication)).
 
 The response is the [Version object](#reference/actors/version-object) as returned by the
 [Get version](#reference/actors/version-object/get-version) endpoint.
@@ -1382,6 +1386,8 @@ The response is the full task object as returned by the
 
 The request needs to specify the `Content-Type: application/json` HTTP header!
 
+When providing your API authentication token, we recommend using the request's `Authorization` header, rather than the URL. ([More info](#introduction/authentication)).
+
 + Request (application/json)
 
     + Attributes(TaskCreate)
@@ -1420,6 +1426,8 @@ The response is the full task object as returned by the
 [Get task](#reference/tasks/task-object/get-task) endpoint.
 
 The request needs to specify the `Content-Type: application/json` HTTP header!
+
+When providing your API authentication token, we recommend using the request's `Authorization` header, rather than the URL. ([More info](#introduction/authentication)).
 
 + Request (application/json)
 
@@ -1465,6 +1473,8 @@ The response is the full task input as returned by the
 [Get task](#reference/tasks/task-input-object/get-task-input) endpoint.
 
 The request needs to specify the `Content-Type: application/json` HTTP header!
+
+When providing your API authentication token, we recommend using the request's `Authorization` header, rather than the URL. ([More info](#introduction/authentication)).
 
 + Request (application/json)
 
@@ -3123,6 +3133,8 @@ The response is the full webhook object as returned by the
 
 The request needs to specify the `Content-Type: application/json` HTTP header!
 
+When providing your API authentication token, we recommend using the request's `Authorization` header, rather than the URL. ([More info](#introduction/authentication)).
+
 + Request (application/json)
 
     + Attributes(WebhookUpdate)
@@ -3262,6 +3274,8 @@ The response is the created schedule object.
 
 The request needs to specify the `Content-Type: application/json` HTTP header!
 
+When providing your API authentication token, we recommend using the request's `Authorization` header, rather than the URL. ([More info](#introduction/authentication)).
+
 + Request (application/json)
 
     + Attributes(ScheduleCreate)
@@ -3300,6 +3314,8 @@ The response is the full schedule object as returned by the
 [Get schedule](#reference/schedules/schedule-object/get-schedule) endpoint.
 
 **The request needs to specify the `Content-Type: application/json` HTTP header!**
+
+When providing your API authentication token, we recommend using the request's `Authorization` header, rather than the URL. ([More info](#introduction/authentication)).
 
 + Request (application/json)
 

--- a/docs/schedules.md
+++ b/docs/schedules.md
@@ -55,11 +55,11 @@ If you are an advanced user, you can also add a [webhook](https://docs.apify.com
 
 ### [](#via-api) Via API
 
-To [create a new schedule](https://docs.apify.com/api/v2#/reference/schedules) using the [Apify API](https://docs.apify.com/api/v2#), send a [POST request](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/POST) to
+To [create a new schedule](https://docs.apify.com/api/v2#/reference/schedules) using the [Apify API](https://docs.apify.com/api/v2#), send a [POST request](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/POST) to the [create schedule](https://docs.apify.com/api/v2#/reference/schedules/schedules-collection/create-schedule) endpoint.
 
-`https://api.apify.com/v2/schedules?token={YOUR_API_TOKEN}`.
+You can find your [secret API token]({{@link tutorials/integrations.md#api-token}}) in your Apify account's [Integrations](https://my.apify.com/account#/integrations) tab. When providing your API authentication token, we recommend using the request's `Authorization` header, rather than the URL. ([More info](/api/v2#/introduction/authentication)).
 
-You can find your [secret API token]({{@link tutorials/integrations.md#api-token}}) in your Apify account's [Integrations](https://my.apify.com/account#/integrations) tab. In the POST request's payload should be a JSON object specifying the schedule's name, your [user ID](https://my.apify.com/account#/integrations), and the schedule's **actions**.
+In the POST request's payload should be a JSON object specifying the schedule's name, your [user ID](https://my.apify.com/account#/integrations), and the schedule's **actions**.
 
 The below JSON object creates a schedule which runs an SEO audit of the Apify domain once a month.
 

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -140,7 +140,7 @@ In most cases, when accessing your storages via API, you will need to provide a 
 
 For read (GET) requests, it is enough to use a store's alpha-numerical ID, since the ID is hard to guess and effectively serves as an authentication key.
 
-With other request types and when using the **username~store-name**, however, you will need to provide your secret API token as a query parameter. You can find your token on the [Integrations](https://my.apify.com/account#/integrations) page of your Apify account.
+With other request types and when using the **username~store-name**, however, you will need to provide your secret API token in [your request's `Authorization` header](/api/v2#/introduction/authentication) or as a query parameter. You can find your token on the [Integrations](https://my.apify.com/account#/integrations) page of your Apify account.
 
 For more information and a detailed breakdown of each storage API endpoint, see the [API documentation](https://docs.apify.com/api/v2#/reference/datasets).
 

--- a/docs/storage/dataset.md
+++ b/docs/storage/dataset.md
@@ -157,25 +157,27 @@ For more information, see the JavaScript API client [documentation](https://docs
 
 The [Apify API](https://docs.apify.com/api/v2#/reference/datasets) allows you to access your datasets programmatically using [HTTP requests](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods) and easily share your crawling results.
 
-If you are accessing your datasets using the **username~store-name** [store ID format]({{@link storage.md#apify-api}}), you will need to append your [secret API token]({{@link tutorials/integrations.md#api-token}}) as a query parameter (see below). You can find the token (and your user ID) on the [Integrations](https://my.apify.com/account#/integrations) page of your Apify account.
+If you are accessing your datasets using the **username~store-name** [store ID format]({{@link storage.md#apify-api}}), you will need to use your [secret API token]({{@link tutorials/integrations.md#api-token}}). You can find the token (and your user ID) on the [Integrations](https://my.apify.com/account#/integrations) page of your Apify account.
 
-To **get a list of your datasets**, send a GET request to the [Get list of datasets](https://docs.apify.com/api/v2#/reference/datasets/get-list-of-datasets) endpoint, providing your API token as a query parameter.
+> When providing your API authentication token, we recommend using the request's `Authorization` header, rather than the URL. ([More info](#introduction/authentication)).
+
+To **get a list of your datasets**, send a GET request to the [Get list of datasets](https://docs.apify.com/api/v2#/reference/datasets/get-list-of-datasets) endpoint.
 
 ```text
-https://api.apify.com/v2/datasets?token={YOUR_API_TOKEN}
+https://api.apify.com/v2/datasets
 ```
 
 To **get information about a dataset** such as its creation time and **item count**, send a GET request to the [Get dataset](https://docs.apify.com/api/v2#/reference/datasets/dataset/get-dataset) endpoint.
 
 ```text
-https://api.apify.com/v2/datasets/{DATASET_ID}?token={YOUR_API_TOKEN}
+https://api.apify.com/v2/datasets/{DATASET_ID}
 ```
 
 To **view a dataset's data**, send a GET request to the
 [Get dataset items](https://docs.apify.com/api/v2#/reference/datasets/item-collection/get-items) Apify API endpoint.
 
 ```text
-https://api.apify.com/v2/datasets/{DATASET_ID}/items/?token={YOUR_API_TOKEN}
+https://api.apify.com/v2/datasets/{DATASET_ID}/items
 ```
 
 You can **specify which data are exported** by adding a comma-separated list of fields to the **fields** query parameter. Likewise, you can also omit certain fields using the **omit** parameter.
@@ -187,7 +189,7 @@ In addition, you can set the format in which you retrieve the data using the **?
 To retrieve the **hotel** and **cafe** fields, you would send your GET request to the URL below.
 
 ```text
-https://api.apify.com/v2/datasets/{DATASET_ID}/items?format=json?token={YOUR_API_TOKEN}&fields=hotel%2Ccafe
+https://api.apify.com/v2/datasets/{DATASET_ID}/items?format=json&fields=hotel%2Ccafe
 ```
 
 > Instead of commas, you will need to use the `%2C` code, which represents `,` in URL encoding.<br/>
@@ -196,7 +198,7 @@ https://api.apify.com/v2/datasets/{DATASET_ID}/items?format=json?token={YOUR_API
 To **add data to a dataset**, send a POST request, with a JSON object containing the data you want to add as the payload to the [Put items](https://docs.apify.com/api/v2#/reference/datasets/item-collection/put-items) endpoint.
 
 ```text
-https://api.apify.com/v2/datasets/{DATASET_ID}/items/?token={YOUR_API_TOKEN}
+https://api.apify.com/v2/datasets/{DATASET_ID}/items
 ```
 
 > Pushing data to dataset via API is limited to **200** requests per second to prevent our servers from being overloaded.

--- a/docs/storage/key_value_store.md
+++ b/docs/storage/key_value_store.md
@@ -151,30 +151,32 @@ For more information on managing your key-value stores using the JavaScript API 
 
 The [Apify API](https://docs.apify.com/api/v2#/reference/key-value-stores) allows you to access your key-value stores programmatically using [HTTP requests](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods) and easily share your crawling results.
 
-If you are accessing your stores using the **username~store-name** [store ID format]({{@link storage.md#apify-api}}), you will need to append your [secret API token]({{@link tutorials/integrations.md#api-token}}) as a query parameter (see below). You can find the token (and your user ID) on the [Integrations](https://my.apify.com/account#/integrations) page of your Apify account.
+If you are accessing your datasets using the **username~store-name** [store ID format]({{@link storage.md#apify-api}}), you will need to use your [secret API token]({{@link tutorials/integrations.md#api-token}}). You can find the token (and your user ID) on the [Integrations](https://my.apify.com/account#/integrations) page of your Apify account.
 
-To **get a list of your key-value stores**, send a GET request to the [Get list of key-value stores](https://docs.apify.com/api/v2#/reference/key-value-stores/store-collection/get-list-of-key-value-stores) endpoint, providing your secret API token as a query parameter.
+> When providing your API authentication token, we recommend using the request's `Authorization` header, rather than the URL. ([More info](#introduction/authentication)).
+
+To **get a list of your key-value stores**, send a GET request to the [Get list of key-value stores](https://docs.apify.com/api/v2#/reference/key-value-stores/store-collection/get-list-of-key-value-stores) endpoint.
 
 ```text
-https://api.apify.com/v2/key-value-stores?token={YOUR_API_TOKEN}
+https://api.apify.com/v2/key-value-stores
 ```
 
 To **get information about a key-value store** such as its creation time and item count, send a GET request to the [Get store](https://docs.apify.com/api/v2#/reference/key-value-stores/store-object/get-store) endpoint.
 
 ```text
-https://api.apify.com/v2/key-value-stores/{STORE_ID}?token={YOUR_API_TOKEN}
+https://api.apify.com/v2/key-value-stores/{STORE_ID}
 ```
 
 To **get a record** (its value) from a key-value store, send a GET request to the [Get record](https://docs.apify.com/api/v2#/reference/key-value-stores/key-collection/get-record) endpoint.
 
 ```text
-https://api.apify.com/v2/key-value-stores/{STORE_ID}/records/{KEY_ID}?token={YOUR_API_TOKEN}
+https://api.apify.com/v2/key-value-stores/{STORE_ID}/records/{KEY_ID}
 ```
 
 To **add a record** to a specific key in a key-value store, send a PUT request to the [Put record](https://docs.apify.com/api/v2#/reference/key-value-stores/record/put-record) endpoint.
 
 ```text
-https://api.apify.com/v2/key-value-stores/{STORE_ID}/records/{KEY_ID}?token={YOUR_API_TOKEN}
+https://api.apify.com/v2/key-value-stores/{STORE_ID}/records/{KEY_ID}
 ```
 
 Example payload:
@@ -189,7 +191,7 @@ Example payload:
 To **delete a record**, send a DELETE request specifying the key from a key-value store to the [Delete record](https://docs.apify.com/api/v2#/reference/key-value-stores/record/delete-record) endpoint.
 
 ```text
-https://api.apify.com/v2/key-value-stores/{STORE_ID}/records/{KEY_ID}?token={YOUR_API_TOKEN}
+https://api.apify.com/v2/key-value-stores/{STORE_ID}/records/{KEY_ID}
 ```
 
 For a detailed breakdown of each API endpoint, see the [API documentation](https://docs.apify.com/api/v2#/reference/key-value-stores).

--- a/docs/storage/request_queue.md
+++ b/docs/storage/request_queue.md
@@ -157,30 +157,32 @@ For more information on managing your request queues using the JavaScript API cl
 
 The [Apify API](https://docs.apify.com/api/v2#/reference/request-queues) allows you to access your request queues programmatically using [HTTP requests](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods).
 
-If you are accessing your request queues using the **username~store-name** [store ID format]({{@link storage.md#apify-api}}), you will need to append your [secret API token]({{@link tutorials/integrations.md#api-token}}) as a query parameter (see below). You can find the token (and your user ID) on the [Integrations](https://my.apify.com/account#/integrations) page of your Apify account.
+If you are accessing your datasets using the **username~store-name** [store ID format]({{@link storage.md#apify-api}}), you will need to use your [secret API token]({{@link tutorials/integrations.md#api-token}}). You can find the token (and your user ID) on the [Integrations](https://my.apify.com/account#/integrations) page of your Apify account.
 
-To **get a list of your request queues**, send a GET request to the [Get list of request queues](https://docs.apify.com/api/v2#/reference/request-queues/store-collection/get-list-of-request-queues) endpoint, providing your secret API token as a query parameter.
+> When providing your API authentication token, we recommend using the request's `Authorization` header, rather than the URL. ([More info](#introduction/authentication)).
+
+To **get a list of your request queues**, send a GET request to the [Get list of request queues](https://docs.apify.com/api/v2#/reference/request-queues/store-collection/get-list-of-request-queues) endpoint.
 
 ```text
-https://api.apify.com/v2/request-queues?token={YOUR_API_TOKEN}
+https://api.apify.com/v2/request-queues
 ```
 
 To **get information about a request queue** such as its creation time and item count, send a GET request to the [Get request queue](https://docs.apify.com/api/v2#/reference/request-queues/queue/get-request-queue) endpoint.
 
 ```text
-https://api.apify.com/v2/request-queues/{QUEUE_ID}?token={YOUR_API_TOKEN}
+https://api.apify.com/v2/request-queues/{QUEUE_ID}
 ```
 
 To **get a request from a queue**, send a GET request to the [Get request](https://docs.apify.com/api/v2#/reference/request-queues/request/get-request) endpoint.
 
 ```text
-https://api.apify.com/v2/request-queues/{QUEUE_ID}/requests/{REQUEST_ID}?token={YOUR_API_TOKEN}
+https://api.apify.com/v2/request-queues/{QUEUE_ID}/requests/{REQUEST_ID}
 ```
 
 To **add a request to a queue**, send a POST request with the request to be added as a JSON object in the request's payload to the [Add request](https://docs.apify.com/api/v2#/reference/request-queues/request-collection/add-request) endpoint.
 
 ```text
-https://api.apify.com/v2/request-queues/{QUEUE_ID}/requests?token={YOUR_API_TOKEN}
+https://api.apify.com/v2/request-queues/{QUEUE_ID}/requests
 ```
 
 Example payload:
@@ -196,7 +198,7 @@ Example payload:
 To **update a request in a queue**, send a PUT request with the request to update as a JSON object in the request's payload to the [Update request](https://docs.apify.com/api/v2#/reference/request-queues/request/update-request) endpoint. In the payload, specify the request's ID and add the information you want to update.
 
 ```text
-https://api.apify.com/v2/request-queues/{QUEUE_ID}/requests/{REQUEST_ID}?token={YOUR_API_TOKEN}
+https://api.apify.com/v2/request-queues/{QUEUE_ID}/requests/{REQUEST_ID}
 ```
 
 Example payload:

--- a/docs/tutorials/integrations.md
+++ b/docs/tutorials/integrations.md
@@ -40,11 +40,7 @@ To access our API in your integrations, you will need to use your secret API tok
 
 ![Integrations page in the Apify app]({{@asset tutorials/images/api-token.png}})
 
-Add the secret API token to your request URL as the `token` query parameter.
-
-```cURL
-https://api.apify.com/v2/acts?token=[YOUR_TOKEN]
-```
+> When providing your API authentication token, we recommend using the request's `Authorization` header, rather than the URL. ([More info](#introduction/authentication)).
 
 **IMPORTANT**: **Do not share the API token with untrusted parties, or use it directly from client-side code,
 unless you fully understand the consequences!**


### PR DESCRIPTION
API docs - I updated only the introduction. It would be cool to also add this info to the console thing, but I couldn't find a way how. Added an info sentence throughout the API reference as a reminder

Docs - updated examples of endpoint URLs to not show the API token as a query parameter and added an info box instead.

closes #219 