### PR TITLE
chore: Rename docs.yml to docs.yaml in the publish workflow, fix readme

### DIFF
--- a/.github/workflows/publish-theme.yaml
+++ b/.github/workflows/publish-theme.yaml
@@ -114,4 +114,4 @@ jobs:
           - env:
               GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
             run: |
-                gh workflow run docs.yml --repo ${{ matrix.repo }} --ref ${{ matrix.branch }}
+                gh workflow run docs.yaml --repo ${{ matrix.repo }} --ref ${{ matrix.branch }}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Apify Documentation
 
-[![Check & Release](https://github.com/apify/apify-docs/actions/workflows/test.yml/badge.svg)](https://github.com/apify/apify-docs/actions/workflows/test.yml)
+[![Check & Release](https://github.com/apify/apify-docs/actions/workflows/test.yaml/badge.svg)](https://github.com/apify/apify-docs/actions/workflows/test.yaml)
 
 ## Intro
 


### PR DESCRIPTION
`docs.yml` has been renamed in all repos or is in PR with rename