### PR TITLE
feat: Add api doc for maxItems param

### DIFF
--- a/sources/platform/api_v2/api_v2_reference.apib
+++ b/sources/platform/api_v2/api_v2_reference.apib
@@ -953,6 +953,7 @@ received in the response JSON to the [Get items](#reference/datasets/item-collec
     + token: `soSkq9ekdmfOslopH` (string, optional) - API authentication token. Public actors that are configured to be anonymously runnable do not require the token.
     + timeout: 60 (number, optional) - Optional timeout for the run, in seconds. By default, the run uses a timeout specified in the default run configuration for the actor.
     + memory: 256 (number, optional) - Memory limit for the run, in megabytes. The amount of memory can be set to a power of 2 with a minimum of 128. By default, the run uses a memory limit specified in the default run configuration for the actor.
+    + maxItems: 1000 (number, optional) - The maximum number of items that the actor run should return. This is useful for pay-per-result actors, as it allows you to limit the number of results that will be charged to your subscription. You can access the maximum number of items in your actor by using the `APIFY_ACTOR_MAX_ITEMS` environment variable.
     + build: `0.1.234` (string, optional) - Specifies the actor build to run. It can be either a build tag or build number. By default, the run uses the build specified in the default run configuration for the actor (typically `latest`).
     + waitForFinish: 60 (number, optional) - The maximum number of seconds the server waits for the run to finish. By default, it is `0`, the maximum value is `300`. <!-- MAX_ACTOR_JOB_SYNC_WAIT_SECS -->
                                              If the build finishes in time then the returned run object will have a terminal status (e.g. `SUCCEEDED`),
@@ -989,6 +990,7 @@ received in the response JSON to the [Get items](#reference/datasets/item-collec
                                                      in the response. By default, it is `OUTPUT`.
     + timeout: 60 (number, optional) - Optional timeout for the run, in seconds. By default, the run uses a timeout specified in the default run configuration for the actor.
     + memory: 256 (number, optional) - Memory limit for the run, in megabytes. The amount of memory can be set to a power of 2 with a minimum of 128. By default, the run uses a memory limit specified in the default run configuration for the actor.
+    + maxItems: 1000 (number, optional) - The maximum number of items that the actor run should return. This is useful for pay-per-result actors, as it allows you to limit the number of results that will be charged to your subscription. You can access the maximum number of items in your actor by using the `APIFY_ACTOR_MAX_ITEMS` environment variable.
     + build: `0.1.234` (string, optional) - Specifies the actor build to run. It can be either a build tag or build number. By default, the run uses the build specified in the default run configuration for the actor (typically `latest`).
     + webhooks: `dGhpcyBpcyBqdXN0IGV4YW1wbGUK...` (string, optional) - Specifies optional webhooks associated with the actor run, which can be used to receive a notification
       e.g. when the actor finished or failed. The value is a Base64-encoded JSON array of objects defining the webhooks. For more information, see
@@ -1106,6 +1108,7 @@ To run the actor asynchronously, use the [Run actor](#reference/actors/run-colle
     + token: `soSkq9ekdmfOslopH` (string, optional) - API authentication token. Public actors that are configured to be anonymously runnable do not require token parameter.
     + timeout: 60 (number, optional) - Optional timeout for the run, in seconds. By default, the run uses a timeout specified in the default run configuration for the actor.
     + memory: 256 (number, optional) - Memory limit for the run, in megabytes. The amount of memory can be set to a power of 2 with a minimum of 128. By default, the run uses a memory limit specified in the default run configuration for the actor.
+    + maxItems: 1000 (number, optional) - The maximum number of items that the actor run should return. This is useful for pay-per-result actors, as it allows you to limit the number of results that will be charged to your subscription. You can access the maximum number of items in your actor by using the `APIFY_ACTOR_MAX_ITEMS` environment variable.
     + build: `0.1.234` (string, optional) - Specifies the actor build to run. It can be either a build tag or build number. By default, the run uses the build specified in the default run configuration for the actor (typically `latest`).
     + webhooks: `dGhpcyBpcyBqdXN0IGV4YW1wbGUK...` (string, optional) - Specifies optional webhooks associated with the actor run, which can be used to receive a notification
       e.g. when the actor finished or failed. The value is a Base64-encoded JSON array of objects defining the webhooks. For more information, see
@@ -1699,6 +1702,7 @@ received in the response JSON to the [Get items](#reference/datasets/item-collec
     + token: `soSkq9ekdmfOslopH` (string, optional) - API authentication token.
     + timeout: 60 (number, optional) - Optional timeout for the run, in seconds. By default, the run uses a timeout specified in the task settings.
     + memory: 256 (number, optional) - Memory limit for the run, in megabytes. The amount of memory can be set to a power of 2 with a minimum of 128. By default, the run uses a memory limit specified in the task settings.
+    + maxItems: 1000 (number, optional) - The maximum number of items that the actor run should return. This is useful for pay-per-result actors, as it allows you to limit the number of results that will be charged to your subscription. You can access the maximum number of items in your actor by using the `APIFY_ACTOR_MAX_ITEMS` environment variable.
     + build: `0.1.234` (string, optional) - Specifies the actor build to run. It can be either a build tag or build number. By default, the run uses the build specified in the task settings (typically `latest`).
     + waitForFinish: 60 (number, optional) - The maximum number of seconds the server waits for the run to finish. By default, it is `0`, the maximum value is `300`. <!-- MAX_ACTOR_JOB_SYNC_WAIT_SECS -->
       If the build finishes in time then the returned run object will have a terminal status (e.g. `SUCCEEDED`),
@@ -1735,6 +1739,7 @@ received in the response JSON to the [Get items](#reference/datasets/item-collec
     + token: `soSkq9ekdmfOslopH` (string, optional) - API authentication token.
     + timeout: 60 (number, optional) - Optional timeout for the run, in seconds. By default, the run uses a timeout specified in the task settings.
     + memory: 256 (number, optional) - Memory limit for the run, in megabytes. The amount of memory can be set to a power of 2 with a minimum of 128. By default, the run uses a memory limit specified in the task settings.
+    + maxItems: 1000 (number, optional) - The maximum number of items that the task run should return. This is useful for pay-per-result tasks, as it allows you to limit the number of results that will be charged to your subscription. You can access the maximum number of items in your actor by using the `APIFY_ACTOR_MAX_ITEMS` environment variable.
     + build: `0.1.234` (string, optional) - Specifies the actor build to run. It can be either a build tag or build number. By default, the run uses the build specified in the task settings (typically `latest`).
     + outputRecordKey: `OUTPUT` (string, optional) - Key of the record from run's default key-value store to be returned
       in the response. By default, it is `OUTPUT`.
@@ -1842,6 +1847,7 @@ To run the Task asynchronously, use the [Run task asynchronously](#reference/act
     + token: `soSkq9ekdmfOslopH` (string, optional) - API authentication token.
     + timeout: 60 (number, optional) - Optional timeout for the run, in seconds. By default, the run uses a timeout specified in the task settings.
     + memory: 256 (number, optional) - Memory limit for the run, in megabytes. The amount of memory can be set to a power of 2 with a minimum of 128. By default, the run uses a memory limit specified in the task settings.
+    + maxItems: 1000 (number, optional) - The maximum number of items that the task run should return. This is useful for pay-per-result tasks, as it allows you to limit the number of results that will be charged to your subscription. You can access the maximum number of items in your actor by using the `APIFY_ACTOR_MAX_ITEMS` environment variable.
     + build: `0.1.234` (string, optional) - Specifies the actor build to run. It can be either a build tag or build number. By default, the run uses the build specified in the task settings (typically `latest`).
     + webhooks: `dGhpcyBpcyBqdXN0IGV4YW1wbGUK...` (string, optional) - Specifies optional webhooks associated with the actor run, which can be used to receive a notification
       e.g. when the actor finished or failed. The value is a Base64-encoded JSON array of objects defining the webhooks. For more information, see


### PR DESCRIPTION
This adds description for `maxItems` param into API doc.