### PR TITLE
feat: Increased actor build timeout

### DIFF
--- a/content/docs/actors/limits.md
+++ b/content/docs/actors/limits.md
@@ -28,10 +28,10 @@ If needed, the limits shown below can be increased on paid accounts. For details
 | Maximum combined memory of all running jobs <br/>(Free plan)     | 4,096 MB<!-- ACTOR_LIMITS.FREE_PLAN_MAX_MEMORY_MBYTES -->                             |
 | Maximum combined memory of all running jobs <br/>(Personal plan) | 32,768 MB<!-- ACTOR_LIMITS.PERSONAL_PLAN_MAX_MEMORY_MBYTES -->                        |
 | Maximum combined memory of all running jobs <br/>(Team plan)     | 131,072 MB<!-- ACTOR_LIMITS.TEAM_PLAN_MAX_MEMORY_MBYTES -->                           |
-| Build timeout                                                    | 600 secs<!-- ACTOR_LIMITS.BUILD_TIMEOUT_SECS -->                                      |
+| Build timeout                                                    | 1800 secs<!-- ACTOR_LIMITS.BUILD_TIMEOUT_SECS -->                                     |
 | Build/run disk size                                              | 2x job memory limit<!-- ACTOR_LIMITS.RUN_DISK_TO_MEMORY_SIZE_COEFF -->                |
 | Memory per CPU core                                              | 4,096 MB<!-- ACTOR_LIMITS.RUN_MEMORY_MBYTES_PER_CPU_CORE -->                          |
-| Build/run maximum log size                                       | 10,485,760 characters<!-- ACTOR_LIMITS.LOG_MAX_CHARS -->                               |
+| Build/run maximum log size                                       | 10,485,760 characters<!-- ACTOR_LIMITS.LOG_MAX_CHARS -->                              |
 | Maximum number of dataset columns for xlsx format                | 2,000 columns                                                                         |
 | Maximum size of input schema for a task/actor                    | 100 kB<!-- ACTOR_LIMITS.INPUT_SCHEMA_MAX_BYTES -->                                    |
 


### PR DESCRIPTION
Increased build timeout to 30 minutes, as per https://github.com/apify/apify-shared-js/pull/357