### PR TITLE
fix: optional subtitle `to` link, academy sidebar

### DIFF
--- a/apify-docs-theme/src/theme/Navbar/Content/index.jsx
+++ b/apify-docs-theme/src/theme/Navbar/Content/index.jsx
@@ -45,7 +45,7 @@ function SubNavbar() {
                 <div className="navbar__container">
                     <div className="navbar__items">
                         <div className="navbar__sub--title">
-                            <NavbarItem label={subNavbar.title} to="/" activeBaseRegex='(?!)' />
+                            <NavbarItem label={subNavbar.title} to={subNavbar.to ?? '/'} activeBaseRegex='(?!)' />
                         </div>
                         <NavbarItems items={subNavbar.items}/>
                     </div>

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -26,6 +26,7 @@ module.exports = {
                 subNavbar: {
                     title: 'Academy',
                     pathRegex: '/academy',
+                    to: '/academy',
                     items: [
                         {
                             label: 'Courses',

--- a/sources/academy/index.mdx
+++ b/sources/academy/index.mdx
@@ -3,6 +3,7 @@ title: Home
 description: Learn everything about web scraping and automation with our free courses that will turn you into an expert scraper developer.
 sidebar_position: 0
 slug: /
+displayed_sidebar: courses
 hide_table_of_contents: true
 ---
 import AcademyCard from "@site/src/components/AcademyCard";

--- a/sources/academy/sidebars.js
+++ b/sources/academy/sidebars.js
@@ -1,6 +1,5 @@
 module.exports = {
     courses: [
-        'index',
         {
             type: 'category',
             label: 'Web scraping & Automation',


### PR DESCRIPTION
As per @mtrunkat 's request, this PR slightly changes the academy index page and aligns the behavior with the other projects' instances.


https://user-images.githubusercontent.com/61918049/225900705-63ad614a-28ed-4fff-b91c-c9a9b013c360.mp4

