### PR TITLE
docs: fix the contributing link in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This repository is the home of Apify's documentation, which you can find at [doc
 > [!IMPORTANT]
 > Before you contribute to Apify documentation with your first pull request, please read the following 2 articles:
 >
-> - [Contributing guidelines](./CONTRIBUTING.md), where you learn about the project structure, local development, and testing.
+> - [Contributing guidelines](CONTRIBUTING.md), where you learn about the project structure, local development, and testing.
 > - [Style guide](#style-guide), here below, where you learn how to keep the documentation style consistent.
 
 ## Style guide


### PR DESCRIPTION
relevant slack message: https://apifier.slack.com/archives/C0L33UM7Z/p1695047131214619

![obrazek](https://github.com/apify/apify-docs/assets/61918049/3836b0af-8326-4c3c-8a85-b17be0fd9e96)
