### PR TITLE
feat: Graduate the Python SDK out of beta

### DIFF
--- a/apify-docs-theme/src/config.js
+++ b/apify-docs-theme/src/config.js
@@ -78,7 +78,7 @@ const themeConfig = ({
                         rel: 'dofollow',
                     },
                     {
-                        html: 'SDK for Python <span class="beta-chip">beta</span>',
+                        html: 'SDK for Python',
                         href: `${absoluteUrl}/sdk/python/`, // we need a trailing slash here, we'd get redirected there anyway
                         target: '_self',
                         rel: 'dofollow',
@@ -198,7 +198,7 @@ const themeConfig = ({
                         rel: 'dofollow',
                     },
                     {
-                        label: 'SDK for Python (beta)',
+                        label: 'SDK for Python',
                         href: `${absoluteUrl}/sdk/python/`, // we need a trailing slash here, we'd get redirected there anyway
                         target: '_self',
                         rel: 'dofollow',

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -86,7 +86,7 @@ export default function Home() {
                     />
                     <CardWithIcon
                         icon={<RectanglePythonIcon />}
-                        title="SDK for Python (beta)"
+                        title="SDK for Python"
                         description="A toolkit for building actors on Apify Platform in Python"
                         to="/sdk/python/"
                         width="calc(50% - 12px)"


### PR DESCRIPTION
This removes the "beta" chip next to the Python SDK from the docs header.