### PR TITLE
fix(docs): removed publishing actors link from homepage

### DIFF
--- a/content/docs/homepage_content.json
+++ b/content/docs/homepage_content.json
@@ -172,10 +172,6 @@
             "isExternalLink": true
         },
         {
-            "cardItem": "Publish your actor",
-            "href": "/actors/publishing"
-        },
-        {
             "cardItem": "Apify SDK API reference",
             "href": "https://sdk.apify.com/api/apify",
             "isExternalLink": true


### PR DESCRIPTION
The `actors/publish` was removed from docs but the link on docs homepage remained there. Fixed in this PR