### PR TITLE
docs: integrate new og:image links

### DIFF
--- a/apify-docs-theme/src/config.js
+++ b/apify-docs-theme/src/config.js
@@ -145,7 +145,7 @@ const themeConfig = ({
         additionalLanguages: ['docker', 'log', 'php'],
     },
     // this needs to be absolute link otherwise it gets resolved wrongly in project docs
-    image: 'https://docs.apify.com/img/docs-og.png',
+    image: 'https://apify.com/api/og-image/docs-article',
     footer: {
         links: [
             {

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
         "": {
             "name": "apify-docs",
             "version": "2.0.0",
+            "hasInstallScript": true,
             "license": "Apache-2.0",
             "workspaces": [
                 "apify-docs-theme"

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
         "swizzle": "docusaurus swizzle",
         "deploy": "rimraf .docusaurus && docusaurus deploy",
         "docusaurus": "docusaurus",
+        "postinstall": "npx patch-package",
         "lint": "npm run lint:md && npm run lint:code",
         "lint:fix": "npm run lint:md:fix && npm run lint:code:fix",
         "lint:md": "markdownlint '**/*.md'",

--- a/patches/@docusaurus+mdx-loader+2.4.3.patch
+++ b/patches/@docusaurus+mdx-loader+2.4.3.patch
@@ -1,0 +1,16 @@
+diff --git a/node_modules/@docusaurus/mdx-loader/lib/loader.js b/node_modules/@docusaurus/mdx-loader/lib/loader.js
+index 5f9dce1..fdc1976 100644
+--- a/node_modules/@docusaurus/mdx-loader/lib/loader.js
++++ b/node_modules/@docusaurus/mdx-loader/lib/loader.js
+@@ -103,6 +103,11 @@ async function mdxLoader(fileString) {
+     const filePath = this.resourcePath;
+     const reqOptions = this.getOptions();
+     const { frontMatter, content: contentWithTitle } = (0, utils_1.parseFrontMatter)(fileString);
++
++    const ogImageURL = new URL('https://apify.com/api/og-image/docs-article');
++    ogImageURL.searchParams.set('title', frontMatter.title);
++    frontMatter.image ??= ogImageURL.toString();
++
+     const { content, contentTitle } = (0, utils_1.parseMarkdownContentTitle)(contentWithTitle, {
+         removeContentTitle: reqOptions.removeContentTitle,
+     });


### PR DESCRIPTION
Long time no `patch-package` - unfortunately, I didn't come up with a better solution (that wouldn't adding a frontmatter tag to every markdown file in the repo).

Related to apify/apify-web#3159