### PR TITLE
fix: improve contrast on inline code blocks and footer links

### DIFF
--- a/apify-docs-theme/src/theme/custom.css
+++ b/apify-docs-theme/src/theme/custom.css
@@ -18,6 +18,10 @@ html[data-theme='dark'] {
     --ifm-navbar-height: 68px;
     --ifm-line-height-base: 1.65;
 
+    --ifm-code-background: var(--ifm-pre-background) !important;
+    --ifm-footer-title-color: #f2f3fb;
+    --ifm-footer-link-color: #8d92af;
+
     --docusaurus-highlighted-code-line-bg: rgba(255, 255, 255, 0.1);
     --docsearch-text-color: #8d92af;
 
@@ -136,7 +140,6 @@ html[data-theme='dark'] {
     --ifm-heading-margin-top: var(--ifm-heading-margin-bottom);
     --ifm-hero-background-color: transparent;
 
-    --ifm-code-background: var(--ifm-pre-background) !important;
     --ifm-code-padding-horizontal: 6.4px;
     --ifm-code-padding-vertical: 3.2px;
 
@@ -155,9 +158,11 @@ html[data-theme='dark'] {
     --ifm-link-hover-decoration: none;
 
     --ifm-footer-background-color: #272c3d;
-    --ifm-footer-title-color: #f2f3fb;
-    --ifm-footer-link-color: #8d92af;
+    --ifm-footer-title-color: #60626e;
+    --ifm-footer-link-color: #6b6e80;
     --max-layout-width: 1440px;
+
+    --ifm-code-background: #f6f8fa;
 
     --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.1);
 
@@ -572,6 +577,10 @@ header.hero div[class^=heroButtons] {
     border-radius: var(--ifm-alert-border-radius);
     box-shadow: var(--ifm-alert-shadow);
     padding: var(--ifm-alert-padding-vertical) var(--ifm-alert-padding-horizontal);
+}
+
+html[data-theme='dark'] .markdown code {
+    border-color: rgba(255, 255, 255, 0.1);
 }
 
 article .card h2 {


### PR DESCRIPTION
<img width="787" alt="image" src="https://github.com/apify/apify-docs/assets/615580/fc684bd2-39ab-4ab6-bae2-73702ab00d3d">


<img width="776" alt="image" src="https://github.com/apify/apify-docs/assets/615580/f3d93c9f-17ae-4ffe-a131-a7a7d0c12772">


<img width="469" alt="image" src="https://github.com/apify/apify-docs/assets/615580/7ec432ca-22c3-411a-853d-409581cfbb3b">


Closes #769