### PR TITLE
Add references to the Python client & Python examples to various places

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,4 +232,5 @@ There are, however, a few exceptions, shown below. To make changes to them, you'
 
 * Tutorials for Apify's scrapers (**docs/scraping** directory) are in the [**apify/actor-scraper**](https://github.com/apify/actor-scraper) repository.
 * Apify's API client for JavaScript documentation is in the [**apify-docs/apify-client-js**](https://github.com/apify/apify-client-js) repository.
+* Apify's API client for Python documentation is in the [**apify-docs/apify-client-python**](https://github.com/apify/apify-client-python) repository.
 * Docs for the command-line interface are in the [**apify/apify-cli**](https://github.com/apify/apify-cli) repo.

--- a/docs/actors/development/base_docker_images.md
+++ b/docs/actors/development/base_docker_images.md
@@ -8,7 +8,15 @@ paths:
 
 # [](#base-docker-images) Base Docker images
 
-Apify provides the following Docker images that can be used as a base for user actors. You can read more about them in the [Apify SDK Docker image guide](https://sdk.apify.com/docs/guides/docker-images).
+Apify provides several Docker images that can be used as a base for user actors.
+
+All images come in two versions: the **latest** tag corresponds to the stable version and **beta** to images where we test new features. Use the beta version at your own risk.
+
+Note that all Apify Docker images are pre-cached on Apify servers in order to speed up the actor builds and runs. The source code used to generate the images is available in the [apify-actor-docker](https://github.com/apifytech/apify-actor-docker) GitHub repository.
+
+## [](#apify-sdk-actor-images) Images with Apify SDK preinstalled
+
+These images contain the [Apify SDK for Javascript](https://sdk.apify.com/) preinstalled. You can read more about them in the [Apify SDK Docker image guide](https://sdk.apify.com/docs/guides/docker-images).
 
 - **Node.js 14 on Alpine Linux** ([`apify/actor-node`](https://hub.docker.com/r/apify/actor-node/)) - slim and efficient image, contains only the most elementary tools. Note that headless browsers (Puppeteer, Playwright) are not available in this image.
 
@@ -18,6 +26,8 @@ Apify provides the following Docker images that can be used as a base for user a
 
 For a full list of available images, [see the Apify SDK Docker image guide](https://sdk.apify.com/docs/guides/docker-images). Note that some images available in the Apify UI can be marked as deprecated. This means that they should no longer be used for new projects and old projects are encouraged to migrate to one of the non-deprecated images.
 
-All images come in two versions: the **latest** tag corresponds to the stable version and **beta** to images where we test new features. Use the beta version at your own risk.
+## [](#python-actor-images) Images with Apify Client for Python preinstalled
 
-Note that all Apify Docker images are pre-cached on Apify servers in order to speed up the actor builds and runs. The source code used to generate the images is available in the [apify-actor-docker](https://github.com/apifytech/apify-actor-docker) GitHub repository.
+These images contain the [Apify API client for Python](https://docs.apify.com/apify-client-python) preinstalled.
+
+- **Python 3 on Alpine Linux** ([`apify/actor-python`](https://hub.docker.com/r/apify/actor-python/)) - a slim image with Python 3 and the [Apify API client for Python](https://docs.apify.com/apify-client-python) preinstalled. Comes in multiple versions containing Python 3.7, 3.8 or 3.9.

--- a/docs/actors/development/base_docker_images.md
+++ b/docs/actors/development/base_docker_images.md
@@ -16,7 +16,7 @@ Note that all Apify Docker images are pre-cached on Apify servers in order to sp
 
 ## [](#apify-sdk-actor-images) Images with Apify SDK preinstalled
 
-These images contain the [Apify SDK for Javascript](https://sdk.apify.com/) preinstalled. You can read more about them in the [Apify SDK Docker image guide](https://sdk.apify.com/docs/guides/docker-images).
+The [Apify SDK for JavaScript](https://sdk.apify.com) is preinstalled on these images. You can read more about them in the [Apify SDK Docker image guide](https://sdk.apify.com/docs/guides/docker-images).
 
 - **Node.js 14 on Alpine Linux** ([`apify/actor-node`](https://hub.docker.com/r/apify/actor-node/)) - slim and efficient image, contains only the most elementary tools. Note that headless browsers (Puppeteer, Playwright) are not available in this image.
 
@@ -28,6 +28,6 @@ For a full list of available images, [see the Apify SDK Docker image guide](http
 
 ## [](#python-actor-images) Images with Apify Client for Python preinstalled
 
-These images contain the [Apify API client for Python](https://docs.apify.com/apify-client-python) preinstalled.
+The [Apify API client for Python](https://docs.apify.com/apify-client-python) is preinstalled on these images.
 
 - **Python 3 on Alpine Linux** ([`apify/actor-python`](https://hub.docker.com/r/apify/actor-python/)) - a slim image with Python 3 and the [Apify API client for Python](https://docs.apify.com/apify-client-python) preinstalled. Comes in multiple versions containing Python 3.7, 3.8 or 3.9.

--- a/docs/actors/development/environment_variables.md
+++ b/docs/actors/development/environment_variables.md
@@ -39,3 +39,10 @@ To access environment variables in Node.js, use the `process.env` object, for ex
 ```js
 console.log(process.env.APIFY_USER_ID);
 ```
+
+To access environment variables in Python, use the `os.environ` dictionary, for example:
+
+```python
+import os
+print(os.environ['APIFY_USER_ID'])
+```

--- a/docs/actors/development/input_schema.md
+++ b/docs/actors/development/input_schema.md
@@ -21,7 +21,7 @@ You can also use our [visual input schema editor](https://apify.github.io/input-
 
 ## [](#example)Example
 
-Imagine you are building a simple crawler whose inputs are an array of start URLs and a Javascript function that will be executed at each page the crawler visits. Then the input schema will look as follows:
+Imagine you are building a simple crawler whose inputs are an array of start URLs and a JavaScript function that will be executed at each page the crawler visits. Then the input schema will look as follows:
 
 ```json
 {

--- a/docs/actors/development/source_code.md
+++ b/docs/actors/development/source_code.md
@@ -100,7 +100,7 @@ For more information about Dockerfile syntax and commands, see the [Dockerfile r
 
 Note that `apify/actor-node-basic` is a base Docker image provided by Apify. There are other base images with other features available. However, you can use arbitrary Docker images as the base for your actors, although using the Apify images has some performance advantages. See [base Docker images]({{@link actors/development/base_docker_images.md}}) for details.
 
-By default, all Apify base Docker images with the Apify SDK start your Node.js application same way as **npm start** does, i.e. by running the command specified in the **package.json** file under the **scripts** - **start** key. The default **package.json** file is similar to the following.
+By default, all Apify base Docker images with the Apify SDK start your Node.js application the same way as **npm start** does, i.e. by running the command specified in the **package.json** file under the **scripts** - **start** key. The default **package.json** file is similar to the following.
 
 ```json
 {

--- a/docs/actors/development/source_code.md
+++ b/docs/actors/development/source_code.md
@@ -100,7 +100,7 @@ For more information about Dockerfile syntax and commands, see the [Dockerfile r
 
 Note that `apify/actor-node-basic` is a base Docker image provided by Apify. There are other base images with other features available. However, you can use arbitrary Docker images as the base for your actors, although using the Apify images has some performance advantages. See [base Docker images]({{@link actors/development/base_docker_images.md}}) for details.
 
-By default, all Apify base Docker images start your Node.js application same way as **npm start** does, i.e. by running the command specified in the **package.json** file under the **scripts** - **start** key. The default **package.json** file is similar to the following.
+By default, all Apify base Docker images with the Apify SDK start your Node.js application same way as **npm start** does, i.e. by running the command specified in the **package.json** file under the **scripts** - **start** key. The default **package.json** file is similar to the following.
 
 ```json
 {

--- a/docs/actors/paid_actors.md
+++ b/docs/actors/paid_actors.md
@@ -21,7 +21,7 @@ Each paid actor has a **free trial,** followed by a flat monthly rental fee that
 
 ## Can I run paid actors via API or the Apify client?
 
-Yes, when you are renting a paid actor, you can run it using either our [API](https://docs.apify.com/api/v2) or [JavaScript](https://docs.apify.com/apify-client-js) or Python clients as you would do with private or free public actors.
+Yes, when you are renting a paid actor, you can run it using either our [API](https://docs.apify.com/api/v2) or [JavaScript](https://docs.apify.com/apify-client-js) or [Python](https://docs.apify.com/apify-client-python) clients as you would do with private or free public actors.
 
 ## Do I pay platform costs for running paid actors?
 

--- a/docs/actors/running.md
+++ b/docs/actors/running.md
@@ -44,6 +44,13 @@ const run = await Apify.call('apify/hello-world', {
 console.dir(run.output);
 ```
 
+Similarly, actors can be invoked programmatically from other actors using the [`call()`](https://docs.apify.com/apify-client-python#actorclient-call) function provided by the [`apify-client`](https://docs.apify.com/apify-client-python) Python package. For example:
+
+```python
+run = apify_client.actor('apify/hello-world').call(run_input={ 'message': 'Hello!' })
+print(run['id'])
+```
+
 The newly started actor runs under the same user account as the initial actor and therefore all resources consumed are charged to the same user account. This allows more complex actors to be built using simpler actors built and owned by other users.
 
 Internally, the `call()` function takes the user's API token from the `APIFY_TOKEN` environment variable, then it invokes the [Run actor](https://docs.apify.com/api/v2/#/reference/actors/run-collection/run-actor) API endpoint, waits for the actor to finish and reads its output using the [Get record](https://docs.apify.com/api/v2/#/reference/key-value-stores/record/get-record) API endpoint.

--- a/docs/api_v2/api_v2_reference.apib
+++ b/docs/api_v2/api_v2_reference.apib
@@ -11,7 +11,9 @@ with a few exceptions that are explicitly described in the reference.
 
 To access the API using [Node.js](https://nodejs.org/en/), we recommend the
 [`apify-client`](https://docs.apify.com/api/apify-client-js/latest) [NPM package](https://www.npmjs.com/package/apify-client).
-The client's functions correspond to the API endpoints and have the same parameters. This simplifies development of apps that depend on the Apify platform.
+To access the API using [Python](https://www.python.org/), we recommend the
+[`apify-client`](https://docs.apify.com/api/apify-client-python/latest) [PyPI package](https://pypi.org/project/apify-client/).
+The clients' functions correspond to the API endpoints and have the same parameters. This simplifies development of apps that depend on the Apify platform.
 
 **Note:** All requests with JSON payloads need to specify the `Content-Type: application/json` HTTP header!
 
@@ -368,8 +370,9 @@ and it can be described using the following pseudo-code:
 If all requests sent by the client implement the above steps,
 the client will automatically use the maximum available bandwidth for its requests.
 
-Note that the <a href="https://docs.apify.com/api/apify-client-js/latest">apify-client</a> NPM package
-uses the exponential backoff algorithm transparently, so that you do not need to worry about it.
+Note that the Apify API clients <a href="https://docs.apify.com/api/apify-client-js/latest">for Javascript</a>
+and <a href="https://docs.apify.com/api/apify-client-python/latest">for Python</a>
+use the exponential backoff algorithm transparently, so that you do not need to worry about it.
 
 
 # Group Actors

--- a/docs/api_v2/api_v2_reference.apib
+++ b/docs/api_v2/api_v2_reference.apib
@@ -370,8 +370,8 @@ and it can be described using the following pseudo-code:
 If all requests sent by the client implement the above steps,
 the client will automatically use the maximum available bandwidth for its requests.
 
-Note that the Apify API clients <a href="https://docs.apify.com/api/apify-client-js/latest">for Javascript</a>
-and <a href="https://docs.apify.com/api/apify-client-python/latest">for Python</a>
+Note that the Apify API clients [for JavaScript](https://docs.apify.com/api/apify-client-js)
+and [for Python](https://docs.apify.com/api/apify-client-python)
 use the exponential backoff algorithm transparently, so that you do not need to worry about it.
 
 

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -9,7 +9,7 @@ paths:
 
 # [](#storage) Storage
 
-The Apify platform includes three types of storage you can use both in your [actors]({{@link actors.md}}) and outside the Apify platform via [API](/api/v2#/), the [Apify SDK](https://sdk.apify.com) and Apify's [JavaScript API client](/apify-client-js).
+The Apify platform includes three types of storage you can use both in your [actors]({{@link actors.md}}) and outside the Apify platform via [API](/api/v2#/), the [Apify SDK](https://sdk.apify.com) and Apify's [JavaScript API client](/apify-client-js) and [Python API client](/apify-client-python).
 
 This page contains a brief introduction of the three types of Apify Storage.
 
@@ -17,8 +17,8 @@ This page contains a brief introduction of the three types of Apify Storage.
 * [Key-value store](#key-value-store) - storage for arbitrary data records such as files, images, and strings.
 * [Request queue](#request-queue) - a queue of URLs for your actors to visit.
 
-You will then find [basic usage](#basic-usage) information relating to all three types of storage. For example, how to manage your storages in the [Apify app](#apify-app), the basics of setting up the [Apify SDK](#apify-sdk) and
-[JavaScript API client](#javascript-api-client),
+You will then find [basic usage](#basic-usage) information relating to all three types of storage. For example, how to manage your storages in the [Apify app](#apify-app), the basics of setting up the [Apify SDK](#apify-sdk),
+the [JavaScript API client](#javascript-api-client) and the [Python API client](/apify-client-python),
 and general information for using storages with the [Apify API](#apify-api).
 
 ## [](#dataset) Dataset
@@ -32,8 +32,9 @@ The easiest way to access your datasets is via the
 
 To manage your datasets, you can use the
 [Apify SDK](https://sdk.apify.com/docs/api/dataset),
-[JavaScript API client](/apify-client-js#datasetclient) or
-the [Apify API](/api/v2#/reference/datasets).
+[JavaScript API client](/apify-client-js#datasetclient),
+[Python API client](/apify-client-python#datasetclient),
+or the [Apify API](/api/v2#/reference/datasets).
 
 [See the dataset documentation]({{@link storage/dataset.md}}) for details.
 
@@ -47,8 +48,10 @@ The easiest way to access your key-value stores is via the
 [Apify app](https://my.apify.com/storage#/keyValueStores), which provides a user-friendly interface for viewing or downloading the data and editing your key-value stores' properties.
 
 To manage your key-value stores, you can use the
-[Apify SDK](https://sdk.apify.com/docs/api/key-value-store), [JavaScript API client](/apify-client-js#keyvaluestoreclient) or
-the [Apify API](/api/v2#/reference/key-value-stores).
+[Apify SDK](https://sdk.apify.com/docs/api/key-value-store),
+[JavaScript API client](/apify-client-js#keyvaluestoreclient),
+[Python API client](/apify-client-python#keyvaluestoreclient),
+or the [Apify API](/api/v2#/reference/key-value-stores).
 
 [See the key-value store documentation]({{@link storage/key_value_store.md}}) for details.
 
@@ -61,19 +64,22 @@ the [Apify API](/api/v2#/reference/key-value-stores).
 The easiest way to access your request queues is via the
 [Apify app](https://my.apify.com/storage#/requestQueues), which provides a user-friendly interface for viewing your request queues and editing your queues' properties.
 
-To manage your request queues using the
-[Apify SDK](https://sdk.apify.com/docs/api/request-queue), [JavaScript API client](/apify-client-js#requestqueueclient) or
-the [Apify API](/api/v2#/reference/request-queues).
+To manage your request queues, you can use the
+[Apify SDK](https://sdk.apify.com/docs/api/request-queue),
+[JavaScript API client](/apify-client-js#requestqueueclient),
+[Python API client](/apify-client-python#requestqueueclient),
+or the [Apify API](/api/v2#/reference/request-queues).
 
 [See the request queue documentation]({{@link storage/request_queue.md}}) for details.
 
 ## [](#basic-usage) Basic usage
 
-There are four ways to access your storage:
+There are five ways to access your storage:
 
 * [Apify app](https://my.apify.com/storage) - provides an easy-to-understand interface [[details](#apify-app)].
 * [Apify SDK](https://sdk.apify.com/docs/guides/data-storage) - when building your own Apify actor [[details](#apify-sdk)].
 * [JavaScript API client](/apify-client-js) - to access your storages from any Node.js application [[details](#javascript-api-client)].
+* [Python API client](/apify-client-python) - to access your storages from any Python application [[details](#python-api-client)].
 * [Apify API](/api/v2#/reference/key-value-stores) - for accessing your storages programmatically [[details](#apify-api)].
 
 ### [](#apify-app) Apify app
@@ -106,6 +112,12 @@ The [Apify SDK](https://sdk.apify.com) is a JavaScript/Node.js library which all
 Apify's [JavaScript API client](/apify-client-js) (`apify-client`) allows you to access your datasets from any Node.js application, whether it is running on the Apify platform or elsewhere.
 
 [See the client's documentation](/apify-client-js#quick-start) for help with setup.
+
+### [](#python-api-client) Python API client
+
+Apify's [Python API client](/apify-client-python) (`apify-client`) allows you to access your datasets from any Python application, whether it is running on the Apify platform or elsewhere.
+
+[See the client's documentation](/apify-client-python#quick-start) for help with setup.
 
 ### [](#apify-api) Apify API
 
@@ -189,5 +201,9 @@ Named storages are only removed when you request it. You can delete storages in 
 [dataset](/apify-client-js#datasetclient),
 [key-value store](/apify-client-js#keyvaluestoreclient),
 or [request queue](/apify-client-js#requestqueueclient) clients.
+* [Python API client](/apify-client-python) - using the `.delete()` method in the
+[dataset](/apify-client-python#datasetclient),
+[key-value store](/apify-client-python#keyvaluestoreclient),
+or [request queue](/apify-client-python#requestqueueclient) clients.
 * [API](/api/v2#/reference/key-value-stores/store-object/delete-store) using the - **Delete [store]** endpoint, where **[store]** is the type of storage you want to delete.
 

--- a/docs/storage/dataset.md
+++ b/docs/storage/dataset.md
@@ -316,7 +316,7 @@ In the [JavaScript API client](/apify-client-js), you can access a dataset using
 const otherDatasetClient = apifyClient.dataset('jane-doe/old-dataset');
 ```
 
-The same works in the [Python API client](/apify-client-python), you can access a dataset using [its client](/apify-client-python#datasetclient) again.
+Likewise, in the [Python API client](/apify-client-python), you can access a dataset using [its client](/apify-client-python#datasetclient).
 
 ```python
 other_dataset_client = apify_client.dataset('jane-doe/old-dataset')

--- a/docs/storage/dataset.md
+++ b/docs/storage/dataset.md
@@ -20,11 +20,12 @@ Dataset storage is **append-only** - data can only be added and cannot be change
 
 ## [](#basic-usage) Basic usage
 
-There are four ways to access your datasets:
+There are five ways to access your datasets:
 
 * [Apify app](https://my.apify.com/storage#/datasets) - provides an easy-to-understand interface [[details](#apify-app)].
 * [Apify SDK](https://sdk.apify.com/docs/guides/data-storage#dataset) - when building your own Apify actor [[details](#apify-sdk)].
 * [JavaScript API client](/apify-client-js#datasetclient) - to access your datasets from any Node.js application [[details](#javascript-api-client)].
+* [Python API client](/apify-client-python#datasetclient) - to access your datasets from any Python application [[details](#python-api-client)].
 * [Apify API](https://docs.apify.com/api/v2#/reference/datasets) - for accessing your datasets programmatically [[details](#apify-api)].
 
 ### [](#apify-app) Apify app
@@ -111,6 +112,22 @@ You can then use that variable to [access the dataset's items and manage it](/ap
 Note: When using the [`.listItems()`](/apify-client-js#datasetclient-listitems) method, if you mention the same field name in the `field` and `omit` parameters, the `omit` parameter will prevail and the field will not be returned.
 
 [See the JavaScript API client documentation](/apify-client-js#datasetclient) for [help with setup](/apify-client-js#quick-start) and more details.
+
+### [](#python-api-client) Python API client
+
+Apify's [Python API client](/apify-client-python) (`apify-client`) allows you to access your datasets from any Python application, whether it is running on the Apify platform or elsewhere.
+
+After importing and initiating the client, you can save each dataset to a variable for easier access.
+
+```python
+my_dataset_client = apify_client.dataset('jane-doe/my-dataset')
+```
+
+You can then use that variable to [access the dataset's items and manage it](/apify-client-python#datasetclient).
+
+Note: When using the [`.list_items()`](/apify-client-python#datasetclient-list_items) method, if you mention the same field name in the `field` and `omit` parameters, the `omit` parameter will prevail and the field will not be returned.
+
+[See the Python API client documentation](/apify-client-python#datasetclient) for [help with setup](/apify-client-python#quick-start) and more details.
 
 ### [](#apify-api) Apify API
 
@@ -297,6 +314,12 @@ In the [JavaScript API client](/apify-client-js), you can access a dataset using
 
 ```js
 const otherDatasetClient = apifyClient.dataset('jane-doe/old-dataset');
+```
+
+The same works in the [Python API client](/apify-client-python), you can access a dataset using [its client](/apify-client-python#datasetclient) again.
+
+```python
+other_dataset_client = apify_client.dataset('jane-doe/old-dataset')
 ```
 
 The same applies for the [Apify API](#apify-api) - you can use [the same endpoints](#apify-api) as you would normally.

--- a/docs/storage/key_value_store.md
+++ b/docs/storage/key_value_store.md
@@ -214,7 +214,7 @@ In the [JavaScript API client](/apify-client-js), you can access a store using [
 const otherStoreClient = apifyClient.keyValueStore('jane-doe/old-store');
 ```
 
-The same works in the [Python API client](/apify-client-python), you can access a store using [its client](/apify-client-python#keyvaluestoreclient) again.
+Likewise, in the [Python API client](/apify-client-python), you can access a store using [its client](/apify-client-python#keyvaluestoreclient).
 
 ```python
 other_store_client = apify_client.key_value_store('jane-doe/old-store')

--- a/docs/storage/key_value_store.md
+++ b/docs/storage/key_value_store.md
@@ -20,11 +20,12 @@ Key-value stores are mutable–you can both add entries and delete them.
 
 ## Basic usage
 
-There are four ways to access your key-value stores:
+There are five ways to access your key-value stores:
 
 * [Apify app](https://my.apify.com/storage#/keyValueStores) - provides an easy-to-understand interface [[details](#apify-app)].
 * [Apify software development kit (SDK)](https://sdk.apify.com/docs/guides/data-storage#key-value-store) - when building your own Apify actor [[details](#apify-sdk)].
 * [JavaScript API client](/apify-client-js#keyvaluestoreclient) - to access your key-value stores from any Node.js application [[details](#javascript-api-client)].
+* [Python API client](/apify-client-python#keyvaluestoreclient) - to access your key-value stores from any Python application [[details](#python-api-client)].
 * [Apify API](https://docs.apify.com/api/v2#/reference/key-value-stores/get-items) - for accessing your key-value stores programmatically [[details](#apify-api)].
 
 ### Apify app
@@ -122,6 +123,20 @@ You can then use that variable to [access the key-value store's items and manage
 
 [See the JavaScript API client documentation](/apify-client-js#keyvaluestoreclient) for [help with setup](/apify-client-js#quick-start) and more details.
 
+### Python API client
+
+Apify's [Python API client](/apify-client-python#keyvaluestoreclient) (`apify-client`) allows you to access your key-value stores from any Python application, whether it is running on the Apify platform or elsewhere.
+
+After importing and initiating the client, you can save each key-value store to a variable for easier access.
+
+```python
+my_key_val_store_client = apify_client.key_value_store('jane-doe/my-key-val-store')
+```
+
+You can then use that variable to [access the key-value store's items and manage it](/apify-client-python#keyvaluestoreclient).
+
+[See the Python API client documentation](/apify-client-python#keyvaluestoreclient) for [help with setup](/apify-client-python#quick-start) and more details.
+
 ### Apify API
 
 The [Apify API](https://docs.apify.com/api/v2#/reference/key-value-stores) allows you to access your key-value stores programmatically using [HTTP requests](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods) and easily share your crawling results.
@@ -197,6 +212,12 @@ In the [JavaScript API client](/apify-client-js), you can access a store using [
 
 ```js
 const otherStoreClient = apifyClient.keyValueStore('jane-doe/old-store');
+```
+
+The same works in the [Python API client](/apify-client-python), you can access a store using [its client](/apify-client-python#keyvaluestoreclient) again.
+
+```python
+other_store_client = apify_client.key_value_store('jane-doe/old-store')
 ```
 
 The same applies for the [Apify API](#apify-api) - you can use [the same endpoints](#apify-api) as you would normally.

--- a/docs/storage/request_queue.md
+++ b/docs/storage/request_queue.md
@@ -18,11 +18,12 @@ Request queue storage supports both breadth-first and depth-first crawling order
 
 ## [](#basic-usage) Basic usage
 
-There are four ways to access your request queues:
+There are five ways to access your request queues:
 
 * [Apify app](https://my.apify.com/storage#/requestQueues) - provides an easy-to-understand interface [[details](#apify-app)].
 * [Apify SDK](https://sdk.apify.com/docs/guides/data-storage#request-queue) - when building your own Apify actor [[details](#apify-sdk)].
 * [JavaScript API client](apify-client-js#requestqueueclient) - to access your request queues from any Node.js application [[details](#javascript-api-client)].
+* [Python API client](apify-client-python#requestqueueclient) - to access your request queues from any Python application [[details](#python-api-client)].
 * [Apify API](/api/v2#/reference/request-queues) - for accessing your request queues programmatically [[details](#apify-api)].
 
 ### [](#apify-app) Apify app
@@ -122,6 +123,20 @@ You can then use that variable to [access the request queue's items and manage i
 
 [See the JavaScript API client documentation](/apify-client-js#requestqueueclient) for [help with setup](/apify-client-js#quick-start) and more details.
 
+### [](#python-api-client) Python API client
+
+Apify's [Python API client](/apify-client-python) (`apify-client`) allows you to access your request queues from any Python application, whether it is running on the Apify platform or elsewhere.
+
+After importing and initiating the client, you can save each request queue to a variable for easier access.
+
+```python
+my_queue_client = apify_client.request_queue('jane-doe/my-request-queue')
+```
+
+You can then use that variable to [access the request queue's items and manage it](/apify-client-python#requestqueueclient).
+
+[See the Python API client documentation](/apify-client-python#requestqueueclient) for [help with setup](/apify-client-python#quick-start) and more details.
+
 ### [](#apify-api) Apify API
 
 The [Apify API](/api/v2#/reference/request-queues) allows you to access your request queues programmatically using [HTTP requests](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods).
@@ -204,6 +219,12 @@ In the [JavaScript API client](/apify-client-js), you can access a request queue
 
 ```js
 const otherQueueClient = apifyClient.requestQueue('jane-doe/old-queue');
+```
+
+The same works in the [Python API client](/apify-client-python), you can access a request queue using [its client](/apify-client-python#requestqueueclient) again.
+
+```python
+other_queue_client = apify_client.request_queue('jane-doe/old-queue')
 ```
 
 The same applies for the [Apify API](#apify-api) - you can use [the same endpoints](#apify-api) as you would normally.

--- a/docs/storage/request_queue.md
+++ b/docs/storage/request_queue.md
@@ -221,7 +221,7 @@ In the [JavaScript API client](/apify-client-js), you can access a request queue
 const otherQueueClient = apifyClient.requestQueue('jane-doe/old-queue');
 ```
 
-The same works in the [Python API client](/apify-client-python), you can access a request queue using [its client](/apify-client-python#requestqueueclient) again.
+Likewise, in the [Python API client](/apify-client-python), you can access a request queue using [its client](/apify-client-python#requestqueueclient).
 
 ```python
 other_queue_client = apify_client.request_queue('jane-doe/old-queue')

--- a/docs/tutorials/integrations.md
+++ b/docs/tutorials/integrations.md
@@ -20,7 +20,7 @@ Integrations use [APIs](https://www.smashingmagazine.com/2018/01/understanding-u
 Our [RESTful API](/api/v2#) allows you to control the Apify platform from any application.
 You can create [actors](/api/v2#/reference/actors/actor-collection/create-actor) and [tasks](/api/v2#/reference/actor-tasks/task-collection/create-task),
 [start and stop your runs](/api/v2#/reference/actor-tasks/run-task-synchronously/run-task-synchronously-(post)),
-and [manage your data](/api/v2#/reference/datasets/item-collection/put-items) using only HTTP requests (or our handy API clients [for Javascript]({{@link apify_client_js.md}}) [for Python]({{@link apify_client_python.md}})).
+and [manage your data](/api/v2#/reference/datasets/item-collection/put-items) using only HTTP requests (or our handy API clients [for Javascript]({{@link apify_client_js.md}}) and [for Python]({{@link apify_client_python.md}})).
 Meanwhile, webhooks allow you to perform tasks like sending HTTP requests or notification on when certain [events]({{@link webhooks/events.md}}) occur.
 
 ## [](#get-started) Get started

--- a/docs/tutorials/integrations.md
+++ b/docs/tutorials/integrations.md
@@ -20,7 +20,8 @@ Integrations use [APIs](https://www.smashingmagazine.com/2018/01/understanding-u
 Our [RESTful API](/api/v2#) allows you to control the Apify platform from any application.
 You can create [actors](/api/v2#/reference/actors/actor-collection/create-actor) and [tasks](/api/v2#/reference/actor-tasks/task-collection/create-task),
 [start and stop your runs](/api/v2#/reference/actor-tasks/run-task-synchronously/run-task-synchronously-(post)),
-and [manage your data](/api/v2#/reference/datasets/item-collection/put-items) using only HTTP requests (or our handy [API client]({{@link apify_client_js.md}})). Meanwhile, webhooks allow you to perform tasks like sending HTTP requests or notification on when certain [events]({{@link webhooks/events.md}}) occur.
+and [manage your data](/api/v2#/reference/datasets/item-collection/put-items) using only HTTP requests (or our handy API clients [for Javascript]({{@link apify_client_js.md}}) [for Python]({{@link apify_client_python.md}})).
+Meanwhile, webhooks allow you to perform tasks like sending HTTP requests or notification on when certain [events]({{@link webhooks/events.md}}) occur.
 
 ## [](#get-started) Get started
 

--- a/docs/tutorials/integrations.md
+++ b/docs/tutorials/integrations.md
@@ -20,8 +20,8 @@ Integrations use [APIs](https://www.smashingmagazine.com/2018/01/understanding-u
 Our [RESTful API](/api/v2#) allows you to control the Apify platform from any application.
 You can create [actors](/api/v2#/reference/actors/actor-collection/create-actor) and [tasks](/api/v2#/reference/actor-tasks/task-collection/create-task),
 [start and stop your runs](/api/v2#/reference/actor-tasks/run-task-synchronously/run-task-synchronously-(post)),
-and [manage your data](/api/v2#/reference/datasets/item-collection/put-items) using only HTTP requests (or our handy API clients [for Javascript]({{@link apify_client_js.md}}) and [for Python]({{@link apify_client_python.md}})).
-Meanwhile, webhooks allow you to perform tasks like sending HTTP requests or notification on when certain [events]({{@link webhooks/events.md}}) occur.
+and [manage your data](/api/v2#/reference/datasets/item-collection/put-items) using only HTTP requests (or our handy API clients [for JavaScript]({{@link apify_client_js.md}}) and [for Python]({{@link apify_client_python.md}})).
+Meanwhile, webhooks allow you to perform tasks like sending HTTP requests or notifications when certain [events]({{@link webhooks/events.md}}) occur.
 
 ## [](#get-started) Get started
 

--- a/docs/web_scraping_101/web_scraping_techniques.md
+++ b/docs/web_scraping_101/web_scraping_techniques.md
@@ -76,7 +76,7 @@ For example, if you are searching for Kaffeine café on [Yelp](https://www.yelp.
 }
 ```
 
-Check out [this tutorial](https://blog.apify.com/web-scraping-in-2018-forget-html-use-xhrs-metadata-or-javascript-variables-8167f252439c) for more information and code examples for scraping with internal Javascript variables.
+Check out [this tutorial](https://blog.apify.com/web-scraping-in-2018-forget-html-use-xhrs-metadata-or-javascript-variables-8167f252439c) for more information and code examples for scraping with internal JavaScript variables.
 
 ## [](#xhrs) XHRs
 


### PR DESCRIPTION
I've added a bunch of Python client references to places where only the JS client was referenced, and added some Python examples to relevant places.

Python tutorials will come soon in a separate PR.