### PR TITLE
Add overview file check for folders

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -59,8 +59,20 @@ const identifyFilesAndDirectories = async (currentPath, items, sourceDirPath) =>
         const itemFullPath = path.join(sourceDirPath, itemPath);
         const stat = await lstatPromised(itemFullPath);
 
-        if (stat.isDirectory()) dirPaths.push(itemPath);
-        else filePaths.push(itemPath);
+        if (stat.isDirectory()) {
+            // Check if the directory has a corresponding overview (.md) file and exit with error if not
+            // This does not apply to the `images` or `api_v2` dirs
+            if (
+                item !== 'images'
+                && item !== 'api_v2'
+                && !items.includes(`${item}.md`)
+            ) {
+                throw new Error(`The directory ${item} doesn't have a corresponding overview file ${item}.md. This will break the menu.`
+                    + `\nPlease, add an overview for this section.`);
+            }
+
+            dirPaths.push(itemPath);
+        } else filePaths.push(itemPath);
     });
     await Promise.all(promises);
 

--- a/src/parser.js
+++ b/src/parser.js
@@ -67,7 +67,7 @@ const identifyFilesAndDirectories = async (currentPath, items, sourceDirPath) =>
                 && item !== 'api_v2'
                 && !items.includes(`${item}.md`)
             ) {
-                throw new Error(`The directory ${item} doesn't have a corresponding overview file ${item}.md. This will break the menu.`
+                throw new Error(`The directory "${item}" doesn't have a corresponding overview file "${item}.md". This will break the menu.`
                     + `\nPlease, add an overview for this section.`);
             }
 


### PR DESCRIPTION
A safety check that makes sure new contributors are less likely to break docs. 
It checks that each folder (with exceptions) has an overview file that's needed for the menu to work properly.

<img width="863" alt="Screenshot 2022-05-19 at 12 04 44" src="https://user-images.githubusercontent.com/38246758/169268599-a411e2a0-97b4-406b-931a-99ea6b674a7b.png">
