### PR TITLE
Create the API Client for Python page, add it to menu

### DIFF
--- a/docs/apify_client_python.md
+++ b/docs/apify_client_python.md
@@ -1,0 +1,11 @@
+---
+title: Python API client
+description: Simplified access to the Apify API from any Python application. Manage your actors, tasks and storage via API with the apify_client PyPI package.
+category: developer tools
+menuWeight: 15
+paths:
+    - api/apify-client-python
+    - api/apify-client-python/latest
+    - apify-client-python/latest
+    - apify-client-python
+---

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -2,7 +2,7 @@
 title: Command-line interface
 description: Create new actors from your computer's command line. Run actors locally or deploy them to the Apify platform. View the Apify CLI's command reference.
 externalSourceUrl: https://raw.githubusercontent.com/apifytech/apify-cli/master/README.md
-menuWeight: 15
+menuWeight: 16
 category: developer tools
 paths:
     - cli

--- a/docs/sdk.md
+++ b/docs/sdk.md
@@ -1,7 +1,7 @@
 ---
 title: Apify SDK
 description: Develop web scraping and automation tools using JavaScript/Node.js and headless Chrome and Puppeteer. Build Apify actors locally or upload to the Apify cloud.
-menuWeight: 16
+menuWeight: 17
 category: developer tools
 paths:
     - sdk


### PR DESCRIPTION
This will pull content from the docs in the Python Client repo, similar to how the Javascript client does it. The support on the web is already there.