### PR TITLE
Update node_js_scraper.md

### DIFF
--- a/sources/academy/webscraping/web_scraping_for_beginners/data_extraction/node_js_scraper.md
+++ b/sources/academy/webscraping/web_scraping_for_beginners/data_extraction/node_js_scraper.md
@@ -52,7 +52,7 @@ const response = await gotScraping(storeUrl);
 const html = response.body;
 
 // Parse HTML with Cheerio
-const $ = cheerio.load(html);
+const $ = load.load(html);
 const headingElement = $('h1');
 const headingText = headingElement.text();
 


### PR DESCRIPTION
'cheerio' is deprecated.ts(6385)
index.d.ts(39, 4): The declaration was marked as deprecated here. (alias) const cheerio: CheerioAPI
import cheerio
The default cheerio instance.

@deprecated — Use the function returned by load instead.