### PR TITLE
chore: bump @apify/docs-search-modal version

### DIFF
--- a/apify-docs-theme/package.json
+++ b/apify-docs-theme/package.json
@@ -19,7 +19,7 @@
         "access": "public"
     },
     "dependencies": {
-        "@apify/docs-search-modal": "^1.0.23",
+        "@apify/docs-search-modal": "^1.0.24",
         "@docusaurus/theme-common": "^2.4.1",
         "@stackql/docusaurus-plugin-hubspot": "^1.1.0",
         "axios": "^1.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,7 +53,7 @@
             "version": "1.0.97",
             "license": "ISC",
             "dependencies": {
-                "@apify/docs-search-modal": "^1.0.23",
+                "@apify/docs-search-modal": "^1.0.24",
                 "@docusaurus/theme-common": "^2.4.1",
                 "@stackql/docusaurus-plugin-hubspot": "^1.1.0",
                 "axios": "^1.4.0",
@@ -286,9 +286,9 @@
             }
         },
         "node_modules/@apify/docs-search-modal": {
-            "version": "1.0.23",
-            "resolved": "https://registry.npmjs.org/@apify/docs-search-modal/-/docs-search-modal-1.0.23.tgz",
-            "integrity": "sha512-g+0qk++QUwp7se4NmvaZcocLyomeI65txLN0M9ck0DRZfWp10rbmM1xaTIf+s5/lEE6Hm1xCXCnYl+aRXo6m4A==",
+            "version": "1.0.24",
+            "resolved": "https://registry.npmjs.org/@apify/docs-search-modal/-/docs-search-modal-1.0.24.tgz",
+            "integrity": "sha512-cfyoY5MovRbIMAHQ9j3iIvRgQJJrvUGCPCqxjUOWqCEIE3SEeMIQrszLcA2tFqvumjPEZrexU41RA0k67vzflQ==",
             "dependencies": {
                 "@algolia/autocomplete-js": "^1.10.0",
                 "@algolia/autocomplete-theme-classic": "^1.10.0",


### PR DESCRIPTION
Adds different icon for fragment-level records and expands the breadcrumbs.

See the left pane (results list) in the before / after comparison:

| before | after |
|---|---|
| ![obrazek](https://github.com/apify/docs-search-modal/assets/61918049/ada4fcde-9b58-45c9-875b-7efe5e6ee70d) | ![obrazek](https://github.com/apify/docs-search-modal/assets/61918049/fd99a507-5d7b-4aab-9681-407d2fbfb0be) |