### PR TITLE
Add NPM links to Client docs

### DIFF
--- a/content/docs/apify_client_js.md
+++ b/content/docs/apify_client_js.md
@@ -1,6 +1,6 @@
 ---
 title: JavaScript API client
-description: Simplified access to the Apify API from any JavaScript or Node.js application. Manage your actors, tasks and storage via API with the apify-client NPM package.
+description: Simplified access to the Apify API from any JavaScript or Node.js application. Manage your actors, tasks and storage via API with the [apify-client NPM package](https://www.npmjs.com/package/apify-client).
 category: developer tools
 menuWeight: 14
 paths:

--- a/content/docs/apify_client_python.md
+++ b/content/docs/apify_client_python.md
@@ -1,6 +1,6 @@
 ---
 title: Python API client
-description: Simplified access to the Apify API from any Python application. Manage your actors, tasks and storage via API with the apify_client PyPI package.
+description: Simplified access to the Apify API from any Python application. Manage your actors, tasks and storage via API with the [apify_client PyPI package](https://pypi.org/project/apify-client/).
 category: developer tools
 menuWeight: 15
 paths:


### PR DESCRIPTION
GitHub is already linked in the `Edit` button, so I didn't add this.