### PR TITLE
feat: Drop basic settings mentions

### DIFF
--- a/content/docs/actors/tasks.md
+++ b/content/docs/actors/tasks.md
@@ -33,11 +33,13 @@ Actors' input fields will vary depending on their purpose, but they all follow t
 
 You can set run options such as timeout and [memory]({{@link actors/running/memory_and_cpu.md}}) at the bottom of the input section.
 
+### Identifying tasks
+
+To make a task easier to identify, you can give it a name, title, and description by clicking it's caption on the detail page.  A task's name should be 3-63 characters long.
+
 ### Settings
 
-To make a task easier to identify, you can give it a name and description under the **Settings** tab. A task's name should be 3-63 characters long.
-
-![Apify task settings]({{@asset actors/images/create-task-settings.webp}})
+Under the **Settings** tab of their detail page, you can grant [access rights](/access-rights) to other Apify users.
 
 ## Run
 

--- a/content/docs/storage.md
+++ b/content/docs/storage.md
@@ -89,7 +89,9 @@ To access your storages from Apify Console, go to the [**Storage** section](http
 
 > Only named storages are displayed by default. Select the **Include unnamed store** checkbox to display all of your storages.
 
-You can edit your stores' names under the **Settings** tab of their detail page. There, you can also grant [access rights](/access-rights) to other Apify users.
+You can edit your stores' names by clicking their caption (id or name) on their detail page.
+
+Under the **Settings** tab of their detail page, you can grant [access rights](/access-rights) to other Apify users.
 
 You can quickly share your storages' contents and details by sharing the URLs you find under the **API** tab in a store's detail page.
 


### PR DESCRIPTION
I think it's all the mentions.

We should add new screenshots, and respective section to actors (it's missing there), once we do the changes with access rights.