### PR TITLE
fix: try to fix the theme publishing CI

### DIFF
--- a/.github/workflows/publish-theme.yaml
+++ b/.github/workflows/publish-theme.yaml
@@ -42,6 +42,11 @@ jobs:
                 uses: actions/setup-node@v4
                 with:
                     node-version: 18
+                    cache: 'npm'
+                    cache-dependency-path: 'package-lock.json'
+                    registry-url: 'https://npm.pkg.github.com/'
+                    scope: '@apify-packages'
+    
 
             -   name: Setup git user and npm
                 run: |
@@ -55,6 +60,8 @@ jobs:
                 run: |
                     cd $GITHUB_WORKSPACE/apify-docs-theme
                     npm version patch --legacy-peer-deps
+                env:
+                    NODE_AUTH_TOKEN: ${{ secrets.APIFY_SERVICE_ACCOUNT_NPM_TOKEN }}
 
             -   name: Deploy theme to npm
                 run: |


### PR DESCRIPTION
The theme publishing CI is failing with missing NPM token ([see here](https://github.com/apify/apify-docs/actions/runs/7409319676/job/20159355378)). 

This PR replicates the steps from all the other CI pipelines in the theme publishing one.