### PR TITLE
fix too early persistence

### DIFF
--- a/content/academy/expert_scraping_with_apify/solutions/saving_stats.md
+++ b/content/academy/expert_scraping_with_apify/solutions/saving_stats.md
@@ -19,18 +19,18 @@ class Stats {
             errors: {},
             totalSaved: 0,
         };
-
-        Apify.events.on('persistState', async () => {
-            await Apify.setValue('STATS', this.state);
-        });
-
-        setInterval(() => console.log(this.state), 10000);
     }
 
     async initialize() {
         const data = await Apify.getValue('STATS');
 
         if (data) this.state = data;
+
+        Apify.events.on('persistState', async () => {
+            await Apify.setValue('STATS', this.state);
+        });
+
+        setInterval(() => console.log(this.state), 10000);
     }
 
     addError(url, errorMessage) {


### PR DESCRIPTION
Without this fix, the code could actually overwrite the "STATS" value before loading the previous state to memory. I also moved the start of the logging to after loading the stats from memory, which makes more sense.