### PR TITLE
Update links to Apify JS Client and examples

### DIFF
--- a/docs/storage.md
+++ b/docs/storage.md
@@ -9,7 +9,7 @@ paths:
 
 # [](#storage) Storage
 
-The Apify platform includes three types of storage you can use both in your [actors]({{@link actors.md}}) and outside the Apify platform via [API](/api/v2#/reference/key-value-stores), the [Apify SDK](https://sdk.apify.com) and Apify's [JavaScript API client](/api/apify-client-js).
+The Apify platform includes three types of storage you can use both in your [actors]({{@link actors.md}}) and outside the Apify platform via [API](/api/v2#/), the [Apify SDK](https://sdk.apify.com) and Apify's [JavaScript API client](/api/apify-client-js).
 
 This page contains a brief introduction of the three types of Apify Storage.
 

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -99,7 +99,7 @@ These URLs provide links to API **endpoints**–the places where your data are s
 
 The [Apify SDK](https://sdk.apify.com) is a JavaScript/Node.js library which allows you to build your own web scraping and automation solutions. It requires [Node.js](https://nodejs.org/en/) 10.17 or later, with the exception of **Node.js 11**.
 
-[See the [SDK documentation](https://sdk.apify.com/docs/guides/getting-started) for setup instructions and to learn how to build your own actors.
+[See the SDK documentation](https://sdk.apify.com/docs/guides/getting-started) for setup instructions and to learn how to build your own actors.
 
 ### [](#javascript-api-client) JavaScript API client
 

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -50,7 +50,7 @@ To manage your key-value stores, you can use the
 [Apify SDK](https://sdk.apify.com/docs/api/key-value-store), [JavaScript API client](/apify-client-js#keyvaluestoreclient) or
 the [Apify API](/api/v2#/reference/key-value-stores).
 
-For more information, see the [key-value store]({{@link storage/key_value_store.md}}) documentation page.
+[See the key-value store documentation]({{@link storage/key_value_store.md}}) for details.
 
 ## [](#request-queue) Request queue
 
@@ -99,7 +99,7 @@ These URLs provide links to API **endpoints**–the places where your data are s
 
 The [Apify SDK](https://sdk.apify.com) is a JavaScript/Node.js library which allows you to build your own web scraping and automation solutions. It requires [Node.js](https://nodejs.org/en/) 10.17 or later, with the exception of **Node.js 11**.
 
-For setup instructions and to learn how to build your own actors, visit the [SDK documentation](https://sdk.apify.com/docs/guides/getting-started).
+[See the [SDK documentation](https://sdk.apify.com/docs/guides/getting-started) for setup instructions and to learn how to build your own actors.
 
 ### [](#javascript-api-client) JavaScript API client
 
@@ -166,7 +166,7 @@ For example, the storage names **janedoe~my-storage-1** and **janedoe~web-scrape
 
 ## [](#sharing) Sharing
 
-You can invite other Apify users to view or modify your storages using the [access rights]({{@link access_rights.md}}) system. See the full list of permissions [here]({{@link access_rights/list_of_permissions.md#storage}}).
+You can invite other Apify users to view or modify your storages using the [access rights]({{@link access_rights.md}}) system. [See the full list of permissions]({{@link access_rights/list_of_permissions.md#storage}}).
 
 ### [](#sharing-storages-between-runs) Sharing storages between runs
 

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -82,7 +82,7 @@ To access your storages from the Apify app, go to the [**Storage** section](http
 
 ![Storages in app]({{@asset storage/images/datasets-app.png}})
 
-> Only named storages are displayed by default. Select the **Include unnamed *store*** checkbox to display all of your storages.
+> Only named storages are displayed by default. Select the **Include unnamed store** checkbox to display all of your storages.
 
 You can edit your stores' names under the **Settings** tab of their detail page. There, you can also grant [access rights](/access-rights) to other Apify users.
 

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -71,10 +71,10 @@ the [Apify API](/api/v2#/reference/request-queues).
 
 There are four ways to access your storage:
 
-* [Apify app](https://my.apify.com/storage) - provides an easy-to-understand interface [[details](#apify-app)]
-* [Apify (SDK)](https://sdk.apify.com/docs/guides/data-storage) - when building your own Apify actor [[details](#apify-sdk)]
-* [JavaScript API client](/apify-client-js) - to access your storages from any Node.js application [[details](#javascript-api-client)]
-* [Apify API](/api/v2#/reference/key-value-stores) - for accessing your storages programmatically [[details](#apify-api)]
+* [Apify app](https://my.apify.com/storage) - provides an easy-to-understand interface [[details](#apify-app)].
+* [Apify (SDK)](https://sdk.apify.com/docs/guides/data-storage) - when building your own Apify actor [[details](#apify-sdk)].
+* [JavaScript API client](/apify-client-js) - to access your storages from any Node.js application [[details](#javascript-api-client)].
+* [Apify API](/api/v2#/reference/key-value-stores) - for accessing your storages programmatically [[details](#apify-api)].
 
 ### [](#apify-app) Apify app
 
@@ -113,8 +113,8 @@ The [Apify API](/api/v2#/reference/key-value-stores) allows you to access your s
 
 In most cases, when accessing your storages via API, you will need to provide a **store ID**, which you can do in the following formats:
 
-* **WkzbQMuFYuamGv3YF** - the store's alpha-numerical ID if the store is unnamed
-* **username~store-name** - your username and the store's name separated by a tilde (`~`) character (e.g. **janedoe~ecommerce-scraping-results**) if the store is named
+* **WkzbQMuFYuamGv3YF** - the store's alpha-numerical ID if the store is unnamed.
+* **username~store-name** - your username and the store's name separated by a tilde (`~`) character (e.g. **janedoe~ecommerce-scraping-results**) if the store is named.
 
 For read (GET) requests, it is enough to use a store's alpha-numerical ID, since the ID is hard to guess and effectively serves as an authentication key.
 
@@ -172,7 +172,7 @@ You can invite other Apify users to view or modify your storages using the [acce
 
 Any storage can be accessed from any [actor]({{@link actors.md}}) or [task]({{@link actors/tasks.md}}) run as long as you know its **name** or **ID**. You can access and manage storages from other runs using the same methods or endpoints as with storages from your current run.
 
-[Datasets]({{@link storage/dataset.md}}) and [key-value stores]({{@link storage/key_value_store.md}}) can be used concurently by multiple actors. This means that multiple actors or tasks running at the same time can **write** data to a single dataset or key-value store. The same applies for reading data–multiple runs can **read** data from datasets and key-value stores concurrently.
+[Datasets]({{@link storage/dataset.md}}) and [key-value stores]({{@link storage/key_value_store.md}}) can be used concurrently by multiple actors. This means that multiple actors or tasks running at the same time can **write** data to a single dataset or key-value store. The same applies for reading data–multiple runs can **read** data from datasets and key-value stores concurrently.
 
 [Request queues]({{@link storage/request_queue.md}}), on the other hand, only allow multiple runs to **add new data**. A request queue can only be processed by one actor or task run at any one time.
 

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -30,12 +30,12 @@ and general information for using storages with the [Apify API](#apify-api).
 The easiest way to access your datasets is via the
 [Apify app](https://my.apify.com/storage#/datasets), which provides a user-friendly interface for viewing or downloading the data and editing your datasets' properties.
 
-To add data to your datasets (and for more management options), you can use the
+To manage your datasets, you can use the
 [Apify SDK](https://sdk.apify.com/docs/api/dataset),
-Apify's [JavaScript API client](https://docs.apify.com/apify-client-js#ApifyClient-datasets) or
-the [Apify API](https://docs.apify.com/api/v2#/reference/datasets).
+[JavaScript API client](/apify-client-js#datasetclient) or
+the [Apify API](/api/v2#/reference/datasets).
 
-For more information, see the [dataset]({{@link storage/dataset.md}}) documentation page.
+[See the dataset documentation]({{@link storage/dataset.md}}) for details.
 
 ## [](#key-value-store) Key-value store
 
@@ -46,9 +46,9 @@ The [key-value store]({{@link storage/key_value_store.md}}) is ideal for saving 
 The easiest way to access your key-value stores is via the
 [Apify app](https://my.apify.com/storage#/keyValueStores), which provides a user-friendly interface for viewing or downloading the data and editing your key-value stores' properties.
 
-To manage the data in your key-value stores (and for more access options), you can use the
-[Apify SDK](https://sdk.apify.com/docs/api/key-value-store), Apify's [JavaScript API client](https://docs.apify.com/apify-client-js#ApifyClient-keyValueStores) or
-the [Apify API](https://docs.apify.com/api/v2#/reference/key-value-stores).
+To manage your key-value stores, you can use the
+[Apify SDK](https://sdk.apify.com/docs/api/key-value-store), [JavaScript API client](/apify-client-js#keyvaluestoreclient) or
+the [Apify API](/api/v2#/reference/key-value-stores).
 
 For more information, see the [key-value store]({{@link storage/key_value_store.md}}) documentation page.
 
@@ -61,11 +61,11 @@ For more information, see the [key-value store]({{@link storage/key_value_store.
 The easiest way to access your request queues is via the
 [Apify app](https://my.apify.com/storage#/requestQueues), which provides a user-friendly interface for viewing your request queues and editing your queues' properties.
 
-To manage your request queues, you can use the
-[Apify SDK](https://sdk.apify.com/docs/api/request-queue), Apify's [JavaScript API client](https://docs.apify.com/apify-client-js#ApifyClient-requestQueues) or
-the [Apify API](https://docs.apify.com/api/v2#/reference/request-queues).
+You can also manage your request queues using the
+[Apify SDK](https://sdk.apify.com/docs/api/request-queue), [JavaScript API client](/apify-client-js#requestqueueclient) or
+the [Apify API](/api/v2#/reference/request-queues).
 
-For more information, see the [request queue]({{@link storage/request_queue.md}}) documentation page.
+[See the request queue documentation]({{@link storage/request_queue.md}}) for more information.
 
 ## [](#basic-usage) Basic usage
 
@@ -101,33 +101,11 @@ The [Apify SDK](https://sdk.apify.com) is a JavaScript/Node.js library which all
 
 For setup instructions and to learn how to build your own actors, visit the [SDK documentation](https://sdk.apify.com/docs/guides/getting-started).
 
-<!-- This will be included in the new JS API CLIENT docs -->
-<!-- so all we'll have to do is link to the instructions -->
 ### [](#javascript-api-client) JavaScript API client
 
 Apify's [JavaScript API client](https://docs.apify.com/apify-client-js) (`apify-client`) allows you to access your datasets from any Node.js application, whether it is running on the Apify platform or elsewhere.
 
-To use `apify-client` in your application, you will first need to have [Node.js](https://nodejs.org/en/) version 10 or higher installed.
-
-You can then install the `apify-client` package from [NPM](https://www.npmjs.com/package/apify-cli) using the command below in your terminal.
-
-```bash
-npm install apify-client
-```
-
-Once installed, **require** the `apify-client` package in your app and create a new instance of it using your **user ID** and secret [**API token**]({{@link tutorials/integrations.md#api-token}}) (you can find these on the [Integrations](https://my.apify.com/account#/integrations) page of your Apify account).
-
-```js
-// Import the `apify-client` package
-const ApifyClient = require('apify-client');
-
-// Create a new instance of the client
-// and configure it to use your credentials
-const apifyClient = new ApifyClient({
-    userId: 'RWnGtczasdwP63Mak',
-    token: 'f5J7XsdaKDyRywwuGGo9',
-});
-```
+[See the client's documentation]({{@link apify_client_js.md#quick-start}}) for help with setup.
 
 ### [](#apify-api) Apify API
 
@@ -142,7 +120,7 @@ For read (GET) requests, it is enough to use a store's alpha-numerical ID, since
 
 With other request types and when using the **username~store-name**, however, you will need to provide your secret API token in [your request's `Authorization` header](/api/v2#/introduction/authentication) or as a query parameter. You can find your token on the [Integrations](https://my.apify.com/account#/integrations) page of your Apify account.
 
-For more information and a detailed breakdown of each storage API endpoint, see the [API documentation](https://docs.apify.com/api/v2#/reference/datasets).
+[See the API documentation](https://docs.apify.com/api/v2#/reference/datasets) for details and a breakdown of each storage API endpoint.
 
 ## [](#rate-limiting) Rate limiting
 
@@ -166,7 +144,7 @@ If a client sends too many requests, the API endpoints respond with the HTTP sta
 }
 ```
 
-See the [API documentation](https://docs.apify.com/api/v2#/introduction/rate-limiting) for more details and to learn what to do if you exceed the rate limit.
+[See the API documentation](https://docs.apify.com/api/v2#/introduction/rate-limiting) for details and to learn what to do if you exceed the rate limit.
 
 ## [](#data-retention) Data retention
 
@@ -205,11 +183,11 @@ Any storage can be accessed from any [actor]({{@link actors.md}}) or [task]({{@l
 
 Named storages are only removed when you request it. You can delete storages in the following ways.
 
-* [Apify app](https://my.apify.com/storage) - using the **Actions** button in the store's detail page
+* [Apify app](https://my.apify.com/storage) - using the **Actions** button in the store's detail page.
 * [Apify SDK](https://sdk.apify.com/docs/api/key-value-store#keyvaluestoredrop) - using the `[store].drop()` method, where **[store]** is the type of storage you want to delete.
-* [JavaScript API client](https://docs.apify.com/apify-client-js) - using the
-[`deleteStore()`](https://docs.apify.com/apify-client-js#ApifyClient-datasets),
-[`deleteDataset()`](https://docs.apify.com/apify-client-js#ApifyClient-keyValueStores)
-or [`deleteQueue()`](https://docs.apify.com/apify-client-js#ApifyClient-requestQueues) methods
-* [API](https://docs.apify.com/api/v2#/reference/key-value-stores/store-object/delete-store) using the - **Delete [store]** endpoint, where **[store]** is the type of storage you want to delete
+* [JavaScript API client](/apify-client-js) - using the `.delete()` method in the
+[dataset](/apify-client-js#datasetclient),
+[key-value store](/apify-client-js#keyvaluestoreclient),
+or [request queue](/apify-client-js#requestqueueclient) clients.
+* [API](/api/v2#/reference/key-value-stores/store-object/delete-store) using the - **Delete [store]** endpoint, where **[store]** is the type of storage you want to delete.
 

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -9,7 +9,7 @@ paths:
 
 # [](#storage) Storage
 
-The Apify platform includes three types of storage you can use both in your [actors]({{@link actors.md}}) and outside the Apify platform via [API](https://docs.apify.com/api/v2#/reference/key-value-stores), the [Apify SDK](https://sdk.apify.com) and Apify's [JavaScript API client](https://docs.apify.com/api/apify-client-js).
+The Apify platform includes three types of storage you can use both in your [actors]({{@link actors.md}}) and outside the Apify platform via [API](/api/v2#/reference/key-value-stores), the [Apify SDK](https://sdk.apify.com) and Apify's [JavaScript API client](/api/apify-client-js).
 
 This page contains a brief introduction of the three types of Apify Storage.
 
@@ -73,8 +73,8 @@ There are four ways to access your storage:
 
 * [Apify app](https://my.apify.com/storage) - provides an easy-to-understand interface [[details](#apify-app)]
 * [Apify (SDK)](https://sdk.apify.com/docs/guides/data-storage) - when building your own Apify actor [[details](#apify-sdk)]
-* [JavaScript API client](https://docs.apify.com/apify-client-js) - to access your storages from any Node.js application [[details](#javascript-api-client)]
-* [Apify API](https://docs.apify.com/api/v2#/reference/key-value-stores) - for accessing your storages programmatically [[details](#apify-api)]
+* [JavaScript API client](/apify-client-js) - to access your storages from any Node.js application [[details](#javascript-api-client)]
+* [Apify API](/api/v2#/reference/key-value-stores) - for accessing your storages programmatically [[details](#apify-api)]
 
 ### [](#apify-app) Apify app
 
@@ -84,13 +84,13 @@ To access your storages from the Apify app, go to the [**Storage** section](http
 
 > Only named storages are displayed by default. Select the **Include unnamed *store*** checkbox to display all of your storages.
 
-You can edit your stores' names under the **Settings** tab of their detail page. There, you can also grant [access rights](https://docs.apify.com/access-rights) to other Apify users.
+You can edit your stores' names under the **Settings** tab of their detail page. There, you can also grant [access rights](/access-rights) to other Apify users.
 
 You can quickly share your storages' contents and details by sharing the URLs you find under the **API** tab in a store's detail page.
 
 ![Storage API]({{@asset storage/images/overview-api.png}})
 
-These URLs provide links to API **endpoints**–the places where your data are stored. Endpoints that allow you to **read** stored information do not require an [authentication token](https://docs.apify.com/api/v2#/introduction/authentication). The calls are authenticated using a hard-to-guess ID, so they can be shared freely. Operations such as **update** or **delete**, however, will need the authentication token.
+These URLs provide links to API **endpoints**–the places where your data are stored. Endpoints that allow you to **read** stored information do not require an [authentication token](/api/v2#/introduction/authentication). The calls are authenticated using a hard-to-guess ID, so they can be shared freely. Operations such as **update** or **delete**, however, will need the authentication token.
 
 > Never share a URL containing your authentication token, as this will compromise your account's security. <br/>
 > If the data you want to share requires a token, first download the data, then share it as a file.
@@ -103,13 +103,13 @@ For setup instructions and to learn how to build your own actors, visit the [SDK
 
 ### [](#javascript-api-client) JavaScript API client
 
-Apify's [JavaScript API client](https://docs.apify.com/apify-client-js) (`apify-client`) allows you to access your datasets from any Node.js application, whether it is running on the Apify platform or elsewhere.
+Apify's [JavaScript API client](/apify-client-js) (`apify-client`) allows you to access your datasets from any Node.js application, whether it is running on the Apify platform or elsewhere.
 
-[See the client's documentation]({{@link apify_client_js.md#quick-start}}) for help with setup.
+[See the client's documentation](/apify-client-js#quick-start) for help with setup.
 
 ### [](#apify-api) Apify API
 
-The [Apify API](https://docs.apify.com/api/v2#/reference/key-value-stores) allows you to access your storages programmatically using [HTTP requests](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods) and easily share your crawling results.
+The [Apify API](/api/v2#/reference/key-value-stores) allows you to access your storages programmatically using [HTTP requests](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods) and easily share your crawling results.
 
 In most cases, when accessing your storages via API, you will need to provide a **store ID**, which you can do in the following formats:
 
@@ -120,17 +120,17 @@ For read (GET) requests, it is enough to use a store's alpha-numerical ID, since
 
 With other request types and when using the **username~store-name**, however, you will need to provide your secret API token in [your request's `Authorization` header](/api/v2#/introduction/authentication) or as a query parameter. You can find your token on the [Integrations](https://my.apify.com/account#/integrations) page of your Apify account.
 
-[See the API documentation](https://docs.apify.com/api/v2#/reference/datasets) for details and a breakdown of each storage API endpoint.
+[See the API documentation](/api/v2#/reference/datasets) for details and a breakdown of each storage API endpoint.
 
 ## [](#rate-limiting) Rate limiting
 
 All API endpoints limit their rate of requests to protect Apify servers from overloading. The default rate limit is **30** requests per second per storage object, with a few exceptions, which are limited to **200** requests per second per storage object:
 
-* [Push items](https://docs.apify.com/api/v2#/reference/datasets/item-collection/put-items) to dataset.
-* CRUD ([add](https://docs.apify.com/api/v2#/reference/request-queues/request-collection/add-request),
-[get](https://docs.apify.com/api/v2#/reference/request-queues/request-collection/get-request),
-[update](https://docs.apify.com/api/v2#/reference/request-queues/request-collection/update-request),
-[delete](https://docs.apify.com/api/v2#/reference/request-queues/request-collection/delete-request))
+* [Push items](/api/v2#/reference/datasets/item-collection/put-items) to dataset.
+* CRUD ([add](/api/v2#/reference/request-queues/request-collection/add-request),
+[get](/api/v2#/reference/request-queues/request-collection/get-request),
+[update](/api/v2#/reference/request-queues/request-collection/update-request),
+[delete](/api/v2#/reference/request-queues/request-collection/delete-request))
 operations of **request queue** requests.
 
 If a client sends too many requests, the API endpoints respond with the HTTP status code `429 Too Many Requests` and the following body:
@@ -144,7 +144,7 @@ If a client sends too many requests, the API endpoints respond with the HTTP sta
 }
 ```
 
-[See the API documentation](https://docs.apify.com/api/v2#/introduction/rate-limiting) for details and to learn what to do if you exceed the rate limit.
+[See the API documentation](/api/v2#/introduction/rate-limiting) for details and to learn what to do if you exceed the rate limit.
 
 ## [](#data-retention) Data retention
 

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -9,7 +9,7 @@ paths:
 
 # [](#storage) Storage
 
-The Apify platform includes three types of storage you can use both in your [actors]({{@link actors.md}}) and outside the Apify platform via [API](/api/v2#/), the [Apify SDK](https://sdk.apify.com) and Apify's [JavaScript API client](/api/apify-client-js).
+The Apify platform includes three types of storage you can use both in your [actors]({{@link actors.md}}) and outside the Apify platform via [API](/api/v2#/), the [Apify SDK](https://sdk.apify.com) and Apify's [JavaScript API client](/apify-client-js).
 
 This page contains a brief introduction of the three types of Apify Storage.
 
@@ -61,18 +61,18 @@ the [Apify API](/api/v2#/reference/key-value-stores).
 The easiest way to access your request queues is via the
 [Apify app](https://my.apify.com/storage#/requestQueues), which provides a user-friendly interface for viewing your request queues and editing your queues' properties.
 
-You can also manage your request queues using the
+To manage your request queues using the
 [Apify SDK](https://sdk.apify.com/docs/api/request-queue), [JavaScript API client](/apify-client-js#requestqueueclient) or
 the [Apify API](/api/v2#/reference/request-queues).
 
-[See the request queue documentation]({{@link storage/request_queue.md}}) for more information.
+[See the request queue documentation]({{@link storage/request_queue.md}}) for details.
 
 ## [](#basic-usage) Basic usage
 
 There are four ways to access your storage:
 
 * [Apify app](https://my.apify.com/storage) - provides an easy-to-understand interface [[details](#apify-app)].
-* [Apify (SDK)](https://sdk.apify.com/docs/guides/data-storage) - when building your own Apify actor [[details](#apify-sdk)].
+* [Apify SDK](https://sdk.apify.com/docs/guides/data-storage) - when building your own Apify actor [[details](#apify-sdk)].
 * [JavaScript API client](/apify-client-js) - to access your storages from any Node.js application [[details](#javascript-api-client)].
 * [Apify API](/api/v2#/reference/key-value-stores) - for accessing your storages programmatically [[details](#apify-api)].
 

--- a/docs/storage/dataset.md
+++ b/docs/storage/dataset.md
@@ -100,8 +100,6 @@ const hotelAndCafeData = await dataset.getData({
 
 Apify's [JavaScript API client](/apify-client-js) (`apify-client`) allows you to access your datasets from any Node.js application, whether it is running on the Apify platform or elsewhere.
 
-[See the client's documentation](/apify-client-js#quick-start) for help with setup.
-
 After importing and initiating the client, you can save each dataset to a variable for easier access.
 
 ```js
@@ -112,7 +110,7 @@ You can then use that variable to [access the dataset's items and manage it](/ap
 
 Note: When using the [`.listItems()`](/apify-client-js#datasetclient-listitems) method, if you mention the same field name in the `field` and `omit` parameters, the `omit` parameter will prevail and the field will not be returned.
 
-[See the JavaScript API client documentation](/apify-client-js#datasetclient) for more details.
+[See the JavaScript API client documentation](/apify-client-js#datasetclient) for [help with setup](/apify-client-js#quick-start) and more details.
 
 ### [](#apify-api) Apify API
 

--- a/docs/storage/dataset.md
+++ b/docs/storage/dataset.md
@@ -94,7 +94,7 @@ const hotelAndCafeData = await dataset.getData({
 });
 ```
 
-For more information on managing datasets using the Apify SDK, see the [SDK documentation](https://sdk.apify.com/docs/guides/data-storage#dataset) and the `Dataset` class's [API reference](https://sdk.apify.com/docs/api/dataset#datasetpushdatadata).
+[See the SDK documentation](https://sdk.apify.com/docs/guides/data-storage#dataset) and the `Dataset` class's [API reference](https://sdk.apify.com/docs/api/dataset#datasetpushdatadata) for more information on managing datasets with the Apify SDK.
 
 ### [](#javascript-api-client) JavaScript API client
 
@@ -180,7 +180,7 @@ Example payload:
 ]
 ```
 
-For a detailed breakdown of each API endpoint, see the [API documentation](https://docs.apify.com/api/v2#/reference/datasets).
+[See the API documentation](https://docs.apify.com/api/v2#/reference/datasets) for a detailed breakdown of each API endpoint.
 
 ## [](#hidden-fields) Hidden fields
 
@@ -283,7 +283,7 @@ By default, the whole result is wrapped in an `<items/>` element, while each pag
 
 ## [](#sharing) Sharing
 
-You can invite other Apify users to view or modify your datasets using the [access rights]({{@link access_rights.md}}) system. See the full list of permissions [here]({{@link access_rights/list_of_permissions.md#dataset}}).
+You can invite other Apify users to view or modify your datasets using the [access rights]({{@link access_rights.md}}) system. [See the full list of permissions]({{@link access_rights/list_of_permissions.md#storage}}).
 
 ### [](#sharing-datasets-between-runs) Sharing datasets between runs
 
@@ -303,7 +303,7 @@ const otherDatasetClient = apifyClient.dataset('jane-doe/old-dataset');
 
 The same applies for the [Apify API](#apify-api) - you can use [the same endpoints](#apify-api) as you would normally.
 
-[See the Storage overview page](https://docs.apify.com/storage/#sharing-storages-between-runs) for more information on sharing storages between runs.
+[See the Storage overview](https://docs.apify.com/storage/#sharing-storages-between-runs) for more information on sharing storages between runs.
 
 ## [](#limits) Limits
 
@@ -319,4 +319,4 @@ When pushing data to a dataset via [API](https://docs.apify.com/api/v2#/referenc
 
 All other dataset API [endpoints](https://docs.apify.com/api/v2#/reference/datasets) are limited to **30** requests per second per dataset.
 
-See the [API documentation](https://docs.apify.com/api/v2#/introduction/rate-limiting) for more details and to learn what to do if you exceed the rate limit.
+[See the API documentation](https://docs.apify.com/api/v2#/introduction/rate-limiting) for more details and to learn what to do if you exceed the rate limit.

--- a/docs/storage/dataset.md
+++ b/docs/storage/dataset.md
@@ -24,7 +24,7 @@ There are four ways to access your datasets:
 
 * [Apify app](https://my.apify.com/storage#/datasets) - provides an easy-to-understand interface [[details](#apify-app)].
 * [Apify SDK](https://sdk.apify.com/docs/guides/data-storage#dataset) - when building your own Apify actor [[details](#apify-sdk)].
-* [JavaScript API client](https://docs.apify.com/api/apify-client-js/latest#ApifyClient-datasets) - to access your datasets from any Node.js application [[details](#javascript-api-client)].
+* [JavaScript API client](/apify-client-js#datasetclient) - to access your datasets from any Node.js application [[details](#javascript-api-client)].
 * [Apify API](https://docs.apify.com/api/v2#/reference/datasets) - for accessing your datasets programmatically [[details](#apify-api)].
 
 ### [](#apify-app) Apify app
@@ -36,7 +36,7 @@ Only named datasets are displayed by default. Select the **Include unnamed datas
 ![Datasets in app]({{@asset storage/images/datasets-app.png}})
 
 To view or download a dataset in the above mentioned formats, click on its **Dataset ID**\. In the detail page, you can update the dataset's name (and, in turn, its [retention period]({{@link storage.md#data-retention}})) and
-[access rights]({{@link access_rights.md}}) under the **Settings** tab. The API tab allows you to view and test the dataset's [API endpoints](https://docs.apify.com/api/v2#/reference/datasets).
+[access rights]({{@link access_rights.md}}) under the **Settings** tab. The API tab allows you to view and test the dataset's [API endpoints](/api/v2#/reference/datasets).
 
 ![Datasets detail view]({{@asset storage/images/datasets-detail.png}})
 
@@ -98,60 +98,21 @@ For more information on managing datasets using the Apify SDK, see the [SDK docu
 
 ### [](#javascript-api-client) JavaScript API client
 
-Apify's [JavaScript API client](https://docs.apify.com/apify-client-js#ApifyClient-datasets) (`apify-client`) allows you to access your datasets from any Node.js application, whether it is running on the Apify platform or elsewhere.
+Apify's [JavaScript API client](/apify-client-js) (`apify-client`) allows you to access your datasets from any Node.js application, whether it is running on the Apify platform or elsewhere.
 
-For help with setting up the client, see the JavaScript API client section on the [overview page](https://docs.apify.com/storage/#javascript-api-client).
+[See the client's documentation](/apify-client-js#quick-start) for help with setup.
 
-After [importing](https://docs.apify.com/storage/#javascript-api-client) the `apify-client` package into your application and creating an instance of it, save it to a variable for easier access.
-
-```js
-// Save your datasets to a variable for easier access
-const { datasets } = apifyClient;
-```
-
-You can then create, update, and delete datasets using the commands below.
+After importing and initiating the client, you can save each dataset to a variable for easier access.
 
 ```js
-// Get the dataset with the name "my-dataset"
-// or create it if it doesn't exist
-const dataset = await datasets.getOrCreateDataset({
-    datasetName: 'my-dataset',
-});
-
-// Set the dataset as the default to be used
-// in the following commands
-apifyClient.setOptions({ datasetId: dataset.id });
-
-// Add an object and and array of objects to the dataset
-await datasets.putItems({
-    data: { foo: 'bar' },
-});
-await datasets.putItems({
-    data: [{ foo: 'hotel' }, { foo: 'cafe' }],
-});
-
-// Get items from a dataset
-const paginationList = await datasets.getItems();
-const { items } = paginationList;
-
-// Delete a dataset
-await datasets.deleteDataset();
+const myDatasetClient = apifyClient.dataset('jane-doe/my-dataset');
 ```
 
-When using the `getItems()` method, you can specify the data you retrieve using the `[fields]` parameter. It should be an array of field names (strings) that will be included in the results. To include all the results, exclude the `[fields]` parameter.
+You can then use that variable to [access the dataset's items and manage it](/apify-client-js#datasetclient).
 
-```js
-// Only get the "hotel" and "cafe" fields
-const hotelAndCafeData = await datasets.getItems({
-    fields: ['hotel', 'cafe'],
-});
-```
+Note: When using the [`.listItems()`](/apify-client-js#datasetclient-listitems) method, if you mention the same field name in the `field` and `omit` parameters, the `omit` parameter will prevail and the field will not be returned.
 
-You can **specify which data are exported** by adding a comma-separated list of fields to the **fields** query parameter. Likewise, you can also omit certain fields using the **omit** parameter.
-
-**If you both specify and omit the same field in a request, the **omit** parameter will prevail and the field will not be returned.**
-
-For more information, see the JavaScript API client [documentation](https://docs.apify.com/apify-client-js#ApifyClient-datasets).
+[See the JavaScript API client documentation](/apify-client-js#datasetclient) for more details.
 
 ### [](#apify-api) Apify API
 
@@ -334,19 +295,15 @@ To access a dataset from another run using the Apify SDK, open it using the `Api
 const otherDataset = await Apify.openDataset('old-dataset');
 ```
 
-To access a dataset using the [JavaScript API client](#javascript-api-client), use the `getOrCreateDataset()` [method](https://docs.apify.com/apify-client-js#ApifyClient-datasets).
+In the [JavaScript API client](/apify-client-js), you can access a dataset using [its client](/apify-client-js#datasetclient). Once you've opened the dataset, read its contents and add new data like you would with a dataset from your current run.
 
 ```js
-const otherDataset = await datasets.getOrCreateDataset({
-    datasetName: 'my-dataset',
-});
+const otherDatasetClient = apifyClient.dataset('jane-doe/old-dataset');
 ```
-
-Once you've opened the dataset, read its contents and add new data like you would with a dataset from your current run.
 
 The same applies for the [Apify API](#apify-api) - you can use [the same endpoints](#apify-api) as you would normally.
 
-For more information on sharing storages between runs, see the Storage [overview page](https://docs.apify.com/storage/#sharing-storages-between-runs).
+[See the Storage overview page](https://docs.apify.com/storage/#sharing-storages-between-runs) for more information on sharing storages between runs.
 
 ## [](#limits) Limits
 

--- a/docs/storage/dataset.md
+++ b/docs/storage/dataset.md
@@ -94,7 +94,7 @@ const hotelAndCafeData = await dataset.getData({
 });
 ```
 
-[See the SDK documentation](https://sdk.apify.com/docs/guides/data-storage#dataset) and the `Dataset` class's [API reference](https://sdk.apify.com/docs/api/dataset#datasetpushdatadata) for more information on managing datasets with the Apify SDK.
+[See the SDK documentation](https://sdk.apify.com/docs/guides/data-storage#dataset) and the `Dataset` class's [API reference](https://sdk.apify.com/docs/api/dataset#datasetpushdatadata) for details on managing datasets with the Apify SDK.
 
 ### [](#javascript-api-client) JavaScript API client
 
@@ -301,7 +301,7 @@ const otherDatasetClient = apifyClient.dataset('jane-doe/old-dataset');
 
 The same applies for the [Apify API](#apify-api) - you can use [the same endpoints](#apify-api) as you would normally.
 
-[See the Storage overview](https://docs.apify.com/storage/#sharing-storages-between-runs) for more information on sharing storages between runs.
+[See the Storage overview](https://docs.apify.com/storage/#sharing-storages-between-runs) for details on sharing storages between runs.
 
 ## [](#limits) Limits
 
@@ -317,4 +317,4 @@ When pushing data to a dataset via [API](https://docs.apify.com/api/v2#/referenc
 
 All other dataset API [endpoints](https://docs.apify.com/api/v2#/reference/datasets) are limited to **30** requests per second per dataset.
 
-[See the API documentation](https://docs.apify.com/api/v2#/introduction/rate-limiting) for more details and to learn what to do if you exceed the rate limit.
+[See the API documentation](https://docs.apify.com/api/v2#/introduction/rate-limiting) for details and to learn what to do if you exceed the rate limit.

--- a/docs/storage/key_value_store.md
+++ b/docs/storage/key_value_store.md
@@ -63,7 +63,7 @@ You can find INPUT.json and other key-value stores in the location below.
 
 The default key-value store's ID is **default**\. The {KEY} is the record's **key** and {EXT} corresponds to the data value's MIME content type.
 
-To manage your key-value stores, you can use the following methods. For a full list of methods, see the `KeyValueStore` class's [API reference](https://sdk.apify.com/docs/api/key-value-store#keyvaluestoregetvaluekey).
+To manage your key-value stores, you can use the following methods. [See the `KeyValueStore` class's API reference](https://sdk.apify.com/docs/api/key-value-store#keyvaluestoregetvaluekey) for the full list.
 
 ```js
 // Get the default input
@@ -106,7 +106,7 @@ Apify.main(async () => {
 
 The `Apify.getInput()`method is not only a shortcut to `Apify.getValue('INPUT')`- it is also compatible with `Apify.metamorph()` [[docs](https://docs.apify.com/actors/source-code#metamorph)]. This is because a metamorphed actor run's input is stored in the **INPUT-METAMORPH-1** key instead of **INPUT**, which hosts the original input.
 
-For more information on managing your key-value stores with the Apify SDK, see the SDK [documentation](https://sdk.apify.com/docs/guides/data-storage#key-value-store) and the `KeyValueStore` class's [API reference](https://sdk.apify.com/docs/api/key-value-store#keyvaluestoregetvaluekey).
+[See the SDK documentation](https://sdk.apify.com/docs/guides/data-storage#key-value-store) and the `KeyValueStore` class's [API reference](https://sdk.apify.com/docs/api/key-value-store#keyvaluestoregetvaluekey) for more information on managing your key-value stores with the Apify SDK.
 
 ### JavaScript API client
 
@@ -171,7 +171,7 @@ To **delete a record**, send a DELETE request specifying the key from a key-valu
 https://api.apify.com/v2/key-value-stores/{STORE_ID}/records/{KEY_ID}
 ```
 
-For a detailed breakdown of each API endpoint, see the [API documentation](https://docs.apify.com/api/v2#/reference/key-value-stores).
+[See the API documentation](https://docs.apify.com/api/v2#/reference/key-value-stores) for a detailed breakdown of each API endpoint.
 
 ## Compression
 
@@ -183,7 +183,7 @@ You can compress a record and use the [Content-Encoding request header](https://
 
 ## Sharing
 
-You can invite other Apify users to view or modify your key-value stores using the [access rights]({{@link access_rights.md}}) system. See the full list of permissions [here]({{@link access_rights/list_of_permissions.md#key-value-store}}).
+You can invite other Apify users to view or modify your key-value stores using the [access rights]({{@link access_rights.md}}) system. [See the full list of permissions]({{@link access_rights/list_of_permissions.md#key-value-store}}).
 
 ### Sharing key-value stores between runs
 
@@ -203,7 +203,7 @@ const otherStoreClient = apifyClient.keyValueStore('jane-doe/old-store');
 
 The same applies for the [Apify API](#apify-api) - you can use [the same endpoints](#apify-api) as you would normally.
 
-For more information on sharing storages between runs, see the Storage [overview page](https://docs.apify.com/storage/#sharing-storages-between-runs).
+[See the Storage overview](https://docs.apify.com/storage/#sharing-storages-between-runs) for details on sharing storages between runs.
 
 ## Data consistency
 

--- a/docs/storage/key_value_store.md
+++ b/docs/storage/key_value_store.md
@@ -24,7 +24,7 @@ There are four ways to access your key-value stores:
 
 * [Apify app](https://my.apify.com/storage#/keyValueStores) - provides an easy-to-understand interface [[details](#apify-app)].
 * [Apify software development kit (SDK)](https://sdk.apify.com/docs/guides/data-storage#key-value-store) - when building your own Apify actor [[details](#apify-sdk)].
-* [JavaScript API client](https://docs.apify.com/apify-client-js#ApifyClient-keyValueStores) - to access your key-value stores from any Node.js application [[details](#javascript-api-client)].
+* [JavaScript API client](/apify-client-js#keyvaluestoreclient) - to access your key-value stores from any Node.js application [[details](#javascript-api-client)].
 * [Apify API](https://docs.apify.com/api/v2#/reference/key-value-stores/get-items) - for accessing your key-value stores programmatically [[details](#apify-api)].
 
 ### Apify app
@@ -110,42 +110,19 @@ For more information on managing your key-value stores with the Apify SDK, see t
 
 ### JavaScript API client
 
-Apify's [JavaScript API client](https://docs.apify.com/apify-client-js#ApifyClient-keyValueStores) (`apify-client`) allows you to access your key-value stores from any Node.js application, whether it is running on the Apify platform or elsewhere.
+Apify's [JavaScript API client](/apify-client-js#keyvaluestoreclient) (`apify-client`) allows you to access your key-value stores from any Node.js application, whether it is running on the Apify platform or elsewhere.
 
-For help with setting up the client, see the JavaScript API client section on the [overview page](https://docs.apify.com/storage/#javascript-api-client).
+[See the client's documentation](/apify-client-js#quick-start) for help with setup.
 
-After [importing](https://docs.apify.com/storage/#javascript-api-client) the `apify-client` package into your application and creating an instance of it, save it to a variable for easier access.
-
-```js
-// Save your key-value stores to a variable for easier access
-const { keyValueStores } = apifyClient;
-```
-
-You can then access your stores, retrieve records in stores, write new records or delete records.
+After importing and initiating the client, you can save each key-value store to a variable for easier access.
 
 ```js
-// Get the 'my-store' key-value store or create it
-// if it doesn't exist and set it as the default
-const exampleStore = await keyValueStores.getOrCreateStore({
-    storeName: 'my-store',
-});
-apifyClient.setOptions({ storeId: store.id });
-
-// Get a record from exampleStore
-const record = await keyValueStores.getRecord({ key: 'foo' });
-
-// Write a record to exampleStore
-await keyValueStores.putRecord({
-    key: 'foo',
-    body: 'bar',
-    contentType: 'text/plain; charset=utf-8',
-});
-
-// Delete a record in exampleStore
-await keyValueStores.deleteRecord({ key: 'foo' });
+const myKeyValStoreClient = apifyClient.keyValueStore('jane-doe/my-key-val-store');
 ```
 
-For more information on managing your key-value stores using the JavaScript API client, see its [documentation](https://docs.apify.com/apify-client-js#ApifyClient-keyValueStores).
+You can then use that variable to [access the key-value store's items and manage it](/apify-client-js#keyvaluestoreclient).
+
+[See the JavaScript API client documentation](/apify-client-js#keyvaluestoreclient) for more details.
 
 ### Apify API
 
@@ -218,15 +195,11 @@ To access a key-value store from another run using the Apify SDK, open it using 
 const otherStore = await Apify.openKeyValueStore('old-store');
 ```
 
-To access a key-value store using the [JavaScript API client](#javascript-api-client), use the `getOrCreateStore()` [method](https://docs.apify.com/apify-client-js#ApifyClient-keyValueStores).
+In the [JavaScript API client](/apify-client-js), you can access a store using [its client](/apify-client-js#keyvaluestoreclient). Once you've opened a store, read and manage its contents like you would with a key-value store from your current run.
 
 ```js
-const otherStore = await keyValueStores.getOrCreateStore({
-    storeName: 'my-store',
-});
+const otherStoreClient = apifyClient.keyValueStore('jane-doe/old-store');
 ```
-
-Once you've opened a store, read and manage its contents like you would with a key-value store from your current run.
 
 The same applies for the [Apify API](#apify-api) - you can use [the same endpoints](#apify-api) as you would normally.
 

--- a/docs/storage/key_value_store.md
+++ b/docs/storage/key_value_store.md
@@ -106,7 +106,7 @@ Apify.main(async () => {
 
 The `Apify.getInput()`method is not only a shortcut to `Apify.getValue('INPUT')`- it is also compatible with `Apify.metamorph()` [[docs](https://docs.apify.com/actors/source-code#metamorph)]. This is because a metamorphed actor run's input is stored in the **INPUT-METAMORPH-1** key instead of **INPUT**, which hosts the original input.
 
-[See the SDK documentation](https://sdk.apify.com/docs/guides/data-storage#key-value-store) and the `KeyValueStore` class's [API reference](https://sdk.apify.com/docs/api/key-value-store#keyvaluestoregetvaluekey) for more information on managing your key-value stores with the Apify SDK.
+[See the SDK documentation](https://sdk.apify.com/docs/guides/data-storage#key-value-store) and the `KeyValueStore` class's [API reference](https://sdk.apify.com/docs/api/key-value-store#keyvaluestoregetvaluekey) for details on managing your key-value stores with the Apify SDK.
 
 ### JavaScript API client
 

--- a/docs/storage/key_value_store.md
+++ b/docs/storage/key_value_store.md
@@ -112,8 +112,6 @@ The `Apify.getInput()`method is not only a shortcut to `Apify.getValue('INPUT')`
 
 Apify's [JavaScript API client](/apify-client-js#keyvaluestoreclient) (`apify-client`) allows you to access your key-value stores from any Node.js application, whether it is running on the Apify platform or elsewhere.
 
-[See the client's documentation](/apify-client-js#quick-start) for help with setup.
-
 After importing and initiating the client, you can save each key-value store to a variable for easier access.
 
 ```js
@@ -122,7 +120,7 @@ const myKeyValStoreClient = apifyClient.keyValueStore('jane-doe/my-key-val-store
 
 You can then use that variable to [access the key-value store's items and manage it](/apify-client-js#keyvaluestoreclient).
 
-[See the JavaScript API client documentation](/apify-client-js#keyvaluestoreclient) for more details.
+[See the JavaScript API client documentation](/apify-client-js#keyvaluestoreclient) for [help with setup](/apify-client-js#quick-start) and more details.
 
 ### Apify API
 

--- a/docs/storage/request_queue.md
+++ b/docs/storage/request_queue.md
@@ -81,7 +81,7 @@ Apify.main(async () => {
 });
 ```
 
-Once a queue is open, you can manage it using the following methods. For a full list of methods, see the `RequestQueue` class's [API reference](https://sdk.apify.com/docs/api/request-queue#requestqueueaddrequestrequest-options).
+Once a queue is open, you can manage it using the following methods. [See the `RequestQueue` class's API reference](https://sdk.apify.com/docs/api/request-queue#requestqueueaddrequestrequest-options) for the full list.
 
 ```js
 // Enqueue requests
@@ -106,7 +106,7 @@ await queue.reclaimRequest(request2);
 await queue.drop();
 ```
 
-For more information on managing your request queues with the Apify SDK, see the SDK [documentation](https://sdk.apify.com/docs/guides/data-storage#request-queue) and the `RequestQueue` class's [API reference](https://sdk.apify.com/docs/api/request-queue#requestqueueaddrequestrequest-options).
+[See the SDK documentation](https://sdk.apify.com/docs/guides/data-storage#request-queue) and the `RequestQueue` class's [API reference](https://sdk.apify.com/docs/api/request-queue#requestqueueaddrequestrequest-options) for more information on managing your request queues with the Apify SDK.
 
 ### [](#javascript-api-client) JavaScript API client
 
@@ -183,10 +183,10 @@ Example payload:
 }
 ```
 
-> When adding or updating requests, you can optionally provide a `clientKey` parameter to your request. It must be a string between 1 and 32 characters in length. This identifier is used to determine whether the queue was accessed by [multiple clients](#sharing). If `clientKey` is not provided, the system considers this API call to come from a new client. For details, see the `hadMultipleClients` field returned by the `Get head` [operation](/api/v2#/reference/request-queues/queue-head/get-head). <br/>
+> When adding or updating requests, you can optionally provide a `clientKey` parameter to your request. It must be a string between 1 and 32 characters in length. This identifier is used to determine whether the queue was accessed by [multiple clients](#sharing). If `clientKey` is not provided, the system considers this API call to come from a new client. [See the `hadMultipleClients` field](/api/v2#/reference/request-queues/queue-head/get-head) returned by the `Get head` operation for details. <br/>
 > Example: client-abc
 
-For a detailed breakdown of each API endpoint, see the [API documentation](/api/v2#/reference/request-queues).
+[See the API documentation](/api/v2#/reference/request-queues) for a detailed breakdown of each API endpoint.
 
 ## [](#sharing) Sharing
 
@@ -210,7 +210,7 @@ const otherQueueClient = apifyClient.requestQueue('jane-doe/old-queue');
 
 The same applies for the [Apify API](#apify-api) - you can use [the same endpoints](#apify-api) as you would normally.
 
-For more information on sharing storages between runs, see the Storage [overview page](https://docs.apify.com/storage/#sharing-storages-between-runs).
+[See the Storage overview](https://docs.apify.com/storage/#sharing-storages-between-runs) for more information on sharing storages between runs.
 
 ## [](#limits) Limits
 

--- a/docs/storage/request_queue.md
+++ b/docs/storage/request_queue.md
@@ -106,7 +106,7 @@ await queue.reclaimRequest(request2);
 await queue.drop();
 ```
 
-[See the SDK documentation](https://sdk.apify.com/docs/guides/data-storage#request-queue) and the `RequestQueue` class's [API reference](https://sdk.apify.com/docs/api/request-queue#requestqueueaddrequestrequest-options) for more information on managing your request queues with the Apify SDK.
+[See the SDK documentation](https://sdk.apify.com/docs/guides/data-storage#request-queue) and the `RequestQueue` class's [API reference](https://sdk.apify.com/docs/api/request-queue#requestqueueaddrequestrequest-options) for details on managing your request queues with the Apify SDK.
 
 ### [](#javascript-api-client) JavaScript API client
 
@@ -208,7 +208,7 @@ const otherQueueClient = apifyClient.requestQueue('jane-doe/old-queue');
 
 The same applies for the [Apify API](#apify-api) - you can use [the same endpoints](#apify-api) as you would normally.
 
-[See the Storage overview](https://docs.apify.com/storage/#sharing-storages-between-runs) for more information on sharing storages between runs.
+[See the Storage overview](https://docs.apify.com/storage/#sharing-storages-between-runs) for details on sharing storages between runs.
 
 ## [](#limits) Limits
 
@@ -227,4 +227,4 @@ operation requests are limited to **200** per second per request queue. This hel
 
 All other request queue API [endpoints](/api/v2#/reference/request-queues) are limited to **30** requests per second per request queue.
 
-See the [API documentation](/api/v2#/introduction/rate-limiting) for more details and to learn what to do if you exceed the rate limit.
+See the [API documentation](/api/v2#/introduction/rate-limiting) for details and to learn what to do if you exceed the rate limit.

--- a/docs/storage/request_queue.md
+++ b/docs/storage/request_queue.md
@@ -112,8 +112,6 @@ await queue.drop();
 
 Apify's [JavaScript API client](/apify-client-js) (`apify-client`) allows you to access your request queues from any Node.js application, whether it is running on the Apify platform or elsewhere.
 
-[See the client's documentation](/apify-client-js#quick-start) for help with setup.
-
 After importing and initiating the client, you can save each request queue to a variable for easier access.
 
 ```js
@@ -122,7 +120,7 @@ const myQueueClient = apifyClient.requestQueue('jane-doe/my-request-queue');
 
 You can then use that variable to [access the request queue's items and manage it](/apify-client-js#requestqueueclient).
 
-[See the JavaScript API client documentation](/apify-client-js#requestqueueclient) for more details.
+[See the JavaScript API client documentation](/apify-client-js#requestqueueclient) for [help with setup](/apify-client-js#quick-start) and more details.
 
 ### [](#apify-api) Apify API
 

--- a/docs/storage/request_queue.md
+++ b/docs/storage/request_queue.md
@@ -22,8 +22,8 @@ There are four ways to access your request queues:
 
 * [Apify app](https://my.apify.com/storage#/requestQueues) - provides an easy-to-understand interface [[details](#apify-app)].
 * [Apify SDK](https://sdk.apify.com/docs/guides/data-storage#request-queue) - when building your own Apify actor [[details](#apify-sdk)].
-* [JavaScript API client](https://docs.apify.com/apify-client-js#ApifyClient-requestQueues) - to access your request queues from any Node.js application [[details](#javascript-api-client)].
-* [Apify API](https://docs.apify.com/api/v2#/reference/request-queues) - for accessing your request queues programmatically [[details](#apify-api)].
+* [JavaScript API client](apify-client-js#requestqueueclient) - to access your request queues from any Node.js application [[details](#javascript-api-client)].
+* [Apify API](/api/v2#/reference/request-queues) - for accessing your request queues programmatically [[details](#apify-api)].
 
 ### [](#apify-app) Apify app
 
@@ -37,7 +37,7 @@ To view a request queue, click on its **Queue ID**\.
 In the detail page, under the **Settings** tab, you can update the queue's name (and, in turn, its
 [retention period]({{@link storage.md#data-retention}})) and
 [access rights]({{@link access_rights.md}}).
-The API tab allows you to view and test a queue's [API endpoints](https://docs.apify.com/api/v2#/reference/request-queues).
+The API tab allows you to view and test a queue's [API endpoints](/api/v2#/reference/request-queues).
 
 ![Request queues detail]({{@asset storage/images/request-queue-detail.png}})
 
@@ -110,76 +110,47 @@ For more information on managing your request queues with the Apify SDK, see the
 
 ### [](#javascript-api-client) JavaScript API client
 
-Apify's [JavaScript API client](https://docs.apify.com/apify-client-js#ApifyClient-requestQueues) (`apify-client`) allows you to access your request queues from any Node.js application, whether it is running on the Apify platform or elsewhere.
+Apify's [JavaScript API client](/apify-client-js) (`apify-client`) allows you to access your request queues from any Node.js application, whether it is running on the Apify platform or elsewhere.
 
-For help with setting up the client, see the JavaScript API client section on the [overview page](https://docs.apify.com/storage/#javascript-api-client).
+[See the client's documentation](/apify-client-js#quick-start) for help with setup.
 
-After [importing](https://docs.apify.com/storage/#javascript-api-client) the `apify-client` package into your application and creating an instance of it, save it to a variable for easier access.
-
-```js
-// Save your request queues to a variable for easier access
-const { requestQueues } = apifyClient;
-```
-
-You can then get or create new queues, retrieve existing requests or enqueue new URLs. For a full list of options, see the [JavaScript API client's](https://docs.apify.com/apify-client-js#ApifyClient-requestQueues) documentation.
+After importing and initiating the client, you can save each request queue to a variable for easier access.
 
 ```js
-// Get the 'my-queue' request queue and set it as the default
-// to be used in the following commands
-const queue = await requestQueues.getOrCreateQueue({
-    queueName: 'my-queue',
-});
-apifyClient.setOptions({ queueId: queue.id });
-
-// Add a request to the default queue
-await requestQueues.addRequest({
-    url: 'http://example.com',
-    uniqueKey: 'http://example.com',
-});
-
-await requestQueues.addRequest({
-    url: 'http://example.com',
-    uniqueKey: 'http://example.com',
-});
-await requestQueues.addRequest({
-    url: 'http://example.com/a/b',
-    uniqueKey: 'http://example.com/a/b',
-});
-
-// Mark request as handled.
-request1.handledAt = new Date();
-await requestQueues.updateRequest(request1);
+const myQueueClient = apifyClient.requestQueue('jane-doe/my-request-queue');
 ```
 
-For more information on managing your request queues using the JavaScript API client, see its [documentation](https://docs.apify.com/apify-client-js#ApifyClient-requestQueues).
+You can then use that variable to [access the request queue's items and manage it](/apify-client-js#requestqueueclient).
+
+[See the JavaScript API client documentation](/apify-client-js#requestqueueclient) for more details.
 
 ### [](#apify-api) Apify API
 
-The [Apify API](https://docs.apify.com/api/v2#/reference/request-queues) allows you to access your request queues programmatically using [HTTP requests](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods).
+The [Apify API](/api/v2#/reference/request-queues) allows you to access your request queues programmatically using [HTTP requests](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods).
 
 If you are accessing your datasets using the **username~store-name** [store ID format]({{@link storage.md#apify-api}}), you will need to use your [secret API token]({{@link tutorials/integrations.md#api-token}}). You can find the token (and your user ID) on the [Integrations](https://my.apify.com/account#/integrations) page of your Apify account.
 
 > When providing your API authentication token, we recommend using the request's `Authorization` header, rather than the URL. ([More info](#introduction/authentication)).
 
-To **get a list of your request queues**, send a GET request to the [Get list of request queues](https://docs.apify.com/api/v2#/reference/request-queues/store-collection/get-list-of-request-queues) endpoint.
+To **get a list of your request queues**, send a GET request to the [Get list of request queues](/api/v2#/reference/request-queues/store-collection/get-list-of-request-queues) endpoint.
 
 ```text
 https://api.apify.com/v2/request-queues
 ```
 
-To **get information about a request queue** such as its creation time and item count, send a GET request to the [Get request queue](https://docs.apify.com/api/v2#/reference/request-queues/queue/get-request-queue) endpoint.
+To **get information about a request queue** such as its creation time and item count, send a GET request to the [Get request queue](/api/v2#/reference/request-queues/queue/get-request-queue) endpoint.
 
 ```text
 https://api.apify.com/v2/request-queues/{QUEUE_ID}
 ```
 
-To **get a request from a queue**, send a GET request to the [Get request](https://docs.apify.com/api/v2#/reference/request-queues/request/get-request) endpoint.
+To **get a request from a queue**, send a GET request to the [Get request](/api/v2#/reference/request-queues/request/get-request) endpoint.
 
 ```text
 https://api.apify.com/v2/request-queues/{QUEUE_ID}/requests/{REQUEST_ID}
 ```
 
-To **add a request to a queue**, send a POST request with the request to be added as a JSON object in the request's payload to the [Add request](https://docs.apify.com/api/v2#/reference/request-queues/request-collection/add-request) endpoint.
+To **add a request to a queue**, send a POST request with the request to be added as a JSON object in the request's payload to the [Add request](/api/v2#/reference/request-queues/request-collection/add-request) endpoint.
 
 ```text
 https://api.apify.com/v2/request-queues/{QUEUE_ID}/requests
@@ -195,7 +166,7 @@ Example payload:
 }
 ```
 
-To **update a request in a queue**, send a PUT request with the request to update as a JSON object in the request's payload to the [Update request](https://docs.apify.com/api/v2#/reference/request-queues/request/update-request) endpoint. In the payload, specify the request's ID and add the information you want to update.
+To **update a request in a queue**, send a PUT request with the request to update as a JSON object in the request's payload to the [Update request](/api/v2#/reference/request-queues/request/update-request) endpoint. In the payload, specify the request's ID and add the information you want to update.
 
 ```text
 https://api.apify.com/v2/request-queues/{QUEUE_ID}/requests/{REQUEST_ID}
@@ -212,14 +183,14 @@ Example payload:
 }
 ```
 
-> When adding or updating requests, you can optionally provide a `clientKey` parameter to your request. It must be a string between 1 and 32 characters in length. This identifier is used to determine whether the queue was accessed by [multiple clients](#sharing). If `clientKey` is not provided, the system considers this API call to come from a new client. For details, see the `hadMultipleClients` field returned by the `Get head` [operation](https://docs.apify.com/api/v2#/reference/request-queues/queue-head/get-head). <br/>
+> When adding or updating requests, you can optionally provide a `clientKey` parameter to your request. It must be a string between 1 and 32 characters in length. This identifier is used to determine whether the queue was accessed by [multiple clients](#sharing). If `clientKey` is not provided, the system considers this API call to come from a new client. For details, see the `hadMultipleClients` field returned by the `Get head` [operation](/api/v2#/reference/request-queues/queue-head/get-head). <br/>
 > Example: client-abc
 
-For a detailed breakdown of each API endpoint, see the [API documentation](https://docs.apify.com/api/v2#/reference/request-queues).
+For a detailed breakdown of each API endpoint, see the [API documentation](/api/v2#/reference/request-queues).
 
 ## [](#sharing) Sharing
 
-You can invite other Apify users to view or modify your request queues using the [access rights]({{@link access_rights.md}}) system. See the full list of permissions [here]({{@link access_rights/list_of_permissions.md#request-queue}}).
+You can invite other Apify users to view or modify your request queues using the [access rights]({{@link access_rights.md}}) system. [See the full list of permissions]({{@link access_rights/list_of_permissions.md#request-queue}}).
 
 ### [](#sharing-request-queues-between-runs) Sharing request queues between runs
 
@@ -231,15 +202,11 @@ To access a request queue from another run using the Apify SDK, open it using th
 const otherQueue = await Apify.openRequestQueue('old-queue');
 ```
 
-To access a request queue using the [JavaScript API client](#javascript-api-client), use the `getOrCreateQueue()` [method](https://docs.apify.com/apify-client-js#ApifyClient-requestQueues).
+In the [JavaScript API client](/apify-client-js), you can access a request queue using [its client](/apify-client-js#requestqueueclient). Once you've opened the request queue, you can use it in your crawl or add new requests like you would with a queue from your current run.
 
 ```js
-const otherQueue = await requestQueues.getOrCreateQueue({
-    queueName: 'my-queue',
-});
+const otherQueueClient = apifyClient.requestQueue('jane-doe/old-queue');
 ```
-
-Once you've opened the request queue, you can use it in your crawl or add new requests like you would with a queue from your current run.
 
 The same applies for the [Apify API](#apify-api) - you can use [the same endpoints](#apify-api) as you would normally.
 
@@ -253,13 +220,13 @@ For more information on sharing storages between runs, see the Storage [overview
 
 ### [](#rate-limiting) Rate limiting
 
-When managing request queues via [API](https://docs.apify.com/api/v2#/reference/request-queues/put-items),
-CRUD ([add](https://docs.apify.com/api/v2#/reference/request-queues/request-collection/add-request),
-[get](https://docs.apify.com/api/v2#/reference/request-queues/request-collection/get-request),
-[update](https://docs.apify.com/api/v2#/reference/request-queues/request-collection/update-request),
-[delete](https://docs.apify.com/api/v2#/reference/request-queues/request-collection/delete-request))
+When managing request queues via [API](/api/v2#/reference/request-queues/put-items),
+CRUD ([add](/api/v2#/reference/request-queues/request-collection/add-request),
+[get](/api/v2#/reference/request-queues/request-collection/get-request),
+[update](/api/v2#/reference/request-queues/request-collection/update-request),
+[delete](/api/v2#/reference/request-queues/request-collection/delete-request))
 operation requests are limited to **200** per second per request queue. This helps protect Apify servers from being overloaded.
 
-All other request queue API [endpoints](https://docs.apify.com/api/v2#/reference/request-queues) are limited to **30** requests per second per request queue.
+All other request queue API [endpoints](/api/v2#/reference/request-queues) are limited to **30** requests per second per request queue.
 
-See the [API documentation](https://docs.apify.com/api/v2#/introduction/rate-limiting) for more details and to learn what to do if you exceed the rate limit.
+See the [API documentation](/api/v2#/introduction/rate-limiting) for more details and to learn what to do if you exceed the rate limit.

--- a/docs/web_scraping_101/anti_scraping_techniques.md
+++ b/docs/web_scraping_101/anti_scraping_techniques.md
@@ -9,9 +9,9 @@ paths:
 
 # [](#anti-scraping-techniques-and-how-to-bypass-them) Anti-scraping techniques
 
-Many websites use anti-scraping techniques to block web scraping bots. Our research shows that there are a number of methods deployed in the field to bypass these defenses. 
+Many websites use anti-scraping techniques to block web scraping bots. Our research shows that there are a number of methods deployed in the field to bypass these defenses.
 
-In many cases, we found that very simple changes in approach are commonly used. For example, if a site is blocking based on IP address, switching between different addresses is effective. If a website is analyzing behavior, making that behaviour as human-like as possible will confuse the anti-scraping system. If these simpler options fail, there are more complex methods available, such as [shared IP address emulation](https://dev.to/apify/bypassing-web-scraping-protection-get-the-most-out-of-your-proxies-with-shared-ip-address-emulation-291c) (also known as [session multiplexing](https://en.wikipedia.org/wiki/Session_multiplexing)).
+In many cases, we found that very simple changes in approach are commonly used. For example, if a site is blocking based on IP address, switching between different addresses is effective. If a website is analyzing behavior, making that behavior as human-like as possible will confuse the anti-scraping system. If these simpler options fail, there are more complex methods available, such as [shared IP address emulation](https://dev.to/apify/bypassing-web-scraping-protection-get-the-most-out-of-your-proxies-with-shared-ip-address-emulation-291c) (also known as [session multiplexing](https://en.wikipedia.org/wiki/Session_multiplexing)).
 
 ## [](#ip-address-based-blocking) IP address-based blocking
 


### PR DESCRIPTION
Preview: https://docs.apify.com/storage?version=feature/update-api-client

Updates
- Links to apify-client docs and examples of use updated to use the new client
- Removed duplicated information from storage docs and replaced with links to apify-client docs
- Updated a bunch of links to use relative paths for docs instead of absolute
- Updated link texts for better quality


closes #236 