### PR TITLE
feat: Setup Smartlook [internal]

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -13,3 +13,4 @@ jobs:
         - run: gh workflow run deploy.yaml --repo apify/apify-docs-private
           env:
             GITHUB_TOKEN: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}
+            SMARTLOOK_PROJECT_KEY: ${{ secrets.SMARTLOOK_PROJECT_KEY }}

--- a/.github/workflows/lychee.yml
+++ b/.github/workflows/lychee.yml
@@ -25,6 +25,7 @@ jobs:
         env:
             APIFY_SIGNING_TOKEN: ${{ secrets.APIFY_SIGNING_TOKEN }}
             NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+            SMARTLOOK_PROJECT_KEY: ${{ secrets.SMARTLOOK_PROJECT_KEY }}
 
       - uses: lycheeverse/lychee-action@v1.9.3
         env:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -27,6 +27,7 @@ jobs:
                 run: npm ci --force
                 env:
                     NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+                    SMARTLOOK_PROJECT_KEY: ${{ secrets.SMARTLOOK_PROJECT_KEY }}
 
             -   run: npm run build
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -27,9 +27,10 @@ jobs:
                 run: npm ci --force
                 env:
                     NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-                    SMARTLOOK_PROJECT_KEY: ${{ secrets.SMARTLOOK_PROJECT_KEY }}
 
             -   run: npm run build
+                env:
+                    SMARTLOOK_PROJECT_KEY: ${{ secrets.SMARTLOOK_PROJECT_KEY }}
 
     lint_content:
         name: Lint markdown content

--- a/apify-docs-theme/src/config.js
+++ b/apify-docs-theme/src/config.js
@@ -256,7 +256,7 @@ const themeConfig = ({
 });
 
 const plugins = [
-    'docusaurus/plugin-smartlook',
+    'docusaurus-plugin-smartlook',
     [
         'docusaurus-gtm-plugin',
         {

--- a/apify-docs-theme/src/config.js
+++ b/apify-docs-theme/src/config.js
@@ -13,6 +13,7 @@ const themeConfig = ({
             hideable: true,
         },
     },
+    smartlook: { projectKey: process.env.SMARTLOOK_PROJECT_KEY },
     navbar: {
         title: 'Apify Docs',
         logo: {
@@ -255,6 +256,7 @@ const themeConfig = ({
 });
 
 const plugins = [
+    'docusaurus/plugin-smartlook',
     [
         'docusaurus-gtm-plugin',
         {

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
                 "@docusaurus/theme-mermaid": "^2.4.1",
                 "@giscus/react": "^2.2.8",
                 "clsx": "^2.0.0",
+                "docusaurus-plugin-smartlook": "^1.0.2",
                 "form-data": "^4.0.0",
                 "postcss-preset-env": "^9.3.0",
                 "prop-types": "^15.8.1",
@@ -58,7 +59,7 @@
         },
         "apify-docs-theme": {
             "name": "@apify/docs-theme",
-            "version": "1.0.103",
+            "version": "1.0.108",
             "license": "ISC",
             "dependencies": {
                 "@apify/docs-search-modal": "^1.0.25",
@@ -8956,6 +8957,12 @@
             "version": "0.0.2",
             "resolved": "https://registry.npmjs.org/docusaurus-gtm-plugin/-/docusaurus-gtm-plugin-0.0.2.tgz",
             "integrity": "sha512-Xx/df0Ppd5SultlzUj9qlQk2lX9mNVfTb41juyBUPZ1Nc/5dNx+uN0VuLyF4JEObkDRrUY1EFo9fEUDo8I6QOQ=="
+        },
+        "node_modules/docusaurus-plugin-smartlook": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/docusaurus-plugin-smartlook/-/docusaurus-plugin-smartlook-1.0.2.tgz",
+            "integrity": "sha512-HKOavP16LMWsdZ6xpEqGecIweButfZ3hteCy6FZb1+s8c5b3hFsn9n1ohChAC1B1KETQZG5OhmQ270C0ak06Rg==",
+            "deprecated": "docusaurus-plugin-smartlook is now available at @stackql/docusaurus-plugin-smartlook"
         },
         "node_modules/dom-converter": {
             "version": "0.2.0",

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
         "@docusaurus/theme-mermaid": "^2.4.1",
         "@giscus/react": "^2.2.8",
         "clsx": "^2.0.0",
+        "docusaurus-plugin-smartlook": "^1.0.2",
         "form-data": "^4.0.0",
         "postcss-preset-env": "^9.3.0",
         "prop-types": "^15.8.1",


### PR DESCRIPTION
Closes apify/apify-web#3489

Setup Smartlook for Docusaurus. Smartlook token is imported from Doppler.

Not sure abou lychee check though cc @TC-MO 