### PR TITLE
Increase max length of actor job log to 10 MB

### DIFF
--- a/content/docs/actors/limits.md
+++ b/content/docs/actors/limits.md
@@ -31,7 +31,7 @@ If needed, the limits shown below can be increased on paid accounts. For details
 | Build timeout                                                    | 600 secs<!-- ACTOR_LIMITS.BUILD_TIMEOUT_SECS -->                                      |
 | Build/run disk size                                              | 2x job memory limit<!-- ACTOR_LIMITS.RUN_DISK_TO_MEMORY_SIZE_COEFF -->                |
 | Memory per CPU core                                              | 4,096 MB<!-- ACTOR_LIMITS.RUN_MEMORY_MBYTES_PER_CPU_CORE -->                          |
-| Build/run maximum log size                                       | 5,000,000 characters<!-- ACTOR_LIMITS.LOG_MAX_CHARS -->                               |
+| Build/run maximum log size                                       | 10,485,760 characters<!-- ACTOR_LIMITS.LOG_MAX_CHARS -->                               |
 | Maximum number of dataset columns for xlsx format                | 2,000 columns                                                                         |
 | Maximum size of input schema for a task/actor                    | 100 kB<!-- ACTOR_LIMITS.INPUT_SCHEMA_MAX_BYTES -->                                    |
 


### PR DESCRIPTION
Corresponding constant increase: https://github.com/apify/apify-shared-js/pull/355