### PR TITLE
docs(api): update reference for log endpoints, including the new ones for build

### DIFF
--- a/sources/platform/api_v2/api_v2_reference.apib
+++ b/sources/platform/api_v2/api_v2_reference.apib
@@ -902,25 +902,6 @@ Only builds that are starting or running are aborted. For builds with status `FI
     + Attributes
         - data (BuildAborted, required)
 
-## Build logs [/v2/acts/{actorId}/builds/{buildId}/log{?token,stream,download}]
-
-Check out [Logs](#reference/logs) for full reference.
-
-+ Parameters
-
-    + buildId: `HG7ML7M8z78YcAPEB` (string, required) - ID of the actor build.
-    + token: `soSkq9ekdmfOslopH` (string, required) - API authentication token.
-    + stream: false (boolean, required) - If `true` or `1` then the logs will be streamed as long as the run or build is running.
-    + download: false (boolean, required) - If `true` or `1` then the web browser will download the log file rather than open it in a tab.
-
-### Get log [GET]
-
-+ Response 200 (text/plain)
-
-2017-07-14T06:00:49.733Z Application started.
-2017-07-14T06:00:49.741Z Input: { test: 123 }
-2017-07-14T06:00:49.752Z Some useful debug information follows.
-
 ## Run collection [/v2/acts/{actorId}/runs{?token,offset,limit,desc,waitForFinish,timeout,memory,build,webhooks,status}]
 
 + Parameters

--- a/sources/platform/api_v2/api_v2_reference.apib
+++ b/sources/platform/api_v2/api_v2_reference.apib
@@ -902,6 +902,25 @@ Only builds that are starting or running are aborted. For builds with status `FI
     + Attributes
         - data (BuildAborted, required)
 
+## Build logs [/v2/acts/{actorId}/builds/{buildId}/log{?token,stream,download}]
+
+Check out [Logs](#reference/logs) for full reference.
+
++ Parameters
+
+    + buildId: `HG7ML7M8z78YcAPEB` (string, required) - ID of the actor build.
+    + token: `soSkq9ekdmfOslopH` (string, required) - API authentication token.
+    + stream: false (boolean, required) - If `true` or `1` then the logs will be streamed as long as the run or build is running.
+    + download: false (boolean, required) - If `true` or `1` then the web browser will download the log file rather than open it in a tab.
+
+### Get log [GET]
+
++ Response 200 (text/plain)
+
+2017-07-14T06:00:49.733Z Application started.
+2017-07-14T06:00:49.741Z Input: { test: 123 }
+2017-07-14T06:00:49.752Z Some useful debug information follows.
+
 ## Run collection [/v2/acts/{actorId}/runs{?token,offset,limit,desc,waitForFinish,timeout,memory,build,webhooks,status}]
 
 + Parameters
@@ -2443,6 +2462,25 @@ Only builds that are starting or running are aborted. For builds with status `FI
     + Attributes
         - data (BuildAborted, required)
 
+## Build logs [/v2/actor-builds/{buildId}/log{?token,stream,download}]
+
+Check out [Logs](#reference/logs) for full reference.
+
++ Parameters
+
+    + buildId: `HG7ML7M8z78YcAPEB` (string, required) - ID of the actor build.
+    + token: `soSkq9ekdmfOslopH` (string, required) - API authentication token.
+    + stream: false (boolean, required) - If `true` or `1` then the logs will be streamed as long as the run or build is running.
+    + download: false (boolean, required) - If `true` or `1` then the web browser will download the log file rather than open it in a tab.
+
+### Get log [GET]
+
++ Response 200 (text/plain)
+
+2017-07-14T06:00:49.733Z Application started.
+2017-07-14T06:00:49.741Z Input: { test: 123 }
+2017-07-14T06:00:49.752Z Some useful debug information follows.
+
 # Group Key-value stores
 
 This section describes API endpoints to manage Key-value stores.
@@ -3885,20 +3923,11 @@ are authenticated using a hard-to-guess ID of the actor build or run.
 
 ### Get log [GET]
 
-Responds with HTTP status 302 to redirect to an URL containing the requested log. The log has a content type `text/plain` and it is encoded as `gzip` returned with
-appropriate HTTP headers. The log has following format:
++ Response 200 (text/plain)
 
-```
 2017-07-14T06:00:49.733Z Application started.
 2017-07-14T06:00:49.741Z Input: { test: 123 }
 2017-07-14T06:00:49.752Z Some useful debug information follows.
-```
-
-+ Response 302 (application/json)
-
-    + Headers
-
-            Location: https://apifier-circular-logs-prod.s3.amazonaws.com/yiawTzreqPeFSKySN.log.gz?AWSAccessKeyId=AKIABOIQ&Expires=1500368148&Signature=B7wgpkNKiBin
 
 # Group Users
 

--- a/sources/platform/api_v2/api_v2_reference.apib
+++ b/sources/platform/api_v2/api_v2_reference.apib
@@ -2167,7 +2167,7 @@ Additionally, each of the above API endpoints supports all sub-endpoints
 of the original one:
 
 #### Log
-* `/v2/actor-runs/{runId}/logs` [Log](#reference/log)
+* `/v2/actor-runs/{runId}/log` [Log](#reference/logs)
 
 #### Key-value store
 

--- a/sources/platform/api_v2/api_v2_reference.apib
+++ b/sources/platform/api_v2/api_v2_reference.apib
@@ -2458,9 +2458,11 @@ Check out [Logs](#reference/logs) for full reference.
 
 + Response 200 (text/plain)
 
-2017-07-14T06:00:49.733Z Application started.
-2017-07-14T06:00:49.741Z Input: { test: 123 }
-2017-07-14T06:00:49.752Z Some useful debug information follows.
+    ```
+    2017-07-14T06:00:49.733Z Application started.
+    2017-07-14T06:00:49.741Z Input: { test: 123 }
+    2017-07-14T06:00:49.752Z Some useful debug information follows.
+    ```
 
 # Group Key-value stores
 
@@ -3906,9 +3908,11 @@ are authenticated using a hard-to-guess ID of the actor build or run.
 
 + Response 200 (text/plain)
 
-2017-07-14T06:00:49.733Z Application started.
-2017-07-14T06:00:49.741Z Input: { test: 123 }
-2017-07-14T06:00:49.752Z Some useful debug information follows.
+    ```
+    2017-07-14T06:00:49.733Z Application started.
+    2017-07-14T06:00:49.741Z Input: { test: 123 }
+    2017-07-14T06:00:49.752Z Some useful debug information follows.
+    ```
 
 # Group Users
 

--- a/sources/platform/api_v2/api_v2_reference.apib
+++ b/sources/platform/api_v2/api_v2_reference.apib
@@ -2443,7 +2443,7 @@ Only builds that are starting or running are aborted. For builds with status `FI
     + Attributes
         - data (BuildAborted, required)
 
-## Build logs [/v2/actor-builds/{buildId}/log{?token,stream,download}]
+## Build log [/v2/actor-builds/{buildId}/log{?token,stream,download}]
 
 Check out [Logs](#reference/logs) for full reference.
 


### PR DESCRIPTION
There are two new endpoints, `/actor-builds/<BUILD_ID>/log` and `/acts/<ACTOR_ID>/builds/<BUILD_ID>/log`. This PR adds the corresponding reference.

The endpoints behave the same (modulo authentication) as `/logs/<BUILD_OR_RUN_ID` but due to the limitations of API Blueprint, I couldn't find an easy way to share the reference. Using the same approach as for `/actor-runs/{RUN_ID}/log`, basically just an inline link, also didn't work, as without proper request/response definition, the headlines would not render at all 🤷 Hence a bit of copy-paste seemed like the best approach.

This PR also:

* Removes some outdated information about how the logs endpoint work (they return a standard 200, no redirects)
* Fixes the reference for `/actor-runs/{RUN_ID}/log` 

