### PR TITLE
Fix: broken link on monetizing your actor page

### DIFF
--- a/sources/academy/platform/get_most_of_actors/monetizing_your_actor.md
+++ b/sources/academy/platform/get_most_of_actors/monetizing_your_actor.md
@@ -100,4 +100,4 @@ Getting new users can be an art in itself, but there are **two simple steps** yo
 
 **Don’t overlook promoting your actor**. This is arguably the most important step after publishing your tool. Taking advantage of all the possible channels for promotion is what often differentiates very successful actors with dozens of paid users from actors with few to no users at all.
 
-Finally, don’t forget to check our [pro-tips]./seo_and_promotion.md to take your actor promotion efforts to the next level.
+Finally, don’t forget to check our [pro-tips](./seo_and_promotion.md) to take your actor promotion efforts to the next level.


### PR DESCRIPTION
On page [monetizing your actor](https://docs.apify.com/academy/get-most-of-actors/monetizing-your-actor) link to [seo and promotion is broken](https://docs.apify.com/academy/get-most-of-actors/seo-and-promotion). This fix solves this issue.

![image](https://github.com/apify/apify-docs/assets/599231/0265b99c-6dfd-4d4f-9921-4f8d60423658)

