### PR TITLE
chore: Update Apify CLI installation instructions via Homebrew

### DIFF
--- a/sources/platform/actors/development/quick_start/start_locally.md
+++ b/sources/platform/actors/development/quick_start/start_locally.md
@@ -16,7 +16,7 @@ slug: /actors/development/quick-start/locally
 On macOS (or Linux), you can install the Apify CLI via the Homebrew package manager.
 
 ```bash
-brew install apify/tap/apify-cli
+brew install apify-cli
 ```
 
 Otherwise, use [NPM](https://www.npmjs.com/) to install the Apify CLI.

--- a/sources/platform/actors/development/quick_start/start_web_ide.md
+++ b/sources/platform/actors/development/quick_start/start_web_ide.md
@@ -69,7 +69,7 @@ npm -g install apify-cli
 or using the Homebrew package manager on macOS:
 
 ```bash
-brew install apify/tap/apify-cli
+brew install apify-cli
 ```
 
 Log in to the Apify platform:


### PR DESCRIPTION
Apify CLI was accepted into `homebrew-core`, so the installation instructions got a bit simpler.