### PR TITLE
fix-lessons-order

### DIFF
--- a/content/academy/apify_platform/publishing_actors_on_apify_store/actor_readme.md
+++ b/content/academy/apify_platform/publishing_actors_on_apify_store/actor_readme.md
@@ -6,7 +6,7 @@ paths:
     - apify-platform/publishing-actors-on-apify-store/actor-readme
 ---
 
-## What is the point of this guide?
+# What is the point of this guide?
 
 - It should also be a "template" for developers developing new public actors so that they have a structure and guidance for writing the readmes.
 - The goal is to ensure that more people will understand and run their actors.

--- a/content/academy/apify_platform/publishing_actors_on_apify_store/monetizing_your_actor.md
+++ b/content/academy/apify_platform/publishing_actors_on_apify_store/monetizing_your_actor.md
@@ -1,7 +1,7 @@
 ---
 title: Monetizing your actor
 description: Learn how you can use Apify to monetize your web scraping and automation projects.
-menuWeight: 3
+menuWeight: 4
 paths:
     - apify-platform/publishing-actors-on-apify-store/monetizing-your-actor
 ---

--- a/content/academy/apify_platform/publishing_actors_on_apify_store/publishing_your_actor.md
+++ b/content/academy/apify_platform/publishing_actors_on_apify_store/publishing_your_actor.md
@@ -1,7 +1,7 @@
 ---
 title: Publishing your actor
 description: Prepare your actor for the Apify Store with a description and README file and learn how to make your actor available to the public.
-menuWeight: 4
+menuWeight: 3
 paths:
     - apify-platform/publishing-actors-on-apify-store/publishing-your-actor
 ---

--- a/content/docs/actors/development.md
+++ b/content/docs/actors/development.md
@@ -27,8 +27,7 @@ Here are some resources that will help you go from beginner to pro. If you have 
 
 - [Actor input](https://gitlab.com/apify-public/wiki/-/wikis/public-actors/input).
 - README:
-  - [Quick guide](https://gitlab.com/apify-public/wiki/-/wikis/public-actors/readme).
-  - [How to make your README great](https://help.apify.com/en/articles/2912548-how-to-write-great-readme-for-your-actors).
+  - [How to make your README great](https://developers.apify.com/academy/apify-platform/publishing-actors-on-apify-store/actor-readme).
 - [How to structure your actor's files](https://gitlab.com/apify-public/wiki/-/wikis/public-actors/structure).
 - [Actor building checklist](https://gitlab.com/apify-public/wiki/-/wikis/public-actors/checklist).
-- [Naming your actor](https://docs.apify.com/actors/publishing/naming-your-actor).
+- [Naming your actor](https://developers.apify.com/academy/apify-platform/publishing-actors-on-apify-store/naming-your-actor).


### PR DESCRIPTION
Fixing the lesson order in the "Publishing your actors on Apify Store" section in Academy. The lesson "Publishing your actor" should come before the lesson "Monetizing your actor".