### PR TITLE
fix(academy): remove extraneous semicolon

### DIFF
--- a/sources/academy/webscraping/puppeteer_playwright/executing_scripts/index.md
+++ b/sources/academy/webscraping/puppeteer_playwright/executing_scripts/index.md
@@ -16,7 +16,7 @@ import TabItem from '@theme/TabItem';
 
 An important concept to understand when dealing with headless browsers is the **context** in which your code is being run. For example, if you try to use the native `fs` Node.js module (used in the previous lesson) while running code in the context of the browser, errors will be thrown saying that it is undefined. Similarly, if you are trying to use `document.querySelector()` or other browser-specific functions in the server-side Node.js context, errors will also be thrown.
 
-![Diagram explaining the two different contexts your code can be run in](../images/context-diagram.jpg);
+![Diagram explaining the two different contexts your code can be run in](../images/context-diagram.jpg)
 
 Here is an example of a common mistake made by beginners to Puppeteer/Playwright:
 


### PR DESCRIPTION
I found a lonely semicolon. Let's find him a better place to live, perhaps in some JavaScript code, among his peers.

![Screenshot 2024-03-27 at 10-23-38 III - Executing scripts Academy Apify Documentation](https://github.com/apify/apify-docs/assets/283441/e633b541-04fb-4d8e-9e63-bdb8b0d8958b)
