### PR TITLE
chore: Use new secrets in CI

### DIFF
--- a/.github/workflows/publish-theme.yaml
+++ b/.github/workflows/publish-theme.yaml
@@ -36,7 +36,7 @@ jobs:
         steps:
             -   uses: actions/checkout@v3
                 with:
-                    token: ${{ secrets.GH_TOKEN }}
+                    token: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}
 
             -   name: Use Node.js 16
                 uses: actions/setup-node@v3
@@ -49,7 +49,7 @@ jobs:
                     git config --global user.email "noreply@apify.com"
 
                     echo "access=public" > .npmrc
-                    echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" >> .npmrc
+                    echo "//registry.npmjs.org/:_authToken=${{ secrets.APIFY_SERVICE_ACCOUNT_NPM_TOKEN }}" >> .npmrc
 
             -   name: Bump the theme version
                 run: |
@@ -61,9 +61,9 @@ jobs:
                     cd $GITHUB_WORKSPACE/apify-docs-theme
                     npx -y publish-if-not-exists
                 env:
-                    NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-                    GIT_USER: "barjin:${{ secrets.GH_TOKEN }}"
-                    GH_TOKEN: ${{ secrets.GH_TOKEN }}
+                    NPM_TOKEN: ${{ secrets.APIFY_SERVICE_ACCOUNT_NPM_TOKEN }}
+                    GIT_USER: "barjin:${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}"
+                    GH_TOKEN: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}
 
             - name: Wait until the new theme version is available on npm
               run: |
@@ -112,6 +112,6 @@ jobs:
         runs-on: ubuntu-latest
         steps:
           - env:
-              GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+              GITHUB_TOKEN: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}
             run: |
                 gh workflow run docs.yaml --repo ${{ matrix.repo }} --ref ${{ matrix.branch }}


### PR DESCRIPTION
This switches the repository to use new secrets from the GitHub organization rather than directly from the GitHub repo, as those are what we want to use where possible.

It's a bit hard to test, so 🤞 