### PR TITLE
feat: Replaced all mentions about multiple source file with Web IDE

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ The `./sources/platform/api_v2` directory contains the source file for the API r
 
 1. Install Apiary gem `gem install apiaryio`
 2. After that, you can open the generated doc with the
-   command: `apiary preview --path="./content/docs/api_v2/api_v2_reference.apib"`
+   command: `apiary preview --path="./sources/platform/api_v2/api_v2_reference.apib"`
 
 ### Test
 

--- a/sources/academy/platform/deploying_your_code/deploying.md
+++ b/sources/academy/platform/deploying_your_code/deploying.md
@@ -29,7 +29,7 @@ Easy peasy!
 
 ### Changing source code location {#change-source-code}
 
-In the **Source** tab on the new actor's page, we'll click the dropdown menu under **Source code** and select **Git repository**. By default, this is set to **Multiple source files**.
+In the **Source** tab on the new actor's page, we'll click the dropdown menu under **Source code** and select **Git repository**. By default, this is set to **Web IDE**.
 
 ![Select source code location](../expert_scraping_with_apify/images/select-source-location.png)
 

--- a/sources/academy/platform/expert_scraping_with_apify/managing_source_code.md
+++ b/sources/academy/platform/expert_scraping_with_apify/managing_source_code.md
@@ -43,7 +43,7 @@ First, let's create a repository. This can be done [in a number of ways](https:/
 
 Then, we'll run the commands it tells us in our terminal (while within the **demo-actor** directory) to initialize the repository locally, then push all of the files to the remote one.
 
-After you've created your repo, navigate on the Apify platform to the actor we called **demo-actor**. In the **Source** tab, click the dropdown menu under **Source code** and select **Git repository**. By default, this is set to **Multiple source files**, which is what we've been using so far.
+After you've created your repo, navigate on the Apify platform to the actor we called **demo-actor**. In the **Source** tab, click the dropdown menu under **Source code** and select **Git repository**. By default, this is set to **Web IDE**, which is what we've been using so far.
 
 ![Select source code location](./images/select-source-location.png)
 

--- a/sources/platform/actors/development/source_code.md
+++ b/sources/platform/actors/development/source_code.md
@@ -10,13 +10,13 @@ slug: /actors/development/source-code
 
 ---
 
-The **Source type** setting determines the location of the source code for the actor. It can have one of the following values: [Multiple source files](#multiple-source-files), [Git repository](#git-repository), [Zip file](#zip-file) or [GitHub Gist](#github-gist).
+The **Source type** setting determines the location of the source code for the actor. It can have one of the following values: [WEb IDE](#web-ide), [Git repository](#git-repository), [Zip file](#zip-file) or [GitHub Gist](#github-gist).
 
-## Multiple source files {#multiple-source-files}
+## Web IDE {#web-ide}
 
-If the actor's source code requires the use of multiple files/directories, then it can be hosted on the Apify platform using this option. This is particularly useful when you need to add [**INPUT_SCHEMA.json**](./source_code.md) or **README.md** to your actor, or if you want to create your actor in a language other than JavaScript.
+This option is used by default when your actor's source code is hosted on Apify platform. You can use our Web IDE to preview and update your actor's source code and browse its files and directories. This is especially helpful when you need to make fast updates to your source code or README, or when you want to directly test [**INPUT_SCHEMA.json**](./source_code.md) on the Apify platform.
 
-The only required file for multi-file is **Dockerfile**, and all other files depend on your Dockerfile settings. By default, Apify's custom NodeJS Dockerfile is used, which requires a **main.js** file containing your source code and a **package.json** file containing package configurations for [NPM](https://www.npmjs.com/).
+The only required file is **Dockerfile**, and all other files depend on your Dockerfile settings. By default, Apify's custom NodeJS Dockerfile is used, which requires a **main.js** file containing your source code and a **package.json** file containing package configurations for [NPM](https://www.npmjs.com/).
 
 See [Custom Dockerfile](./source_code.md) and [base Docker images](./base_docker_images.md) for more information about creating your own Dockerfile and using Apify's prepared base images.
 

--- a/sources/platform/api_v2/api_v2_reference.apib
+++ b/sources/platform/api_v2/api_v2_reference.apib
@@ -576,7 +576,9 @@ on its value the Version object has the following additional property:
         Each item of the array is an object with the following fields:<br>
         <code>name</code></li> - File path and name<br>
         <code>format</code></li> - Format of the content, can be either <code>"TEXT"</code> or <code>"BASE64"</code><br>
-        <code>content</code></li> - File content
+        <code>content</code></li> - File content<br>
+        <br>
+        Source files can be shown and edited in the Apify Console's Web IDE.
     </td>
   </tr>
   <tr>


### PR DESCRIPTION
@mtrunkat I think the API docs should be fine as it only explains that the "Actor source code is comprised of multiple files" which is still true and it stays like this. The Web IDE is only connected to the platform's user interface and I replaced all the mentioning of the `Multiple source files` type in this PR.

Closes [apify-web #2597](https://github.com/apify/apify-web/issues/2597)