### PR TITLE
Minor fixes in academy

### DIFF
--- a/sources/academy/platform/expert_scraping_with_apify/apify_api_and_client.md
+++ b/sources/academy/platform/expert_scraping_with_apify/apify_api_and_client.md
@@ -32,7 +32,7 @@ There are two main ways to programmatically interact with the Apify platform: by
 
 In the previous lesson, we created a **task** for the Amazon actor we built in the first two lessons of this course. Now, we'll be creating another new actor, which will have two jobs:
 
-1. Programmatically call the Amazon actor.
+1. Programmatically call the task for the Amazon actor.
 2. Export its results into CSV format under a new key called **OUTPUT.csv** in the default key-value store.
 
 Though it's a bit unintuitive, this is a perfect activity for learning how to use both the Apify API and the Apify JavaScript client.

--- a/sources/academy/platform/expert_scraping_with_apify/apify_api_and_client.md
+++ b/sources/academy/platform/expert_scraping_with_apify/apify_api_and_client.md
@@ -30,7 +30,7 @@ There are two main ways to programmatically interact with the Apify platform: by
 
 ## Our task
 
-In the previous lesson, we created a **task** for the Amazon actor we build in the first two lessons of this course. Now, we'll be creating another new actor, which will have two jobs:
+In the previous lesson, we created a **task** for the Amazon actor we built in the first two lessons of this course. Now, we'll be creating another new actor, which will have two jobs:
 
 1. Programmatically call the Amazon actor.
 2. Export its results into CSV format under a new key called **OUTPUT.csv** in the default key-value store.

--- a/sources/academy/platform/getting_started/apify_client.md
+++ b/sources/academy/platform/getting_started/apify_client.md
@@ -166,8 +166,6 @@ print(items)
 </TabItem>
 </Tabs>
 
-> Notice that in the JavaScript example, we had to convert the `items` to a [`Buffer`](https://nodejs.org/api/buffer.html), then convert the Buffer to a string and parse it. This is because `dataset.downloadItems()` returns a buffer.
-
 The final code for running the actor and fetching its dataset items looks like this:
 
 <Tabs groupId="main">

--- a/sources/academy/webscraping/anti_scraping/index.md
+++ b/sources/academy/webscraping/anti_scraping/index.md
@@ -120,7 +120,7 @@ One of the best ways of avoiding the possible breaking of your scraper due to we
 
 ### IP session consistency
 
-This technique is commonly uses to entirely block the bot from accessing the website altogether. It works on the principle that every entity that accesses the site gets a token. This token is then saved together with the IP address and HTTP request information such as user-agent and other specific headers. If the entity makes another request, but without the session token, the IP address is added on the greylist.
+This technique is commonly used to entirely block the bot from accessing the website altogether. It works on the principle that every entity that accesses the site gets a token. This token is then saved together with the IP address and HTTP request information such as user-agent and other specific headers. If the entity makes another request, but without the session token, the IP address is added on the greylist.
 
 ### Interval analysis
 


### PR DESCRIPTION
- fixed 2 typos
- the deleted note ([link](https://docs.apify.com/academy/getting-started/apify-client#downloading-dataset-items)) refers to `dataset.downloadItems()`, but the code example uses `dataset.listItems()`, so its probably some leftover from previous version
- the first job  in [this task](https://docs.apify.com/academy/expert-scraping-with-apify/apify-api-and-client#our-task) should be to call task for the amazon actor