### PR TITLE
fix: propagate the CSS fixes in the theme

### DIFF
--- a/apify-docs-theme/package.json
+++ b/apify-docs-theme/package.json
@@ -25,6 +25,7 @@
         "axios": "^1.4.0",
         "babel-loader": "^9.1.3",
         "docusaurus-gtm-plugin": "^0.0.2",
+        "postcss-preset-env": "^9.3.0",
         "prism-react-renderer": "^2.0.6"
     },
     "peerDependencies": {

--- a/apify-docs-theme/src/theme.js
+++ b/apify-docs-theme/src/theme.js
@@ -1,3 +1,4 @@
+const postcssPreset = require('postcss-preset-env');
 const path = require('path');
 const fs = require('fs');
 const axios = require('axios');
@@ -124,6 +125,10 @@ This either means that your Docusaurus setup is misconfigured, or that your GitH
                     ],
                 },
             };
+        },
+        configurePostCss(o) {
+            o.plugins.push(postcssPreset); // allow newest CSS syntax
+            return o;
         },
     };
 }

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -1,4 +1,3 @@
-const postcssPreset = require('postcss-preset-env');
 const { config } = require('./apify-docs-theme');
 const { externalLinkProcessor } = require('./tools/utils/externalLink');
 const { collectSlugs } = require('./tools/utils/collectSlugs');
@@ -92,13 +91,6 @@ module.exports = {
                 sidebarPath: require.resolve('./sources/academy/sidebars.js'),
             },
         ],
-        () => ({
-            name: 'new-css-syntax',
-            configurePostCss(options) {
-                options.plugins.push(postcssPreset); // allow newest CSS syntax
-                return options;
-            },
-        }),
         // TODO this should be somehow computed from all the external sources
         // [
         //     '@docusaurus/plugin-client-redirects',

--- a/package-lock.json
+++ b/package-lock.json
@@ -65,6 +65,7 @@
                 "axios": "^1.4.0",
                 "babel-loader": "^9.1.3",
                 "docusaurus-gtm-plugin": "^0.0.2",
+                "postcss-preset-env": "^9.3.0",
                 "prism-react-renderer": "^2.0.6"
             },
             "peerDependencies": {


### PR DESCRIPTION
The postcss preset needs to be in the `apify-docs-theme` to fix the styling issues in all of the subprojects.