### PR TITLE
Improve docs related to actor specs

### DIFF
--- a/content/academy/deploying_your_code/deploying.md
+++ b/content/academy/deploying_your_code/deploying.md
@@ -49,7 +49,7 @@ That's it! the actor should now pull its source code from the repo and automatic
 
 > If you don't yet have the Apify CLI, learn how to install it and log in by following along with [this brief lesson]({{@link tools/apify_cli.md}}) about it.
 
-If you're logged in to the Apify CLI, the `apify push` command can be used to push the code straight onto the Apify platform from your local machine (no GitHub repository required), where it will automatically be built for you. Prior to running this command, make sure that you have an **apify.json** file at the root of the project. If you don't already have one, you can use `apify init .` to automatically generate one for you.
+If you're logged in to the Apify CLI, the `apify push` command can be used to push the code straight onto the Apify platform from your local machine (no GitHub repository required), where it will automatically be built for you. Prior to running this command, make sure that you have an **.actor/actor.json** file at the root of the project. If you don't already have one, you can use `apify init .` to automatically generate one for you.
 
 One important thing to note is that you can use a `.gitignore` file to exclude files from being pushed. When you use `apify push` without a `.gitignore`, the full folder contents will be pushed, meaning that even the even **storage** and **node_modules** will be pushed. These files are unnecessary to push, as they are both generated on the platform.
 

--- a/content/docs/actors/development/base_docker_images.md
+++ b/content/docs/actors/development/base_docker_images.md
@@ -31,3 +31,5 @@ For a full list of available images, [see the Apify SDK Docker image guide](http
 The [Apify API client for Python](https://docs.apify.com/apify-client-python) is preinstalled on these images.
 
 - **Python 3 on Alpine Linux** ([`apify/actor-python`](https://hub.docker.com/r/apify/actor-python/)) - a slim image with Python 3 and the [Apify API client for Python](https://docs.apify.com/apify-client-python) preinstalled. Comes in multiple versions containing Python 3.7, 3.8, 3.9 or 3.10.
+## [](#custom_images) Custom image
+You can always create a custom `Dockerfile` that will be used as a base image for your actor build. To do that, create a Docker file and reference it from the actor config at `.actor/actor.json`, under `dockerfile` field. If not referenced there, the Apify platform will look for the Docker files at `.actor/Dockerfile` and then `Dockerfile` in the actor's root folder.

--- a/content/docs/actors/development/base_docker_images.md
+++ b/content/docs/actors/development/base_docker_images.md
@@ -31,5 +31,3 @@ For a full list of available images, [see the Apify SDK Docker image guide](http
 The [Apify API client for Python](https://docs.apify.com/apify-client-python) is preinstalled on these images.
 
 - **Python 3 on Alpine Linux** ([`apify/actor-python`](https://hub.docker.com/r/apify/actor-python/)) - a slim image with Python 3 and the [Apify API client for Python](https://docs.apify.com/apify-client-python) preinstalled. Comes in multiple versions containing Python 3.7, 3.8, 3.9 or 3.10.
-## [](#custom_images) Custom image
-You can always create a custom `Dockerfile` that will be used as a base image for your actor build. To do that, create a Docker file and reference it from the actor config at `.actor/actor.json`, under `dockerfile` field. If not referenced there, the Apify platform will look for the Docker files at `.actor/Dockerfile` and then `Dockerfile` in the actor's root folder.

--- a/content/docs/actors/development/input_schema.md
+++ b/content/docs/actors/development/input_schema.md
@@ -15,7 +15,7 @@ paths:
 
 An actor's input schema defines the input that the actor accepts and the UI components used for input in Apify Console. Using input schema, you can provide and easy-to-use UI for your actor's users and also ensure that the input provided is valid.
 
-Input schema must be stored in a file named **INPUT_SCHEMA.json** in the actor's root directory. The file's maximum size is 100 kB. If the input schema is provided, then input is always validated to fulfill the schema when an actor is being started (via API or from the console).
+Input schema can be embedded as an object in the `.actor/actor.json` file under `input` field. Alternatively, you can store a path to a json file in that field. If the `input` field or `.actor/actor.json` is omitted, input schema from `.actor/INPUT_SCHEMA.json` is used. In the absence of that file, the `INPUT_SCHEMA.json` file stored in the actor's root directory is used. The file's maximum size is 100 kB. If the input schema is provided, then input is always validated to fulfill the schema when an actor is being started (via API or from the console).
 
 > You can also use our [visual input schema editor](https://apify.github.io/input-schema-editor-react) to guide you through creation of the **INPUT_SCHEMA.json** file.
 <!--  -->

--- a/content/docs/actors/development/input_schema.md
+++ b/content/docs/actors/development/input_schema.md
@@ -15,7 +15,7 @@ paths:
 
 An actor's input schema defines the input that the actor accepts and the UI components used for input in Apify Console. Using input schema, you can provide and easy-to-use UI for your actor's users and also ensure that the input provided is valid.
 
-Input schema can be embedded as an object in the `.actor/actor.json` file under `input` field. Alternatively, you can store a path to a json file in that field. If the `input` field or `.actor/actor.json` is omitted, input schema from `.actor/INPUT_SCHEMA.json` is used. In the absence of that file, the `INPUT_SCHEMA.json` file stored in the actor's root directory is used. The file's maximum size is 100 kB. If the input schema is provided, then input is always validated to fulfill the schema when an actor is being started (via API or from the console).
+Input schema can be embedded as an object in the **.actor/actor.json** file under the `input` field. Alternatively, you can store a path to a JSON file in that field. If the `input` field or **.actor/actor.json** are omitted, the input schema from **.actor/INPUT_SCHEMA.json** is used. In the absence of that file, the **INPUT_SCHEMA.json** file stored in the actor's root directory is used. The file's maximum size is 100 kB. If the input schema is provided, then input is always validated to fulfill the schema when an actor is being started (via API or from Apify Console).
 
 > You can also use our [visual input schema editor](https://apify.github.io/input-schema-editor-react) to guide you through creation of the **INPUT_SCHEMA.json** file.
 <!--  -->

--- a/content/docs/actors/development/output_schema.md
+++ b/content/docs/actors/development/output_schema.md
@@ -18,7 +18,7 @@ An actor's output schema defines the structure and both API and visual represent
 
 ## How to organize files in the .actor folder: two options
 
-**A)** all config options are being set in a `.actor/actor.json` file, e.g.:
+**A)** all config options are being set in a **.actor/actor.json** file, e.g.:
 
 ```JSON
 //file: .actor/actor.json
@@ -43,7 +43,7 @@ An actor's output schema defines the structure and both API and visual represent
 }
 ```
 
-**B)** `.actor/actor.json` links to other sub-config files in the same folder, e.g.:
+**B)** **.actor/actor.json** links to other sub-config files in the same folder, e.g.:
 
 ```JSON
 //file: .actor/actor.json

--- a/content/docs/actors/development/output_schema.md
+++ b/content/docs/actors/development/output_schema.md
@@ -18,7 +18,7 @@ An actor's output schema defines the structure and both API and visual represent
 
 ## How to organize files in the .actor folder: two options
 
-**A)** all config options are being set in a .actor/actor.json file, e.g.:
+**A)** all config options are being set in a `.actor/actor.json` file, e.g.:
 
 ```JSON
 //file: .actor/actor.json
@@ -43,7 +43,7 @@ An actor's output schema defines the structure and both API and visual represent
 }
 ```
 
-**B)** .actor/actor.json links to other sub-config files in the same folder, e.g.:
+**B)** `.actor/actor.json` links to other sub-config files in the same folder, e.g.:
 
 ```JSON
 //file: .actor/actor.json

--- a/content/docs/actors/development/source_code.md
+++ b/content/docs/actors/development/source_code.md
@@ -61,7 +61,7 @@ Similarly, as with the [Git repository]({{@link actors/development/source_code.m
 
 ## [](#custom-dockerfile)Custom Dockerfile
 
-Internally, Apify uses Docker to build and run actors. To control the build of the actor, you can create a custom **Dockerfile** and either reference from `dockerfile` field in actor's config at `.actor/actor.json`, or store it at `.actor/Dockerfile` or at `Dockerfile` in the actor's root directory. These three sites are searched for in this order of preference. If the **Dockerfile** is missing, the system uses the following default:
+Internally, Apify uses Docker to build and run actors. To control the build of the actor, you can create a custom **Dockerfile** and either reference from the `dockerfile` field in the actor's config in **.actor/actor.json**, or store it in **.actor/Dockerfile** or **Dockerfile** in the actor's root directory. These three sites are searched for in this order of preference. If the **Dockerfile** is missing, the system uses the following default:
 
 ```dockerfile
 FROM apify/actor-node:16

--- a/content/docs/actors/development/source_code.md
+++ b/content/docs/actors/development/source_code.md
@@ -61,7 +61,7 @@ Similarly, as with the [Git repository]({{@link actors/development/source_code.m
 
 ## [](#custom-dockerfile)Custom Dockerfile
 
-Internally, Apify uses Docker to build and run actors. To control the build of the actor, you can create a custom **Dockerfile** in the root of the Git repository or Zip directory. If the **Dockerfile** is missing, the system uses the following default:
+Internally, Apify uses Docker to build and run actors. To control the build of the actor, you can create a custom **Dockerfile** and either reference from `dockerfile` field in actor's config at `.actor/actor.json`, or store it at `.actor/Dockerfile` or at `Dockerfile` in the actor's root directory. These three sites are searched for in this order of preference. If the **Dockerfile** is missing, the system uses the following default:
 
 ```dockerfile
 FROM apify/actor-node:16


### PR DESCRIPTION
This PR is adding improvements related to actor specs initiative.

Namely it
1) fixes usage of `apify.json` to` .actor/actor.json`
2) adds info on where the input schema is read from
3) adds info on where the docker is read from
4) some minor tweaks in formatting