### PR TITLE
Feature/proxy restructuring 2

### DIFF
--- a/sources/platform/proxy/datacenter_proxy.md
+++ b/sources/platform/proxy/datacenter_proxy.md
@@ -5,6 +5,9 @@ sidebar_position: 10.3
 slug: /proxy/datacenter-proxy
 ---
 
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
 # Datacenter proxy {#datacenter-proxy}
 
 **Learn how to reduce blocking when web scraping using IP address rotation. See proxy parameters and learn to implement Apify Proxy in an application.**

--- a/sources/platform/proxy/datacenter_proxy.md
+++ b/sources/platform/proxy/datacenter_proxy.md
@@ -1,7 +1,7 @@
 ---
 title: Datacenter proxy
 description: Learn how to reduce blocking when web scraping using IP address rotation. See proxy parameters and learn to implement Apify Proxy in an application.
-sidebar_position: 10.3
+sidebar_position: 10.2
 slug: /proxy/datacenter-proxy
 ---
 
@@ -16,12 +16,7 @@ import TabItem from '@theme/TabItem';
 
 Datacenter proxies are a cheap, fast and stable way to mask your identity online. When you access a website using a datacenter proxy, the site can only see the proxy center's credentials, not yours.
 
-Datacenter proxies allow you to mask and [rotate](./index.md#ip-address-rotation) your IP address during web scraping and automation jobs, reducing the possibility of them being [blocked](/academy/anti-scraping/techniques#access-denied). For each [HTTP/S request](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods), the proxy takes the list of all available IP addresses and selects the one used the longest time ago for the specific hostname.
-
-[Apify Proxy](https://apify.com/proxy) currently offers two types of datacenter proxy:
-
-* [Shared proxy groups](#shared-proxy-groups)
-* [Dedicated proxy groups](#dedicated-proxy-groups)
+Datacenter proxies allow you to mask and [rotate](./usage.md#ip-address-rotation) your IP address during web scraping and automation jobs, reducing the possibility of them being [blocked](/academy/anti-scraping/techniques#access-denied). For each [HTTP/S request](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods), the proxy takes the list of all available IP addresses and selects the one used the longest time ago for the specific hostname.
 
 ## Features {#features}
 
@@ -34,33 +29,29 @@ Datacenter proxies allow you to mask and [rotate](./index.md#ip-address-rotation
 * Measures statistics of traffic for specific users and hostnames.
 * Allows selection of proxy servers by country.
 
-## Shared proxy groups {#shared-proxy-groups}
+## Datacenter proxy types
+
+When using Apify's datacenter proxies, you can either select a proxy group, or the `auto` mode. [Apify Proxy](https://apify.com/proxy) offers either proxy groups that are shared across multiple customers or dedicated ones.
+
+### Shared proxy groups {#shared-proxy-groups}
 
 Each user has access to a selected number of proxy servers from a shared pool. These servers are spread into groups (called proxy groups). Each group shares a common feature (location, provider, speed and so on).
 
-For a full list of plans and number of allocated proxy servers for each plan, see our [pricing](https://apify.com/pricing).
+For a full list of plans and number of allocated proxy servers for each plan, see our [pricing](https://apify.com/pricing). To get access to more servers, you can upgrade your plan in the [subscription settings](https://console.apify.com/billing/subscription);
 
-To access more servers or to use Apify Proxy without other parts of the Apify platform, [contact us](https://apify.com/contact).
-
-## Dedicated proxy groups {#dedicated-proxy-groups}
+### Dedicated proxy groups {#dedicated-proxy-groups}
 
 When you purchase access to dedicated proxy groups, they are assigned to you, and only you can use them. You gain access to a range of static IP addresses from these groups.
 
-This feature is useful if you have your own pool of proxy servers and still want to benefit from the features of Apify Proxy (like [IP address rotation](./index.md#ip-address-rotation), [persistent sessions](#session-persistence), and health checking).
-
-If you do not have your own pool, the [customer support](https://apify.com/contact) team can set up a dedicated group for you based on your needs and requirements.
+This feature is also useful if you have your own pool of proxy servers and still want to benefit from the features of Apify Proxy (like [IP address rotation](./usage.md#ip-address-rotation), [persistent sessions](#session-persistence), and health checking). If you do not have your own pool, the [customer support](https://apify.com/contact) team can set up a dedicated group for you based on your needs and requirements.
 
 Prices for dedicated proxy servers are mainly based on the number of proxy servers, their type, and location. [Contact us](https://apify.com/contact) for more information.
-
-[Contact us](https://apify.com/contact) for more details or if you have any questions.
 
 ## Connecting to datacenter proxies {#connecting-to-datacenter-proxies}
 
 By default, each proxied HTTP request is potentially sent via a different target proxy server, which adds overhead and could be potentially problematic for websites which save cookies based on IP address.
 
-If you want to pick an IP address and pass all subsequent connections via that same IP address, you can use the `session` [parameter](./index.md).
-
-For code examples on how to connect to datacenter proxies, see the [examples](#examples-using-the-apify-sdk-and-crawlee).
+If you want to pick an IP address and pass all subsequent connections via that same IP address, you can use the `session` [parameter](./usage.md#sessions).
 
 ### Username parameters {#username-parameters}
 
@@ -70,42 +61,7 @@ The `username` field enables you to pass various [parameters](./usage.md#connect
 
 If you do not want to specify either `groups` or `session` parameters and therefore use the default behavior for both, set the username to `auto`.
 
-## Session persistence {#session-persistence}
-
-When you use datacenter proxy with the `session` [parameter](./index.md#sessions) set in the `username` [field](#username-parameters), a single IP is assigned to the `session ID` provided after you make the first request.
-
-**Session IDs represent IP addresses. Therefore, you can manage the IP addresses you use by managing sessions.** [[More info](./index.md#sessions)]
-
-This IP/session ID combination is persisted and expires 26 hours later. Each additional request resets the expiration time to 26 hours.
-
-So, if you use the session at least once a day, it will never expire, with two possible exceptions:
-
-* The proxy server stops responding and is marked as dead during a health check.
-* If the proxy server is part of a proxy group that is refreshed monthly and is rotated out.
-
-If the session is discarded due to the reasons above, it is assigned a new IP address.
-
-To learn more about [sessions](./index.md#sessions) and [IP address rotation](./index.md#ip-address-rotation), see the [proxy overview page](./index.md).
-
-
-## Examples using the Apify SDK and Crawlee {#examples-using-the-apify-sdk-and-crawlee}
-
-If you are developing your own Apify [actor](../actors/index.mdx) using the Apify SDK ([JavaScript](/sdk/js) and [Python](/sdk/python)) or [Crawlee](https://crawlee.dev/), you can use Apify Proxy in:
-
-* [`CheerioCrawler`](https://crawlee.dev/api/cheerio-crawler/class/CheerioCrawler) by using the [`Actor.createProxyConfiguration()`](/sdk/js/api/apify/class/Actor#createProxyConfiguration) function.
-* [`PlaywrightCrawler`](https://crawlee.dev/api/playwright-crawler/class/PlaywrightCrawler) by using the [`Actor.createProxyConfiguration()`](/sdk/js/api/apify/class/Actor#createProxyConfiguration) function.
-* [`PuppeteerCrawler`](https://crawlee.dev/api/puppeteer-crawler/class/PuppeteerCrawler) by using the [`Actor.createProxyConfiguration()`](/sdk/js/api/apify/class/Actor#createProxyConfiguration) function.
-* [`JSDOMCrawler`](https://crawlee.dev/api/jsdom-crawler/class/JSDOMCrawler) by using the [`Actor.createProxyConfiguration()`](/sdk/js/api/apify/class/Actor#createProxyConfiguration) function.
-* [`requests`](https://pypi.org/project/requests/) library with Python SDK's [`Actor.createProxyConfiguration()`](/sdk/python/reference/class/Actor#create_proxy_configuration) function.
-* [`launchPlaywright()`](https://crawlee.dev/api/playwright-crawler/function/launchPlaywright) by specifying the proxy configuration in the function's options.
-* [`launchPuppeteer()`](https://crawlee.dev/api/puppeteer-crawler/function/launchPuppeteer) by specifying the proxy configuration in the function's options.
-* [`got-scraping`](https://github.com/apify/got-scraping) [NPM package](https://www.npmjs.com/package/got-scraping) by specifying proxy URL in the options.
-
-The Apify SDK's ProxyConfiguration ([JavaScript](/sdk/js/api/apify/class/ProxyConfiguration) and [Python](/sdk/python/reference/class/ProxyConfiguration)) enables you to choose which proxies you use for all connections. You can inspect the current proxy's URL and other attributes using the [proxyInfo](https://crawlee.dev/api/cheerio-crawler/interface/CheerioCrawlingContext#proxyInfo) property of [crawling context](https://crawlee.dev/api/cheerio-crawler/interface/CheerioCrawlingContext) of your crawler's [requestHandler](https://crawlee.dev/api/cheerio-crawler/interface/CheerioCrawlerOptions#requestHandler).
-
-### Rotate IP addresses {#rotate-ip-addresses}
-
-IP addresses for each request are selected at random from all available proxy servers.
+### Examples {#examples}
 
 <Tabs groupId="main">
 <TabItem value="PuppeteerCrawler" label="PuppeteerCrawler">
@@ -175,40 +131,12 @@ async def main():
             'https': proxy_url,
         }
 
-        # each request uses a different IP address
         for _ in range(10):
             response = requests.get('https://api.apify.com/v2/browser-info', proxies=proxies)
             print(response.text)
 
 if __name__ == '__main__':
     asyncio.run(main())
-```
-
-</TabItem>
-
-
-<TabItem value="launchPuppeteer()" label="launchPuppeteer()">
-
-```javascript
-import { Actor } from 'apify';
-import { launchPuppeteer } from 'crawlee';
-
-await Actor.init();
-
-const proxyConfiguration = await Actor.createProxyConfiguration();
-const proxyUrl = await proxyConfiguration.newUrl();
-
-const browser = await launchPuppeteer({ proxyUrl });
-const page = await browser.newPage();
-await page.goto('https://www.example.com');
-const html = await page.content();
-await browser.close();
-
-console.log('HTML:');
-console.log(html);
-
-await Actor.exit();
-
 ```
 
 </TabItem>
@@ -250,11 +178,25 @@ await Actor.exit();
 </TabItem>
 </Tabs>
 
-### Single IP address for multiple requests {#single-ip-address-for-multiple-requests}
+## Session persistence {#session-persistence}
 
-Use a single IP address until it fails (gets retired).
+When you use datacenter proxy with the `session` [parameter](./usage.md#sessions) set in the `username` [field](#username-parameters), a single IP is assigned to the `session ID` provided after you make the first request.
 
-The `maxPoolSize: 1` specified in `sessionPoolOptions` of [PuppeteerCrawler](https://crawlee.dev/api/puppeteer-crawler/class/PuppeteerCrawler) (works the same with other crawler classes) means that a single IP will be used by all browsers until it fails. Then, all running browsers are retired, a new IP is selected and new browsers opened. The browsers all use the new IP.
+**Session IDs represent IP addresses. Therefore, you can manage the IP addresses you use by managing sessions.** [[More info](./usage.md#sessions)]
+
+This IP/session ID combination is persisted and expires 26 hours later. Each additional request resets the expiration time to 26 hours.
+
+So, if you use the session at least once a day, it will never expire, with two possible exceptions:
+
+* The proxy server stops responding and is marked as dead during a health check.
+* If the proxy server is part of a proxy group that is refreshed monthly and is rotated out.
+
+If the session is discarded due to the reasons above, it is assigned a new IP address.
+
+To learn more about [sessions](./usage.md#sessions) and [IP address rotation](./usage.md#ip-address-rotation), see the [proxy overview page](./index.md).
+
+
+### Examples using sessions
 
 <Tabs groupId="main">
 <TabItem value="PuppeteerCrawler" label="PuppeteerCrawler">
@@ -343,37 +285,6 @@ if __name__ == '__main__':
 
 </TabItem>
 
-<TabItem value="launchPuppeteer()" label="launchPuppeteer()">
-
-```javascript
-import { Actor } from 'apify';
-import { launchPuppeteer } from 'crawlee';
-
-await Actor.init();
-
-const proxyConfiguration = await Actor.createProxyConfiguration();
-const proxyUrl = await proxyConfiguration.newUrl('my_session');
-const browser = await launchPuppeteer({ proxyUrl });
-const page = await browser.newPage();
-
-await page.goto('https://proxy.apify.com/?format=json');
-const html = await page.content();
-
-await page.goto('https://proxy.apify.com');
-const html2 = await page.content();
-
-await browser.close();
-
-console.log(html);
-console.log('Should display the same clientIp as');
-console.log(html2);
-
-await Actor.exit();
-
-```
-
-</TabItem>
-
 
 <TabItem value="gotScraping()" label="gotScraping()">
 
@@ -409,43 +320,6 @@ await Actor.exit();
 </TabItem>
 </Tabs>
 
-### How to use proxy groups {#how-to-use-proxy-groups}
-
-For simplicity, the examples above use the automatic proxy configuration (no specific proxy groups are specified), which selects IP addresses from all available groups.
-
-To use IP addresses from specific proxy groups, add the `groups` [property](/sdk/js/api/apify/interface/ProxyConfigurationOptions#groups)
-to [`Actor.createProxyConfiguration()`](/sdk/js/api/apify/class/Actor#createProxyConfiguration) and specify the group names. For example:
-
-<Tabs groupId="main">
-<TabItem value="JavaScript" label="JavaScript">
-
-```javascript
-import { Actor } from 'apify';
-
-await Actor.init();
-// ...
-const proxyConfiguration = await Actor.createProxyConfiguration({
-    groups: ['GROUP_NAME_1', 'GROUP_NAME_2'],
-});
-// ...
-await Actor.exit();
-```
-
-</TabItem>
-<TabItem value="Python" label="Python">
-
-```python
-from apify import Actor
-
-async with Actor:
-    # ...
-    proxy_configuration = await Actor.create_proxy_configuration(groups=['GROUP_NAME_1', 'GROUP_NAME_2'])
-    # ...
-```
-
-</TabItem>
-</Tabs>
-
 ## Examples using standard libraries and languages {#examples-using-standard-libraries-and-languages}
 
 You can find your proxy password on the [Proxy page](https://console.apify.com/proxy) of the Apify Console.
@@ -457,12 +331,6 @@ You can find your proxy password on the [Proxy page](https://console.apify.com/p
 For examples using [PHP](https://www.php.net/), you need to have the [cURL](https://www.php.net/manual/en/book.curl.php) extension enabled in your PHP installation. See [installation instructions](https://www.php.net/manual/en/curl.installation.php) for more information.
 
 Examples in [Python 2](https://www.python.org/download/releases/2.0/) use the [six](https://pypi.org/project/six/) library. Run `pip install six` to enable it.
-
-### Use IP rotation {#use-ip-rotation}
-
-For each request, a random IP address is chosen from all [available proxy groups](https://console.apify.com/proxy). You can use random IP addresses from proxy groups by specifying the group(s) in the `username` parameter.
-
-A random IP address will be used for each request.
 
 <Tabs groupId="main">
 <TabItem value="Node.js (axios)" label="Node.js (axios)">
@@ -583,184 +451,3 @@ echo $response->getBody();
 
 </TabItem>
 </Tabs>
-
-### Multiple requests with the same IP address {#multiple-requests-with-the-same-ip-address}
-
-The IP address in the example is chosen at random from all available proxy groups.
-
-To use this option, set a session name in the `username` parameter.
-
-<Tabs groupId="main">
-<TabItem value="Node.js (axios)" label="Node.js (axios)">
-
-```javascript
-import axios from 'axios';
-import { HttpsProxyAgent } from 'hpagent';
-
-const httpsAgent = new HttpsProxyAgent({
-    // Replace <YOUR_PROXY_PASSWORD> below with your password
-    // found at https://console.apify.com/proxy
-    proxy: 'http://session-my_session:<YOUR_PROXY_PASSWORD>@proxy.apify.com:8000',
-});
-const axiosWithProxy = axios.create({ httpsAgent });
-
-const url = 'https://api.apify.com/v2/browser-info';
-
-const response1 = await axiosWithProxy.get(url);
-const response2 = await axiosWithProxy.get(url);
-// Should return the same clientIp for both requests
-console.log('clientIp1:', response1.data.clientIp);
-console.log('clientIp2:', response2.data.clientIp);
-
-```
-
-</TabItem>
-
-
-<TabItem value="Python 3" label="Python 3">
-
-```python
-import urllib.request as request
-import ssl
-
-def do_request():
-    # Replace <YOUR_PROXY_PASSWORD> below with your password
-    # found at https://console.apify.com/proxy
-    password = "<YOUR_PROXY_PASSWORD>"
-    proxy_url = f"http://session-my_session:{password}@proxy.apify.com:8000"
-    proxy_handler = request.ProxyHandler({
-        "http": proxy_url,
-        "https": proxy_url,
-    })
-
-    ctx = ssl.create_default_context()
-    ctx.check_hostname = False
-    ctx.verify_mode = ssl.CERT_NONE
-    httpHandler = request.HTTPSHandler(context=ctx)
-
-    opener = request.build_opener(httpHandler,proxy_handler)
-    return opener.open("https://api.apify.com/v2/browser-info").read()
-
-print(do_request())
-print("Should return the same clientIp as ")
-print(do_request())
-
-```
-
-</TabItem>
-
-
-<TabItem value="Python 2" label="Python 2">
-
-```python
-import six
-from six.moves.urllib import request
-import ssl
-
-def do_request():
-    # Replace <YOUR_PROXY_PASSWORD> below with your password
-    # found at https://console.apify.com/proxy
-    password = "<YOUR_PROXY_PASSWORD>"
-    proxy_url = (
-        "http://session-my_session:%s@proxy.apify.com:8000" %
-        (password)
-    )
-    proxy_handler = request.ProxyHandler({
-        "http": proxy_url,
-        "https": proxy_url,
-    })
-
-    ctx = ssl.create_default_context()
-    ctx.check_hostname = False
-    ctx.verify_mode = ssl.CERT_NONE
-    httpHandler = request.HTTPSHandler(context=ctx)
-
-    opener = request.build_opener(httpHandler,proxy_handler)
-    return opener.open("https://api.apify.com/v2/browser-info").read()
-
-print(do_request())
-print("Should return the same clientIp as ")
-print(do_request())
-
-```
-
-</TabItem>
-
-
-<TabItem value="PHP" label="PHP">
-
-```php
-<?php
-function doRequest() {
-    $curl = curl_init("https://api.apify.com/v2/browser-info");
-    curl_setopt($curl, CURLOPT_RETURNTRANSFER, 1);
-    curl_setopt($curl, CURLOPT_PROXY, "http://proxy.apify.com:8000");
-    // Replace <YOUR_PROXY_PASSWORD> below with your password
-    // found at https://console.apify.com/proxy
-    curl_setopt($curl, CURLOPT_PROXYUSERPWD, "session-my_session:<YOUR_PROXY_PASSWORD>");
-    $response = curl_exec($curl);
-    curl_close($curl);
-    return $response;
-}
-$response1 = doRequest();
-$response2 = doRequest();
-echo $response1;
-echo "\nShould return the same clientIp as\n";
-echo $response2;
-?>
-
-```
-
-</TabItem>
-
-
-<TabItem value="PHP (Guzzle)" label="PHP (Guzzle)">
-
-```php
-<?php
-require 'vendor/autoload.php';
-
-$client = new \GuzzleHttp\Client([
-    // Replace <YOUR_PROXY_PASSWORD> below with your password
-    // found at https://console.apify.com/proxy
-    'proxy' => 'http://session-my_session:<YOUR_PROXY_PASSWORD>@proxy.apify.com:8000'
-]);
-
-$response = $client->get("https://api.apify.com/v2/browser-info");
-echo $response->getBody();
-
-// Should return the same clientIp as
-$response = $client->get("https://api.apify.com/v2/browser-info");
-echo $response->getBody();
-
-```
-
-</TabItem>
-</Tabs>
-
-## Username examples {#username-examples}
-
-Use randomly allocated IP addresses from the `BUYPROXIES94952` group:
-
-```text
-groups-BUYPROXIES94952
-```
-
-Use a randomly allocated IP address for multiple requests:
-
-```text
-session-new_job_123
-```
-
-Use the same IP address from the `SHADER` and `BUYPROXIES94952` groups for multiple requests:
-
-```text
-groups-SHADER+BUYPROXIES94952,session-new_job_123
-```
-
-Set a session and select an IP from the `BUYPROXIES94952` group located in the USA:
-
-```text
-groups-BUYPROXIES94952,session-new_job_123,country-US
-```
-

--- a/sources/platform/proxy/google_serp_proxy.md
+++ b/sources/platform/proxy/google_serp_proxy.md
@@ -1,7 +1,7 @@
 ---
 title: Google SERP proxy
 description: Learn how to collect search results from Google Search-powered tools. Get search results from localized domains in multiple countries, e.g. the US and Germany.
-sidebar_position: 10.5
+sidebar_position: 10.4
 slug: /proxy/google-serp-proxy
 ---
 
@@ -45,7 +45,7 @@ When using Google SERP proxy, the username should always be:
 groups-GOOGLE_SERP
 ```
 
-Unlike [datacenter](./datacenter_proxy.md) or [residential](./residential_proxy.md) proxies, there is no [session](./index.md#sessions) parameter.
+Unlike [datacenter](./datacenter_proxy.md) or [residential](./residential_proxy.md) proxies, there is no [session](./usage.md#sessions) parameter.
 
 If you use the `country` [parameter](./usage.md), the Google proxy location is used if you access a website whose hostname (stripped of `www.`) starts with **google**.
 
@@ -62,15 +62,13 @@ For example:
 
 See a [full list](https://ipfs.io/ipfs/QmXoypizjW3WknFiJnKLwHCnL72vedxjQkDDP1mXWo6uco/wiki/List_of_Google_domains.html) of available domain names for specific countries. When using them, remember to prepend the domain name with the `www.` prefix.
 
-## Examples using the Apify SDK {#examples-using-the-apify-sdk}
+## Examples {#examples}
+
+### Using the Apify SDK {#examples-using-the-apify-sdk}
 
 If you are developing your own Apify [actor](../actors/index.mdx) using the Apify SDK ([JavaScript](/sdk/js) and [Python](/sdk/python)) and [Crawlee](https://crawlee.dev/), the most efficient way to use Google SERP proxy is [CheerioCrawler](https://crawlee.dev/api/cheerio-crawler/class/CheerioCrawler). This is because Google SERP proxy [only returns a page's HTML](./index.md). Alternatively, you can use the [got-scraping](https://github.com/apify/got-scraping) [NPM package](https://www.npmjs.com/package/got-scraping) by specifying proxy URL in the options. For Python, you can leverage the [`requests`](https://pypi.org/project/requests/) library along with Apify SDK.
 
-Apify Proxy also works with [PuppeteerCrawler](https://crawlee.dev/api/puppeteer-crawler/class/PuppeteerCrawler), [launchPuppeteer()](https://crawlee.dev/api/puppeteer-crawler/function/launchPuppeteer), [PlaywrightCrawler](https://crawlee.dev/api/playwright-crawler/class/PlaywrightCrawler), [launchPlaywright()](https://crawlee.dev/api/playwright-crawler/function/launchPlaywright) and [JSDOMCrawler](https://crawlee.dev/api/jsdom-crawler/class/JSDOMCrawler). However, `CheerioCrawler` is simply the most efficient solution for this use case.
-
-### Get a list of search results {#get-a-list-of-search-results}
-
-Get a list of search results for the keyword **wikipedia** from the USA (`google.com`).
+The following examples get a list of search results for the keyword **wikipedia** from the USA (`google.com`).
 
 <Tabs groupId="main">
 <TabItem value="CheerioCrawler" label="CheerioCrawler">
@@ -153,95 +151,7 @@ await Actor.exit();
 </TabItem>
 </Tabs>
 
-### Get a list of shopping results {#get-a-list-of-shopping-results}
-
-Get a list of shopping results for the query **Apple iPhone XS 64GB** from Great Britain (`google.co.uk`).
-
-
-<Tabs groupId="main">
-<TabItem value="CheerioCrawler" label="CheerioCrawler">
-
-```javascript
-import { Actor } from 'apify';
-import { CheerioCrawler } from 'crawlee';
-
-await Actor.init();
-
-const proxyConfiguration = await Actor.createProxyConfiguration({
-    groups: ['GOOGLE_SERP'],
-});
-
-const crawler = new CheerioCrawler({
-    proxyConfiguration,
-    async requestHandler({ body }) {
-        // ...
-        console.log(body)
-    },
-});
-
-const query = encodeURI('Apple iPhone XS 64GB');
-await crawler.run([`http://www.google.co.uk/search?q=${query}&tbm=shop`]);
-
-await Actor.exit();
-
-```
-
-</TabItem>
-
-<TabItem value="Python SDK with requests" label="Python SDK with requests">
-
-```python
-from apify import Actor
-import requests, asyncio, urllib.parse
-
-async def main():
-    async with Actor:
-        proxy_configuration = await Actor.create_proxy_configuration(groups=['GOOGLE_SERP'])
-        proxy_url = await proxy_configuration.new_url()
-        proxies = {
-            'http': proxy_url,
-            'https': proxy_url,
-        }
-        query = urllib.parse.urlencode({ 'tbm': 'shop', 'q': 'Apple iPhone XS 64GB' })
-        response = requests.get(f'http://www.google.co.uk/search?{query}', proxies=proxies)
-        print(response.text)
-
-if __name__ == '__main__':
-    asyncio.run(main())
-
-```
-
-</TabItem>
-
-<TabItem value="gotScraping()" label="gotScraping()">
-
-```javascript
-import { Actor } from 'apify';
-import { gotScraping } from 'got-scraping';
-
-await Actor.init();
-
-const proxyConfiguration = await Actor.createProxyConfiguration({
-    groups: ['GOOGLE_SERP'],
-});
-const proxyUrl = await proxyConfiguration.newUrl();
-
-const query = encodeURI('Apple iPhone XS 64GB');
-const { body } = await gotScraping({
-    url: `http://www.google.co.uk/search?tbm=shop&q=${query}`,
-    proxyUrl,
-});
-
-console.log(body);
-
-await Actor.exit();
-
-```
-
-</TabItem>
-</Tabs>
-
-## Examples using standard libraries and languages {#using-standard-libraries-and-languages}
+### Using standard libraries and languages {#using-standard-libraries-and-languages}
 
 You can find your proxy password on the [Proxy page](https://console.apify.com/proxy/access) of the Apify Console.
 
@@ -253,9 +163,7 @@ For examples using [PHP](https://www.php.net/), you need to have the [cURL](http
 
 Examples in [Python 2](https://www.python.org/download/releases/2.0/) use the [six](https://pypi.org/project/six/) library. Run `pip install six` to enable it.
 
-### HTML from search results {#html-from-search-results}
-
-Get the HTML of search results for the keyword **wikipedia** from the USA (**google.com**).
+The following examples get the HTML of search results for the keyword **wikipedia** from the USA (**google.com**).
 
 Select this option by setting the `username` parameter to `groups-GOOGLE_SERP`. Add the item you want to search to the `query` parameter.
 
@@ -374,139 +282,6 @@ $client = new \GuzzleHttp\Client([
 
 $response = $client->get("http://www.google.com/search", [
     'query' => ['q' => 'wikipedia']
-]);
-echo $response->getBody();
-
-```
-
-</TabItem>
-</Tabs>
-
-### HTML from localized shopping results {#html-from-localized-shopping-results}
-
-Get HTML of shopping results for the query **Apple iPhone XS 64GB** from Great Britain (`google.co.uk`).
-
-Select this option by setting the `username` parameter to `groups-GOOGLE_SERP`. In the `query` parameter, add the item you want to search and specify the **shop** page as a URL parameter.
-
-Set the domain (your country of choice) in the URL (in the `response` variable).
-
-<Tabs groupId="main">
-<TabItem value="Node.js (axios)" label="Node.js (axios)">
-
-```javascript
-import axios from 'axios';
-
-const proxy = {
-    protocol: 'http',
-    host: 'proxy.apify.com',
-    port: 8000,
-    // Replace <YOUR_PROXY_PASSWORD> below with your password
-    // found at https://console.apify.com/proxy
-    auth: { username: 'groups-GOOGLE_SERP', password: <YOUR_PROXY_PASSWORD> },
-};
-
-const url = 'http://www.google.co.uk/search';
-const params = { q: 'Apple iPhone XS 64GB', tbm: 'shop' }
-
-const { data } = await axios.get(url, { proxy, params });
-
-console.log(data);
-
-```
-
-</TabItem>
-
-
-<TabItem value="Python 3" label="Python 3">
-
-```python
-import urllib.request as request
-import urllib.parse as parse
-
-# Replace <YOUR_PROXY_PASSWORD> below with your password
-# found at https://console.apify.com/proxy
-password = '<YOUR_PROXY_PASSWORD>'
-proxy_url = f"http://groups-GOOGLE_SERP:{password}@proxy.apify.com:8000"
-proxy_handler = request.ProxyHandler({
-    'http': proxy_url,
-})
-opener = request.build_opener(proxy_handler)
-
-query = parse.urlencode({ 'q': 'Apple iPhone XS 64GB', 'tbm': 'shop' })
-print(opener.open(f"http://www.google.co.uk/search?{query}").read())
-
-```
-
-</TabItem>
-
-
-<TabItem value="Python 2" label="Python 2">
-
-```python
-import six
-from six.moves.urllib import request, urlencode
-
-# Replace <YOUR_PROXY_PASSWORD> below with your password
-# found at https://console.apify.com/proxy
-password = '<YOUR_PROXY_PASSWORD>'
-proxy_url = (
-    'http://groups-GOOGLE_SERP:%s@proxy.apify.com:8000' %
-    (password)
-)
-proxy_handler = request.ProxyHandler({
-    'http': proxy_url,
-})
-opener = request.build_opener(proxy_handler)
-query = parse.urlencode({ 'q': 'Apple iPhone XS 64GB', 'tbm': 'shop' })
-url = (
-    'http://www.google.co.uk/search?%s' %
-    (query)
-)
-print(opener.open(url).read())
-
-```
-
-</TabItem>
-
-
-<TabItem value="PHP" label="PHP">
-
-```php
-<?php
-$query = urlencode('Apple iPhone XS 64GB');
-$curl = curl_init('http://www.google.co.uk/search?tbm=shop&q=' . $query);
-curl_setopt($curl, CURLOPT_RETURNTRANSFER, 1);
-curl_setopt($curl, CURLOPT_PROXY, 'http://proxy.apify.com:8000');
-// Replace <YOUR_PROXY_PASSWORD> below with your password
-// found at https://console.apify.com/proxy
-curl_setopt($curl, CURLOPT_PROXYUSERPWD, 'groups-GOOGLE_SERP:<YOUR_PROXY_PASSWORD>');
-$response = curl_exec($curl);
-curl_close($curl);
-echo $response;
-?>
-
-```
-
-</TabItem>
-
-
-<TabItem value="PHP (Guzzle)" label="PHP (Guzzle)">
-
-```php
-<?php
-require 'vendor/autoload.php';
-
-$client = new \GuzzleHttp\Client([
-    // Replace <YOUR_PROXY_PASSWORD> below with your password
-    // found at https://console.apify.com/proxy
-    'proxy' => 'http://groups-GOOGLE_SERP:<YOUR_PROXY_PASSWORD>@proxy.apify.com:8000'
-]);
-
-$response = $client->get("http://www.google.co.uk/search", [
-    'query' => [
-        'q' => 'Apple iPhone XS 64GB',
-        'tbm' => 'shop'
-    ]
 ]);
 echo $response->getBody();
 

--- a/sources/platform/proxy/google_serp_proxy.md
+++ b/sources/platform/proxy/google_serp_proxy.md
@@ -5,6 +5,9 @@ sidebar_position: 10.5
 slug: /proxy/google-serp-proxy
 ---
 
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
 # Google SERP proxy {#google-serp-proxy}
 
 **Learn how to collect search results from Google Search-powered tools. Get search results from localized domains in multiple countries, e.g. the US and Germany.**

--- a/sources/platform/proxy/index.md
+++ b/sources/platform/proxy/index.md
@@ -6,23 +6,29 @@ category: platform
 slug: /proxy
 ---
 
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+import Card from "@site/src/components/Card";
+import CardGrid from "@site/src/components/CardGrid";
+
 # [](./proxy) Proxy
 
 **Learn to anonymously access websites in scraping/automation jobs. Improve data outputs and efficiency of bots, and access websites from various geographies.**
 
 ---
 
-[Apify Proxy](https://apify.com/proxy) allows you to change your IP address when web scraping to reduce the chance of being [blocked](/academy/anti-scraping/techniques) because of your geographical location.
+> [Apify Proxy](https://apify.com/proxy) allows you to change your IP address when web scraping to reduce the chance of being [blocked](/academy/anti-scraping/techniques) because of your geographical location.
 
 You can use proxies in your [actors](../actors/index.mdx) or any other application that supports HTTP proxies. Apify Proxy monitors the health of your IP pool and intelligently [rotates addresses](#ip-address-rotation) to prevent IP address-based blocking.
 
-**You can view your proxy settings and password on the [Proxy](https://console.apify.com/proxy) page in the Apify Console.**
+You can view your proxy settings and password on the [Proxy](https://console.apify.com/proxy) page in the Apify Console. For pricing information, visit [apify.com/pricing](https://apify.com/pricing).
+
 
 ## Quickstart {#quickstart}
 
-If you want to start using Apify Proxy as soon as possible, we provide minimal working examples for connecting to our proxy using the Apify SDK ([JavaScript](/sdk/js) and [Python](/sdk/python)).
+Usage of Apify Proxy means just a couple of lines of code thanks to our SDKs for ([JavaScript](/sdk/js) and [Python](/sdk/python)):
 
-<Tab groupId="main">
+<Tabs groupId="main">
 <TabItem value="JavaScript SDK with PuppeteerCrawler" label="JavaScript SDK with PuppeteerCrawler">
 
 ```javascript
@@ -43,7 +49,6 @@ const crawler = new PuppeteerCrawler({
 await crawler.run(['https://proxy.apify.com/?format=json']);
 
 await Actor.exit();
-
 ```
 
 </TabItem>
@@ -68,13 +73,14 @@ async def main():
 
 if __name__ == '__main__':
     asyncio.run(main())
-
 ```
 
 </TabItem>
-</Tab>
+</Tabs>
 
-## Our proxies {#our-proxies}
+## Proxy types {#proxy-types}
+
+There are several types of proxy servers each of them with different advantages, disadvantages, and price. You can use them to access websites from different geographies and with different levels of anonymity.
 
 <CardGrid>
     <Card
@@ -93,41 +99,4 @@ if __name__ == '__main__':
         to="/platform/proxy/google-serp-proxy"
     />
 </CardGrid>
-
-**For pricing information, visit [apify.com/proxy](https://apify.com/proxy).**
-
-## IP address rotation {#ip-address-rotation}
-
-Web scrapers can rotate the IP addresses they use to access websites. They assign each request a different IP address, which makes it appear like they are all coming from different users. This greatly enhances performance and data throughout.
-
-Depending on whether you use a [browser](https://apify.com/apify/web-scraper) or [HTTP requests](https://apify.com/apify/cheerio-scraper) for your scraping jobs, IP address rotation works differently.
-
-* Browser – a different IP address is used for each browser.
-* HTTP request – a different IP address is used for each request.
-
-**You can use [sessions](#sessions) to manage how you rotate and [persist](#session-persistence) IP addresses.**
-
-[Click here](/academy/anti-scraping/techniques) to learn more about IP address rotation and our findings on how blocking works.
-
-## Sessions {#sessions}
-
-Sessions allow you to use the same IP address for multiple connections.
-
-To set a new session, pass the `session` parameter in your [username](./usage.md#username-parameters) field when connecting to a proxy. This will serve as the session's ID and an IP address will be assigned to it. To [use that IP address in other requests](./datacenter_proxy.md#multiple-requests-with-the-same-ip-address), pass that same session ID in the username field.
-
-The created session will store information such as cookies and can be used to generate [browser fingerprints](https://pixelprivacy.com/resources/browser-fingerprinting/). You can also assign custom user data such as authorization tokens and specific headers.
-
-Sessions are available for [datacenter](./datacenter_proxy.md) and [residential](./residential_proxy.md#session-persistence) proxies.
-
-**This parameter is optional**. By default, each proxied request is assigned a randomly picked least used IP address.
-
-### Session persistence {#session-persistence}
-
-You can persist your sessions (use the same IP address) by setting the `session` parameter in the `username` [field](./usage.md). This assigns a single IP address to a **session ID** after you make the first request.
-
-**Session IDs represent IP addresses. Therefore, you can manage the IP addresses you use by managing sessions.** In cases where you need to keep the same session (e.g. when you need to log in to a website), it is best to keep the same proxy. By assigning an IP address to a **session ID**, you can use that IP for every request you make.
-
-For datacenter proxies, a session persists for **26 hours** ([more info](./datacenter_proxy.md)). For residential proxies, it persists for **1 minute** ([more info](./residential_proxy.md#session-persistence)). Using a session resets its expiry timer.
-
-Google SERP proxies do not support sessions.
 

--- a/sources/platform/proxy/index.md
+++ b/sources/platform/proxy/index.md
@@ -52,7 +52,7 @@ await Actor.exit();
 ```
 
 </TabItem>
-<TabItem value="Python SDK with `requests`" label="Python SDK with `requests`">
+<TabItem value="Python SDK with `requests`" label="Python SDK with requests">
 
 ```python
 import requests, asyncio

--- a/sources/platform/proxy/residential_proxy.md
+++ b/sources/platform/proxy/residential_proxy.md
@@ -5,6 +5,9 @@ sidebar_position: 10.4
 slug: /proxy/residential-proxy
 ---
 
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
 # Residential proxy {#residential-proxy}
 
 **Achieve a higher level of anonymity using IP addresses from human users. Access a wider pool of proxies and reduce blocking by websites' anti-scraping measures.**
@@ -99,7 +102,7 @@ await Actor.exit();
 ```
 
 </TabItem>
-<TabItem value="JavaScript" label="JavaScript">
+<TabItem value="Python" label="Python">
 
 ```python
 from apify import Actor

--- a/sources/platform/proxy/residential_proxy.md
+++ b/sources/platform/proxy/residential_proxy.md
@@ -1,7 +1,7 @@
 ---
 title: Residential proxy
 description: Achieve a higher level of anonymity using IP addresses from human users. Access a wider pool of proxies and reduce blocking by websites' anti-scraping measures.
-sidebar_position: 10.4
+sidebar_position: 10.3
 slug: /proxy/residential-proxy
 ---
 
@@ -18,7 +18,7 @@ Residential proxies use IP addresses assigned by Internet Service Providers to t
 
 This solution allows you to access a larger pool of servers than datacenter proxy. This makes it a better option in cases when you need a large number of different IP addresses.
 
-Residential proxies support [IP address rotation](./index.md#ip-address-rotation) and [sessions](#session-persistence).
+Residential proxies support [IP address rotation](./usage.md#ip-address-rotation) and [sessions](#session-persistence).
 
 **Pricing is based on data traffic**. It is measured for each connection made and displayed on your [proxy usage dashboard](https://console.apify.com/proxy/usage) in the Apify Console.
 
@@ -120,32 +120,11 @@ async with Actor:
 </TabItem>
 </Tabs>
 
-### Username examples {#username-examples}
-
-Use randomly allocated IP addresses from all available countries:
-
-```text
-groups-RESIDENTIAL
-```
-
-A random proxy from the US:
-
-```text
-groups-RESIDENTIAL,country-US
-```
-
-Set a session and select an IP address from the United States:
-
-```text
-groups-RESIDENTIAL,session-my_session_1,country-US
-```
-
-
 ## Session persistence {#session-persistence}
 
-When using residential proxy with the `session` [parameter](./index.md#sessions) set in the [username](./usage.md#username-parameters), a single IP address is assigned to the **session ID** provided after you make the first request.
+When using residential proxy with the `session` [parameter](./usage.md#sessions) set in the [username](./usage.md#username-parameters), a single IP address is assigned to the **session ID** provided after you make the first request.
 
-**Session IDs represent IP addresses. Therefore, you can manage the IP addresses you use by managing sessions.** [[More info](./index.md#sessions)]
+**Session IDs represent IP addresses. Therefore, you can manage the IP addresses you use by managing sessions.** [[More info](./usage.md#sessions)]
 
 This IP/session ID combination is persisted for 1 minute. Each subsequent request resets the expiration time to 1 minute.
 
@@ -154,7 +133,7 @@ If the proxy server becomes unresponsive or the session expires, a new IP addres
 > If you really need to persist the same session, you can try sending some data using that session (e.g. every 20 seconds) to keep it alive.<br/>
 > Providing the connection is not interrupted, this will let you keep the IP address for longer.
 
-To learn more about [sessions](./index.md#sessions) and [IP address rotation](./index.md#ip-address-rotation), see the proxy [overview page](./index.md).
+To learn more about [sessions](./usage.md#sessions) and [IP address rotation](./usage.md#ip-address-rotation), see the proxy [overview page](./index.md).
 
 ## Tips to keep in mind {#tips-to-keep-in-mind}
 
@@ -168,9 +147,9 @@ To reduce your traffic use, we recommend using the `blockRequests()` function of
 
 ### Connected proxy speed variation {#connected-proxy-speed-variation}
 
-Each host on the residential proxy network uses a different device. They have different network speeds and different latencies. This means that requests made with one [session](./index.md#sessions) can be extremely fast, while another request with a different session can be extremely slow. The difference can range from a few milliseconds to a few seconds.
+Each host on the residential proxy network uses a different device. They have different network speeds and different latencies. This means that requests made with one [session](./usage.md#sessions) can be extremely fast, while another request with a different session can be extremely slow. The difference can range from a few milliseconds to a few seconds.
 
-If your solution requires quickly loaded content, the best option is to set a [session](./index.md#sessions), try a small request and see if the response time is acceptable. If it is, you can use this session for other requests. Otherwise, repeat the attempt with a different session.
+If your solution requires quickly loaded content, the best option is to set a [session](./usage.md#sessions), try a small request and see if the response time is acceptable. If it is, you can use this session for other requests. Otherwise, repeat the attempt with a different session.
 
 ### Connection interruptions {#connection-interruptions}
 

--- a/sources/platform/proxy/usage.md
+++ b/sources/platform/proxy/usage.md
@@ -19,21 +19,19 @@ The full connection string has the following format:
 http://<username>:<password>@proxy.apify.com:8000
 ```
 
-| Parameter           | Value / explanation                                                                                                                                                                                                                                                                                                                                        |
-|---------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| Proxy type          | `HTTP`                                                                                                                                                                                                                                                                                                                                                     |
-| Hostname            | `proxy.apify.com`                                                                                                                                                                                                                                                                                                                                          |
-| Port                | `8000`                                                                                                                                                                                                                                                                                                                                                     |
-| Username            | Specifies the proxy parameters such as groups, [session](#sessions) and location. <br/>See [username parameters](#username-parameters) below for details. <br/>**Note**: this is not your Apify username.                                                                                                                                |
+| Parameter           | Value / explanation |
+|---------------------|---------------------|
+| Proxy type          | `HTTP`              |
+| Hostname            | `proxy.apify.com`, alternatively you can use static IP addresses `18.208.102.16`, `35.171.134.41`. |
+| Port                | `8000`              |
+| Username            | Specifies the proxy parameters such as groups, [session](#sessions) and location. See [username parameters](#username-parameters) below for details. <br/>**Note**: this is not your Apify username.|
 | Password            | Proxy password. Your password is displayed on the [Proxy](https://console.apify.com/proxy/groups) page in Apify Console. In Apify [actors](../actors/index.mdx), it is passed as the `APIFY_PROXY_PASSWORD`  environment variable. See the [environment variables docs](../actors/development/programming_interface/environment_variables.md) for more details. |
-
-| Static IP Addresses | `18.208.102.16`, `35.171.134.41` Static IP addresses, <br/>that can be used as alternatives to `Hostname`.                                                                                                                                                                                                                                                 |
 
 > **WARNING:** All usage of Apify Proxy with your password is charged towards your account. Do not share the password with untrusted parties or use it from insecure networks – **the password is sent unencrypted** due to the HTTP protocol's [limitations](https://www.guru99.com/difference-http-vs-https.html).
 
 ### Username parameters
 
-The `username` field enables you to pass parameters like **[groups](#proxy-groups)**, **[session ID](./index.md#sessions)** and **country** for your proxy connection.
+The `username` field enables you to pass parameters like **[groups](#proxy-groups)**, **[session ID](#sessions)** and **country** for your proxy connection.
 
 For example, if you're using [datacenter proxies](./datacenter_proxy.md) and want to use the `new_job_123` session using the `SHADER` group, the username will be:
 
@@ -44,40 +42,38 @@ groups-SHADER,session-new_job_123
 The table below describes the available parameters.
 
 <table class="table table-bordered table-condensed">
+    <thead>
+        <tr>
+            <td>Parameter</td>
+            <td>Type</td>
+            <td>Description</td>
+        </tr>
+    </thead>
     <tbody>
     <tr>
         <th><code>groups</code></th>
+        <td>Required</td>
         <td>
-            Set proxied requests to use servers from the selected groups.
-            <br/>Set to <code>groups-[group name]</code> or <code>auto</code> when using datacenter proxies.
-            <br/>Set to <code>groups-RESIDENTIAL</code> when using residential proxies.
-            <br/>Set to <code>groups-GOOGLE_SERP</code> when using Google SERP proxies.
+            Set proxied requests to use servers from the selected groups:
+            <br/>- <code>groups-[group name]</code> or <code>auto</code> when using datacenter proxies.
+            <br/>- <code>groups-RESIDENTIAL</code> when using residential proxies.
+            <br/>- <code>groups-GOOGLE_SERP</code> when using Google SERP proxies.
         </td>
     </tr>
     <tr>
         <th><code>session</code></th>
+        <td>Optional</td>
         <td>
-            If specified, all proxied requests with the same session identifier are routed
-            <br/>through the same IP address. For example <code>session-new_job_123</code>.
-            <br /><strong>This parameter is optional</strong>. By default, each proxied request
-            is assigned a
-            <br/>randomly picked least used IP address.
-            <br /><strong>The session string can only contain numbers (0-9), letters (a-z or A-Z),
-            dot (.),
-            <br/>underscore (_), a tilde (~). The maximum length is 50 characters.</strong>
+            <p>If specified, to for example <code>session-new_job_123</code>, all proxied requests with the same session identifier are routed through the same IP address. If not specified, each proxied request is assigned a randomly picked least used IP address.</p>
+            <p>The session string can only contain numbers (0-9), letters (a-z or A-Z), dot (.), underscore (_), a tilde (~). The maximum length is 50 characters.</p>
+            <p>Session management may work differently for residential and SERP proxies. Check relevant documentations for more details.</p>
         </td>
     </tr>
     <tr>
         <th><code>country</code></th>
+        <td>Optional</td>
         <td>
-            If specified, all proxied requests will use proxy servers from a selected country.
-             <br/>Note that if there are no proxy servers
-            <br/>from the specified country, the connection will fail.
-             <br/>For example <code>groups-SHADER,country-US</code> uses proxies
-             <br/> from the <code>SHADER</code> group located in the USA.
-            <br /><strong>This parameter is optional</strong>.
-            By default, the proxy uses all available
-            <br/>proxy servers from all countries.
+            If specified, all proxied requests will use proxy servers from a selected country. Note that if there are no proxy servers from the specified country, the connection will fail. For example <code>groups-SHADER,country-US</code> uses proxies from the <code>SHADER</code> group located in the USA. By default, the proxy uses all available proxy servers from all countries.
         </td>
     </tr>
     </tbody>
@@ -85,15 +81,19 @@ The table below describes the available parameters.
 
 If you want to specify one parameter and not the others, just provide that parameter and omit the others. To use the default behavior (not specifying either `groups`, `session`, or `country`), set the username to **auto**. **auto** serves as a placeholder because the username can't be empty.
 
-To learn more about [sessions](./index.md#sessions) and [IP address rotation](./index.md#ip-address-rotation), see the [proxy overview page](./index.md).
-
 ## Code examples
 
-We have code examples for connecting to our proxy using the Apify SDK ([JavaScript](/sdk/js) and [Python](/sdk/python)) and [Crawlee](https://crawlee.dev/) and other JavaScript libraries (**axios** and **got-scraping**), as well as examples in PHP.
+We have code examples for connecting to our proxy using the Apify SDK ([JavaScript](/sdk/js) and [Python](/sdk/python)) and [Crawlee](https://crawlee.dev/) and other libraries, as well as examples in PHP.
 
-* [Datacenter proxy](./datacenter_proxy.md)
-* [Residential proxy](./residential_proxy.md)
-* [Google SERP proxy](./google_serp_proxy.md)
+* [Datacenter proxy](./datacenter_proxy.md#examples)
+* [Residential proxy](./residential_proxy.md#connecting-to-residential-proxy)
+* [Google SERP proxy](./google_serp_proxy.md#examples)
+
+For code examples related to proxy management in Apify SDK and Crawlee, see:
+
+* [Apify SDK JavaScript](/sdk/js/docs/guides/proxy-management)
+* [Apify SDK Python](/sdk/python/docs/concepts/proxy-management)
+* [Crawlee](https://crawlee.dev/docs/guides/proxy-management)
 
 ## IP address rotation {#ip-address-rotation}
 
@@ -104,47 +104,25 @@ Depending on whether you use a [browser](https://apify.com/apify/web-scraper) or
 * Browser – a different IP address is used for each browser.
 * HTTP request – a different IP address is used for each request.
 
-**You can use [sessions](#sessions) to manage how you rotate and [persist](#session-persistence) IP addresses.**
-
-[Click here](/academy/anti-scraping/techniques) to learn more about IP address rotation and our findings on how blocking works.
+Use [sessions](#sessions) to controll how you rotate and [persist](#session-persistence) IP addresses. See our guide [Anti-scraping techniques](/academy/anti-scraping/techniques) to learn more about IP address rotation and our findings on how blocking works.
 
 ## Sessions {#sessions}
 
-Sessions allow you to use the same IP address for multiple connections.
+Sessions allow you to use the same IP address for multiple connections. In cases where you need to keep the same session (e.g. when you need to log in to a website), it is best to keep the same proxy and so the IP address. On the other hand by switching the IP address, you can avoid being blocked by the website.
 
 To set a new session, pass the `session` parameter in your [username](./usage.md#username-parameters) field when connecting to a proxy. This will serve as the session's ID and an IP address will be assigned to it. To [use that IP address in other requests](./datacenter_proxy.md#multiple-requests-with-the-same-ip-address), pass that same session ID in the username field.
 
-The created session will store information such as cookies and can be used to generate [browser fingerprints](https://pixelprivacy.com/resources/browser-fingerprinting/). You can also assign custom user data such as authorization tokens and specific headers.
+We recommend you to use [SessionPool](https://crawlee.dev/api/core/class/SessionPool) abstraction when managing sessions. The created session will then store information such as cookies and can be used to generate [browser fingerprints](/academy/anti-scraping/mitigation/generating-fingerprints). You can also assign custom user data such as authorization tokens and specific headers.
 
-Sessions are available for [datacenter](./datacenter_proxy.md) and [residential](./residential_proxy.md#session-persistence) proxies.
-
-**This parameter is optional**. By default, each proxied request is assigned a randomly picked least used IP address.
-
-### Session persistence {#session-persistence}
-
-You can persist your sessions (use the same IP address) by setting the `session` parameter in the `username` [field](./usage.md). This assigns a single IP address to a **session ID** after you make the first request.
-
-**Session IDs represent IP addresses. Therefore, you can manage the IP addresses you use by managing sessions.** In cases where you need to keep the same session (e.g. when you need to log in to a website), it is best to keep the same proxy. By assigning an IP address to a **session ID**, you can use that IP for every request you make.
-
-For datacenter proxies, a session persists for **26 hours** ([more info](./datacenter_proxy.md)). For residential proxies, it persists for **1 minute** ([more info](./residential_proxy.md#session-persistence)). Using a session resets its expiry timer.
-
-Google SERP proxies do not support sessions.
-
-
+Sessions are available for [datacenter](./datacenter_proxy.md) and [residential](./residential_proxy.md#session-persistence) proxies. For datacenter proxies, a session persists for **26 hours** ([more info](./datacenter_proxy.md)). For residential proxies, it persists for **1 minute** ([more info](./residential_proxy.md#session-persistence)) but you can prolong the lifetime by regularly using the sessinon. Google SERP proxies do not support sessions.
 
 ## Proxy groups
 
-You can see which proxy groups you have access to on the [Proxy page](https://console.apify.com/proxy/groups) in the Apify Console.
-
-To use a specific proxy group (or multiple groups), specify it in the `username` parameter.
+You can see which proxy groups you have access to on the [Proxy page](https://console.apify.com/proxy/groups) in the Apify Console. To use a specific proxy group (or multiple groups), specify it in the `username` parameter.
 
 ## Troubleshooting
 
-To view your connection status to [Apify Proxy](https://apify.com/proxy), open the URL below in the browser using the proxy:
-
-[http://proxy.apify.com/](http://proxy.apify.com/)
-
-If the proxy connection is working, the page should look something like this:
+To view your connection status to [Apify Proxy](https://apify.com/proxy), open the URL below in the browser using the proxy. [http://proxy.apify.com/](http://proxy.apify.com/). If the proxy connection is working, the page should look something like this:
 
 ![Apify proxy status page](./images/proxy-status.png)
 
@@ -154,30 +132,23 @@ To test that your requests are proxied and IP addresses are being [rotated](/aca
 
 ### A different approach to `502 Bad Gateway`
 
-There are times when the `502` status code is not comprehensive enough. Therefore, we have modified our server with `590-599` codes instead to provide more insight.
+There are times when the `502` status code is not comprehensive enough. Therefore, we have modified our server with `590-599` codes instead to provide more insight:
 
 * `590 Non Successful`: upstream responded with non-200 status code.
-
 * `591 RESERVED`: *this status code is reserved for further use.*
-
 * `592 Status Code Out Of Range`: upstream responded with status code different than 100-999.
-
 * `593 Not Found`: DNS lookup failed - [`EAI_NODATA`](https://github.com/libuv/libuv/blob/cdbba74d7a756587a696fb3545051f9a525b85ac/include/uv.h#L82) or [`EAI_NONAME`](https://github.com/libuv/libuv/blob/cdbba74d7a756587a696fb3545051f9a525b85ac/include/uv.h#L83).
-
 * `594 Connection Refused`: upstream refused connection.
-
 * `595 Connection Reset`: connection reset due to loss of connection or timeout.
-
 * `596 Broken Pipe`: trying to write on a closed socket.
-
 * `597 Auth Failed`: incorrect upstream credentials.
-
 * `598 RESERVED`: *this status code is reserved for further use.*
-
 * `599 Upstream Error`: generic upstream error.
 
-`590` and `592` indicate an issue on the upstream side.<br/>
-`593` indicates an incorrect `proxy-chain` configuration.<br/>
-`594`, `595` and `596` may occur due to connection loss.<br/>
-`597` indicates incorrect upstream credentials.<br/>
-`599` is a generic error, where the above is not applicable.
+The typical issues behind these codes are:
+
+* `590` and `592` indicate an issue on the upstream side.
+* `593` indicates an incorrect `proxy-chain` configuration.
+* `594`, `595` and `596` may occur due to connection loss.
+* `597` indicates incorrect upstream credentials.
+* `599` is a generic error, where the above is not applicable.

--- a/sources/platform/proxy/usage.md
+++ b/sources/platform/proxy/usage.md
@@ -11,24 +11,29 @@ slug: /proxy/usage
 
 ## Connection settings
 
-Below are the HTTP proxy connection settings for Apify Proxy.
+To connect to the Apify Proxy, you use the [HTTP proxy protocol](https://en.wikipedia.org/wiki/Proxy_server#Web_proxy_servers). This means that you need to configure your HTTP client to use the proxy server at `proxy.apify.com:8000` and provide it with your Apify Proxy password and the other parameters described below.
+
+The full connection string has the following format:
+
+```text
+http://<username>:<password>@proxy.apify.com:8000
+```
 
 | Parameter           | Value / explanation                                                                                                                                                                                                                                                                                                                                        |
 |---------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Proxy type          | `HTTP`                                                                                                                                                                                                                                                                                                                                                     |
 | Hostname            | `proxy.apify.com`                                                                                                                                                                                                                                                                                                                                          |
 | Port                | `8000`                                                                                                                                                                                                                                                                                                                                                     |
-| Username            | Specifies the proxy parameters such as groups, [session](./index.md) and location. <br/>See [username parameters](#username-parameters) below for details. <br/>**Note**: this is not your Apify username.                                                                                                                                |
-| Password            | Proxy password. Your password is displayed on the [Proxy](https://console.apify.com/proxy/groups) page in Apify Console. <br/>In Apify [actors](../actors/index.mdx), it is passed as the `APIFY_PROXY_PASSWORD` <br/>environment variable.<br/>See the [environment variables docs](../actors/development/programming_interface/environment_variables.md) for more details. |
-| Connection URL      | `http://<username>:<password>@proxy.apify.com:8000`                                                                                                                                                                                                                                                                                                        |
+| Username            | Specifies the proxy parameters such as groups, [session](#sessions) and location. <br/>See [username parameters](#username-parameters) below for details. <br/>**Note**: this is not your Apify username.                                                                                                                                |
+| Password            | Proxy password. Your password is displayed on the [Proxy](https://console.apify.com/proxy/groups) page in Apify Console. In Apify [actors](../actors/index.mdx), it is passed as the `APIFY_PROXY_PASSWORD`  environment variable. See the [environment variables docs](../actors/development/programming_interface/environment_variables.md) for more details. |
+
 | Static IP Addresses | `18.208.102.16`, `35.171.134.41` Static IP addresses, <br/>that can be used as alternatives to `Hostname`.                                                                                                                                                                                                                                                 |
 
-
-**WARNING:** All usage of Apify Proxy with your password is charged towards your account. Do not share the password with untrusted parties or use it from insecure networks – **the password is sent unencrypted** due to the HTTP protocol's [limitations](https://www.guru99.com/difference-http-vs-https.html).
+> **WARNING:** All usage of Apify Proxy with your password is charged towards your account. Do not share the password with untrusted parties or use it from insecure networks – **the password is sent unencrypted** due to the HTTP protocol's [limitations](https://www.guru99.com/difference-http-vs-https.html).
 
 ### Username parameters
 
-The `username` field enables you to pass parameters like **[groups](#proxy-groups)**, **[session](./index.md#sessions) ID** and **country** for your proxy connection.
+The `username` field enables you to pass parameters like **[groups](#proxy-groups)**, **[session ID](./index.md#sessions)** and **country** for your proxy connection.
 
 For example, if you're using [datacenter proxies](./datacenter_proxy.md) and want to use the `new_job_123` session using the `SHADER` group, the username will be:
 
@@ -89,6 +94,43 @@ We have code examples for connecting to our proxy using the Apify SDK ([JavaScri
 * [Datacenter proxy](./datacenter_proxy.md)
 * [Residential proxy](./residential_proxy.md)
 * [Google SERP proxy](./google_serp_proxy.md)
+
+## IP address rotation {#ip-address-rotation}
+
+Web scrapers can rotate the IP addresses they use to access websites. They assign each request a different IP address, which makes it appear like they are all coming from different users. This greatly enhances performance and data throughout.
+
+Depending on whether you use a [browser](https://apify.com/apify/web-scraper) or [HTTP requests](https://apify.com/apify/cheerio-scraper) for your scraping jobs, IP address rotation works differently.
+
+* Browser – a different IP address is used for each browser.
+* HTTP request – a different IP address is used for each request.
+
+**You can use [sessions](#sessions) to manage how you rotate and [persist](#session-persistence) IP addresses.**
+
+[Click here](/academy/anti-scraping/techniques) to learn more about IP address rotation and our findings on how blocking works.
+
+## Sessions {#sessions}
+
+Sessions allow you to use the same IP address for multiple connections.
+
+To set a new session, pass the `session` parameter in your [username](./usage.md#username-parameters) field when connecting to a proxy. This will serve as the session's ID and an IP address will be assigned to it. To [use that IP address in other requests](./datacenter_proxy.md#multiple-requests-with-the-same-ip-address), pass that same session ID in the username field.
+
+The created session will store information such as cookies and can be used to generate [browser fingerprints](https://pixelprivacy.com/resources/browser-fingerprinting/). You can also assign custom user data such as authorization tokens and specific headers.
+
+Sessions are available for [datacenter](./datacenter_proxy.md) and [residential](./residential_proxy.md#session-persistence) proxies.
+
+**This parameter is optional**. By default, each proxied request is assigned a randomly picked least used IP address.
+
+### Session persistence {#session-persistence}
+
+You can persist your sessions (use the same IP address) by setting the `session` parameter in the `username` [field](./usage.md). This assigns a single IP address to a **session ID** after you make the first request.
+
+**Session IDs represent IP addresses. Therefore, you can manage the IP addresses you use by managing sessions.** In cases where you need to keep the same session (e.g. when you need to log in to a website), it is best to keep the same proxy. By assigning an IP address to a **session ID**, you can use that IP for every request you make.
+
+For datacenter proxies, a session persists for **26 hours** ([more info](./datacenter_proxy.md)). For residential proxies, it persists for **1 minute** ([more info](./residential_proxy.md#session-persistence)). Using a session resets its expiry timer.
+
+Google SERP proxies do not support sessions.
+
+
 
 ## Proxy groups
 

--- a/sources/platform/proxy/your_own_proxies.md
+++ b/sources/platform/proxy/your_own_proxies.md
@@ -1,7 +1,7 @@
 ---
 title: Using your own proxies
 description: Use your own proxies while using the Apify platform.
-sidebar_position: 10.6
+sidebar_position: 10.5
 slug: /proxy/using-your-own-proxies
 ---
 


### PR DESCRIPTION
@jirimoravcik 
- I made some small adjustments on index.md and usage.md, please see the comments 
- But I think that in order to simplify our lives we should do one large change on following 3 md files (datacenter, residential, and serp pages):
    - Let's extract the shared info from those pages and place everything to usage.md - for example sessions are repeated there over and over and that's not nessesary
    - Let's extract the examples and put them to examples.md after usage.md - this is because examples are basically the same and maintaining them 3x everywhere is just too much work. 
   
Could you look into those 2 changes? I think that it will shrink the size of docs and makes it much easier to maintain.