### PR TITLE
feat: add info about webhook headers and description

### DIFF
--- a/sources/platform/api_v2/api_v2_reference.apib
+++ b/sources/platform/api_v2/api_v2_reference.apib
@@ -3489,7 +3489,7 @@ To assign the new webhook to an actor or task, the request body must contain `re
 * `eventTypes` is a list of events that will trigger the webhook, e.g. when the actor run succeeds.
 * `condition` should be an object containing the ID of the actor or task to which the webhook will be assigned.
 * `payloadTemplate` is a JSON-like string, whose syntax is extended with the use of variables.
-* `headersTemplate` is a JSON-like string, whose syntax is extended with the use of variables. Following values will be re-written to defaults: 'host', 'Content-Type', 'X-Apify-Webhook', 'X-Apify-Webhook-Dispatch-Id', 'X-Apify-Request-Origin'
+* `headersTemplate` is a JSON-like string, whose syntax is extended with the use of variables. Following values will be re-written to defaults: "host", "Content-Type", "X-Apify-Webhook", "X-Apify-Webhook-Dispatch-Id", "X-Apify-Request-Origin"
 * `description` is an optional string.
 * `shouldInterpolateStrings` is a boolean indicating whether to interpolate variables contained inside strings in the `payloadTemplate`
 

--- a/sources/platform/api_v2/api_v2_reference.apib
+++ b/sources/platform/api_v2/api_v2_reference.apib
@@ -3489,6 +3489,8 @@ To assign the new webhook to an actor or task, the request body must contain `re
 * `eventTypes` is a list of events that will trigger the webhook, e.g. when the actor run succeeds.
 * `condition` should be an object containing the ID of the actor or task to which the webhook will be assigned.
 * `payloadTemplate` is a JSON-like string, whose syntax is extended with the use of variables.
+* `headersTemplate` is a JSON-like string, whose syntax is extended with the use of variables. Following values will be re-written to defaults: 'host', 'Content-Type', 'X-Apify-Webhook', 'X-Apify-Webhook-Dispatch-Id', 'X-Apify-Request-Origin'
+* `description` is an optional string.
 * `shouldInterpolateStrings` is a boolean indicating whether to interpolate variables contained inside strings in the `payloadTemplate`
 
 ```
@@ -3503,6 +3505,8 @@ To assign the new webhook to an actor or task, the request body must contain `re
         "actorTaskId" : "W9bs9JE9v7wprjAnJ"
     },
     "payloadTemplate": "",
+    "headersTemplate": "",
+    "description": "my awesome webhook",
     "shouldInterpolateStrings": false,
 ```
 
@@ -4897,6 +4901,8 @@ a summary of your limits, and your current usage.
 - doNotRetry:               false                           (boolean, nullable)
 - requestUrl:               `http://example.com/`           (string, required)
 - payloadTemplate:          `{\n \"userId\": {{userId}}...` (string, nullable)
+- headersTemplate:          `{\n \"Authorization\": Bearer...`(string, nullable)
+- description:              `this is webhook description`   (string, nullable)
 - lastDispatch                                              (object, nullable)
     - status:               `SUCCEEDED`                     (string, required)
     - finishedAt:           `2019-12-13T08:36:13.202Z`      (string, required)
@@ -4936,6 +4942,8 @@ a summary of your limits, and your current usage.
 - doNotRetry:               false                           (boolean, nullable)
 - requestUrl:               `http://example.com/`           (string, required)
 - payloadTemplate:          `{\n \"userId\": {{userId}}...` (string, nullable)
+- headersTemplate:          `{\n \"Authorization\": Bearer...`(string, nullable)
+- description:              `this is webhook description`   (string, nullable)
 - shouldInterpolateStrings: false                           (boolean, nullable)
 
 ## WebhookUpdate (object)
@@ -4948,6 +4956,8 @@ a summary of your limits, and your current usage.
 - doNotRetry:               false                           (boolean, nullable)
 - requestUrl:               `http://example.com/`           (string, nullable)
 - payloadTemplate:          `{\n \"userId\": {{userId}}...` (string, nullable)
+- headersTemplate:          `{\n \"Authorization\": Bearer...`(string, nullable)
+- description:              `this is webhook description`   (string, nullable)
 - shouldInterpolateStrings: false                           (boolean, nullable)
 
 ## WebhookDispatch

--- a/sources/platform/integrations/webhooks/actions.md
+++ b/sources/platform/integrations/webhooks/actions.md
@@ -96,6 +96,10 @@ It is important to notice that the following keys are hard-coded and will be re-
 | `X-Apify-Webhook-Dispatch-Id` | Apify id            |
 | `X-Apify-Request-Origin`   | Apify origin           |
 
+### Description
+
+Description is an optional string that you can add to the webhook. It serves for your information, it is not send with the http request when the webhook is dispatched.
+
 ### Available variables
 
 | Variable    | Type   | Description                                                                         |

--- a/sources/platform/integrations/webhooks/actions.md
+++ b/sources/platform/integrations/webhooks/actions.md
@@ -82,6 +82,20 @@ This example shows how you can use the payload template variables to send a cust
 
 You may have noticed that the `eventData` and `resource` properties contain redundant data. This is for backwards compatibility. Feel free to only use `eventData` or `resource` in your templates, depending on your use case.
 
+### Headers template
+
+Headers is a JSON-like string where you can add additional information to the default header of the webhook request. You can pass the variables in the same way as in [payload template](#payload-template) (including the use of string interpolation, available variables and nesting). The resulting headers need to be a valid json object.
+
+It is important to notice that the following keys are hard-coded and will be re-written always.
+
+| Variable                  | Value                   |
+|---------------------------|-------------------------|
+| `host`                    | request url             |
+| `Content-Type`            | application/json        |
+| `X-Apify-Webhook`         | Apify value             |
+| `X-Apify-Webhook-Dispatch-Id` | Apify id            |
+| `X-Apify-Request-Origin`   | Apify origin           |
+
 ### Available variables
 
 | Variable    | Type   | Description                                                                         |

--- a/sources/platform/integrations/webhooks/actions.md
+++ b/sources/platform/integrations/webhooks/actions.md
@@ -84,7 +84,7 @@ You may have noticed that the `eventData` and `resource` properties contain redu
 
 ### Headers template
 
-Headers is a JSON-like string where you can add additional information to the default header of the webhook request. You can pass the variables in the same way as in [payload template](#payload-template) (including the use of string interpolation, available variables and nesting). The resulting headers need to be a valid json object.
+Headers is a JSON-like string where you can add additional information to the default header of the webhook request. You can pass the variables in the same way as in [payload template](#payload-template) (including the use of string interpolation and available variables). The resulting headers need to be a valid json object and values can be strings only.
 
 It is important to notice that the following keys are hard-coded and will be re-written always.
 


### PR DESCRIPTION
Solving [#12285 from apify-core](https://app.zenhub.com/workspaces/platform-team-5f6454160d9f82000fa6733f/issues/gh/apify/apify-core/12285)-> Add documentation for the new webhook headers and description fields

WIP: the feature needs to be released first but comments are welcome in this stage already :-) 

<img width="747" alt="Screenshot 2023-09-27 at 16 50 36" src="https://github.com/apify/apify-docs/assets/56041262/ee79bdad-5607-41aa-8ad3-2590a5953629">


<img width="556" alt="Screenshot 2023-09-27 at 16 41 12" src="https://github.com/apify/apify-docs/assets/56041262/10678760-f12e-41a5-868b-296105feeccc">

<img width="716" alt="Screenshot 2023-09-27 at 16 39 30" src="https://github.com/apify/apify-docs/assets/56041262/84e70502-7062-4301-9811-aadfc788e6fb">
