### PR TITLE
 Corrected link for headers in geolocation.md file

### DIFF
--- a/sources/academy/webscraping/anti_scraping/techniques/geolocation.md
+++ b/sources/academy/webscraping/anti_scraping/techniques/geolocation.md
@@ -23,7 +23,7 @@ On targets which are just utilizing cookies and headers to identify the location
 
 The oldest (and still most common) way of geolocating is based on the IP address used to make the request. Sometimes, country-specific sites block themselves from being accessed from any other country (some Chinese, Indian, Israeli, and Japanese websites do this).
 
-[Proxies](../mitigation/proxies.md) can be used in a scraper to bypass restrictions for make requests from a different location. Often times, proxies need to be used in combination with location-specific [cookies](../../../glossary/concepts/http_cookies.md)/headers(../../../glossary/concepts/http_headers.md).
+[Proxies](../mitigation/proxies.md) can be used in a scraper to bypass restrictions for make requests from a different location. Often times, proxies need to be used in combination with location-specific [cookies](../../../glossary/concepts/http_cookies.md)/[headers](../../../glossary/concepts/http_headers.md).
 
 ## Override/emulate geolocation when using a browser-based scraper {#override-emulate-geolocation}
 


### PR DESCRIPTION
Updated the link in the geolocation.md file to fix a typo and ensure proper navigation. Previously, the link cookies/headers(../../../glossary/concepts/http_headers.md) was incorrectly formatted. The link has been corrected to (../../../glossary/concepts/http_cookies.md)/headers to properly direct readers to the relevant sections on cookies and headers in the HTTP glossary.