### PR TITLE
fix: use `--legacy-peer-deps` in the CI

### DIFF
--- a/.github/workflows/publish-theme.yaml
+++ b/.github/workflows/publish-theme.yaml
@@ -54,7 +54,7 @@ jobs:
             -   name: Bump the theme version
                 run: |
                     cd $GITHUB_WORKSPACE/apify-docs-theme
-                    npm version patch
+                    npm version patch --legacy-peer-deps
 
             -   name: Deploy theme to npm
                 run: |


### PR DESCRIPTION
Installing the `@apify-packages/ui-components` package only works with the `--legacy-peer-deps` flag (and it broke our CI).