### PR TITLE
docs: fix_commands_in_docs

### DIFF
--- a/sources/platform/actors/development/quick_start/start_web_ide.md
+++ b/sources/platform/actors/development/quick_start/start_web_ide.md
@@ -81,13 +81,13 @@ apify login
 Then, you can pull your Actor using the following command:
 
 ```bash
-apify apify pull [actor_name]
+apify pull [actor_name]
 ```
 
 or with specified version:
 
 ```bash
-apify apify pull [actor_name] --version [version_number]
+apify pull [actor_name] --version [version_number]
 ```
 
 ## 6. Iterate


### PR DESCRIPTION
![Screenshot 2024-01-14 at 1 18 16 AM](https://github.com/apify/apify-docs/assets/53312820/019b5946-7b9f-4fd7-9075-1a52c16b8f63)
It should be only one `apify` in each of them