### PR TITLE
fix(docs): actor status message api params

### DIFF
--- a/sources/platform/api_v2/api_v2_reference.apib
+++ b/sources/platform/api_v2/api_v2_reference.apib
@@ -2312,16 +2312,6 @@ you will typically do this in order to inform users of your actor about the acto
 
 The request body must contain `runId` and `statusMessage` properties. The `isStatusMessageTerminal` property is optional and it indicates if the status message is the very last one. In the absence of a status message, the platform will try to substitute sensible defaults.
 
-* `runId` is required string of run ID
-* `statusMessage` is required string of the status message
-* `isStatusMessageTerminal` is optional boolean indicating if this is the final status message of the actor
-
-```
-    "runId" :  `3KH8gEpp4d8uQSe8T`,
-    "statusMessage" : `Actor has finished`,
-    "isStatusMessageTerminal": true,
-```
-
 + Parameters
 
     + token: `soSkq9ekdmfOslopH` (string, required) - API authentication token.

--- a/sources/platform/api_v2/api_v2_reference.apib
+++ b/sources/platform/api_v2/api_v2_reference.apib
@@ -2326,6 +2326,10 @@ The request body must contain `runId` and `statusMessage` properties. The `isSta
 
     + token: `soSkq9ekdmfOslopH` (string, required) - API authentication token.
 
++ Request (application/json)
+
+    + Attributes(StatusMessageUpdate)
+
 + Response 200 (application/json)
 
     + Attributes
@@ -4638,6 +4642,11 @@ a summary of your limits, and your current usage.
     - DATA_TRANSFER_EXTERNAL_GBYTES?:   0.0002 (number, nullable)
     - PROXY_RESIDENTIAL_TRANSFER_GBYTES: 0.16  (number, nullable)
     - PROXY_SERPS:                      0.0006 (number, nullable)
+
+## StatusMessageUpdate (object)
+- runId:            `3KH8gEpp4d8uQSe8T`         (string, required)
+- statusMessage:    `Actor has finished`        (string, required)
+- isStatusMessageTerminal: true                 (boolean, optional)
 
 ## KVStore (object)
 - id:               `WkzbQMuFYuamGv3YF`        (string, required)

--- a/sources/platform/api_v2/api_v2_reference.apib
+++ b/sources/platform/api_v2/api_v2_reference.apib
@@ -2308,15 +2308,23 @@ For more information, see the [Actor docs](https://docs.apify.com/platform/actor
 ### Update status message [PUT]
 
 You can set a single status message on your run that will be displayed in the Apify Console UI. During an actor run,
-you will typically do this in order to inform users of your actor about the actor's progress. If the status message is the very last one,
-you will also need to specify `isStatusMessageTerminal=true`. In the absence of a status message, the platform will try to substitute sensible defaults.
+you will typically do this in order to inform users of your actor about the actor's progress.
+
+The request body must contain `runId` and `statusMessage` properties. The `isStatusMessageTerminal` property is optional and it indicates if the status message is the very last one. In the absence of a status message, the platform will try to substitute sensible defaults.
+
+* `runId` is required string of run ID
+* `statusMessage` is required string of the status message
+* `isStatusMessageTerminal` is optional boolean indicating if this is the final status message of the actor
+
+```
+    "runId" :  `3KH8gEpp4d8uQSe8T`,
+    "statusMessage" : `Actor has finished`,
+    "isStatusMessageTerminal": true,
+```
 
 + Parameters
 
-    + runId: `3KH8gEpp4d8uQSe8T` (string, required) - Run ID.
     + token: `soSkq9ekdmfOslopH` (string, required) - API authentication token.
-    + statusMessage: `Actor has finished` (string, required) - Status message
-    + isStatusMessageTerminal: true (boolean, optional) - Flag indicating if this is the final status message of the actor.
 
 + Response 200 (application/json)
 


### PR DESCRIPTION
Fixing bug reported on [slack](https://apifier.slack.com/archives/C0L33UM7Z/p1696326166649169): The docs at https://docs.apify.com/api/v2#/reference/actor-runs/update-status-message/update-status-message are wrong, the params (except token) can't be in URL, but must be in PUT body as json

Checked w matej that it is ok as well ✅ 

<img width="1496" alt="Screenshot 2023-10-03 at 14 30 54" src="https://github.com/apify/apify-docs/assets/56041262/046f7a82-876e-45c3-b8cf-567418491e65">


