### PR TITLE
feat(request-queue): Extend rq documentation with rqv2 features

### DIFF
--- a/sources/platform/storage/request_queue.md
+++ b/sources/platform/storage/request_queue.md
@@ -276,33 +276,34 @@ For further details and a breakdown of each storage API endpoint, refer to the [
 
 ## Features {#features}
 
-Request queues in Apify offer a set of powerful features designed to support complex web crawling and data scraping operations.
-These features enhance the flexibility, efficiency, and scalability of your projects. All these feature are implemented
-in the Apify tooling like crawlee and Apify SDKs and user can use them without any additional configuration.
+Request queues in Apify power complex web crawling and data scraping operations with a set of robust features.
+These features boost your projects' flexibility, efficiency, and scalability. The Apify tooling, including Crawlee and Apify SDKs,
+incorporates all these features, enabling users to leverage them effortlessly without extra configuration.
+
 
 ### Persistence and retention {#persistence-and-retention}
 
-Request queues are designed with persistence in mind. This means that your requests are retained indefinitely in named request queue and for data retention in unnamed request queues.
-This feature allows to use request queue for incremental crawling, where you can add new URLs to the queue and continue where you left off in the next run.
-Imagine you need to scrape an e-commerce website with thousands of products. Incremental scroll allows you to scrape only new products added since the last run.
+Request queues prioritize persistence, ensuring indefinite retention of your requests in named request queues and for data retention in unnamed request queues.
+This capability facilitates incremental crawling, where you can append new URLs to the queue and resume from where you stopped in the subsequent run.
+Consider the scenario of scraping an e-commerce website with thousands of products. Incremental scrolling allows you to scrape only the products
+added since the last run.
 
 TBD Incremental scrape example
 
 ### Batch operations {#batch-operations}
 
-To optimize performance and reduce API calls and network latency of adding or removing individual requests, request queues support batch operations.
-This feature allows you to enqueue or retrieve multiple requests in a single operation, significantly improving efficiency,
-especially when dealing with a large volume of URLs. Batch operations streamline process flows, reduce API calls, and minimize latency,
-making your web crawling processes faster and more reliable.
+Request queues enhance performance and cut down on API calls and network latency for adding or removing individual requests by supporting batch operations.
+This efficiency booster enables you to enqueue or retrieve requests in bulk, enhancing efficiency when handling numerous URLs.
+Batch operations simplify process flows, decrease API calls, and reduce latency, thus accelerating your web crawling processes and enhancing reliability.
+
 
 TBD JS/python example/API
 
 ### Distributivity {#distributivity}
 
-This design allows for the concurrent processing of requests by multiple Actor runs or server instances,
-making it an ideal solution for large-scale web crawling tasks. Distributivity ensures that scraping jobs can scale horizontally.
-Under the hood, the request queue offers locking mechanisms to prevent multiple runs from processing the same request simultaneously.
-This feature is by default build in the crawlee and users can use it without little additional configuration, see crawlee documentation for more details.
+Our design facilitates the simultaneous processing of requests by multiple Actor runs or server instances, perfectly suiting large-scale web crawling projects.
+Distributivity ensures your scraping tasks can expand horizontally. The request queue system includes locking mechanisms to avoid concurrent
+processing of the same request, a feature seamlessly integrated into Crawlee, requiring minimal extra setup. For more details, refer to the Crawlee documentation.
 
 TBD Example of locking mechanism
 

--- a/sources/platform/storage/request_queue.md
+++ b/sources/platform/storage/request_queue.md
@@ -274,6 +274,38 @@ Example payload:
 
 For further details and a breakdown of each storage API endpoint, refer to the [API documentation](/api/v2#/reference/key-value-stores).
 
+## Features {#features}
+
+Request queues in Apify offer a set of powerful features designed to support complex web crawling and data scraping operations.
+These features enhance the flexibility, efficiency, and scalability of your projects. All these feature are implemented
+in the Apify tooling like crawlee and Apify SDKs and user can use them without any additional configuration.
+
+### Persistence and retention {#persistence-and-retention}
+
+Request queues are designed with persistence in mind. This means that your requests are retained indefinitely in named request queue and for data retention in unnamed request queues.
+This feature allows to use request queue for incremental crawling, where you can add new URLs to the queue and continue where you left off in the next run.
+Imagine you need to scrape an e-commerce website with thousands of products. Incremental scroll allows you to scrape only new products added since the last run.
+
+TBD Incremental scrape example
+
+### Batch operations {#batch-operations}
+
+To optimize performance and reduce API calls and network latency of adding or removing individual requests, request queues support batch operations.
+This feature allows you to enqueue or retrieve multiple requests in a single operation, significantly improving efficiency,
+especially when dealing with a large volume of URLs. Batch operations streamline process flows, reduce API calls, and minimize latency,
+making your web crawling processes faster and more reliable.
+
+TBD JS/python example/API
+
+### Distributivity {#distributivity}
+
+This design allows for the concurrent processing of requests by multiple Actor runs or server instances,
+making it an ideal solution for large-scale web crawling tasks. Distributivity ensures that scraping jobs can scale horizontally.
+Under the hood, the request queue offers locking mechanisms to prevent multiple runs from processing the same request simultaneously.
+This feature is by default build in the crawlee and users can use it without little additional configuration, see crawlee documentation for more details.
+
+TBD Example of locking mechanism
+
 ## Sharing {#sharing}
 
 You can grant [access rights](../collaboration/index.md) to your request queue through the **Share** button under the **Actions** menu. For more details check the [full list of permissions](../collaboration/list_of_permissions.md).

--- a/sources/platform/storage/request_queue.md
+++ b/sources/platform/storage/request_queue.md
@@ -276,10 +276,10 @@ For further details and a breakdown of each storage API endpoint, refer to the [
 
 ## Features {#features}
 
-Request queues in Apify power complex web crawling and data scraping operations with a set of robust features.
-These features boost your projects' flexibility, efficiency, and scalability. The Apify tooling, including Crawlee and Apify SDKs,
-incorporates all these features, enabling users to leverage them effortlessly without extra configuration.
+Request queue is a storage type built with scraping in mind, enabling developers to write scraping logic efficiently and scalable.
+The Apify tooling, including [Crawlee](https://crawlee.dev/) and [Apify SDKs](https://docs.apify.com/sdk/js/), incorporates all these features, enabling users to leverage them effortlessly without extra configuration.
 
+In the following section, we will discuss each main features in depth.
 
 ### Persistence and retention {#persistence-and-retention}
 
@@ -395,9 +395,11 @@ request_queue_client.batch_delete_requests([
 
 ### Distributivity {#distributivity}
 
-Our design facilitates the simultaneous processing of requests by multiple Actor runs or server instances, perfectly suiting large-scale web crawling projects.
+Our design facilitates the simultaneous processing of requests by multiple clients (for example,  Actor runs) or server instances, perfectly suiting large-scale web crawling projects.
 Distributivity ensures your scraping tasks can expand horizontally. The request queue includes locking mechanisms to avoid concurrent
-processing of the same request, a feature seamlessly integrated into Crawlee, requiring minimal extra setup. For more details, refer to the Crawlee documentation.
+processing of the same request, a feature seamlessly integrated into Crawlee, requiring minimal extra setup. The lock mechanism ensures that only one client can process a request at a time. The base scenario is that
+the lock is created for the same amount of time as the timeout for processing requests in the crawler (requestHandlerTimeoutSecs), and if the request timeouts, the lock is prolonged or expired.
+For more details, refer to the Crawlee documentation.
 
 In the following example, we demonstrate how we can use locking mechanisms to avoid concurrent processing of the same request.
 

--- a/sources/platform/storage/request_queue.md
+++ b/sources/platform/storage/request_queue.md
@@ -277,11 +277,11 @@ For further details and a breakdown of each storage API endpoint, refer to the [
 ## Features {#features}
 
 Request queue is a storage type built with scraping in mind, enabling developers to write scraping logic efficiently and scalable.
-The Apify tooling, including [Crawlee](https://crawlee.dev/) and [Apify SDKs](https://docs.apify.com/sdk/js/), incorporates all these features, enabling users to leverage them effortlessly without extra configuration.
+The Apify tooling, including [Crawlee](https://crawlee.dev/), [Apify JS SDK](https://docs.apify.com/sdk/js/), and [Apify Python SDK](https://docs.apify.com/sdk/python/) , incorporates all these features, enabling users to leverage them effortlessly without extra configuration.
 
 In the following section, we will discuss each main features in depth.
 
-### Persistence and retention {#persistence-and-retention}
+### Persistence and retention
 
 Request queues prioritize persistence, ensuring indefinite retention of your requests in named request queues and for data retention in unnamed request queues.
 This capability facilitates incremental crawling, where you can append new URLs to the queue and resume from where you stopped in the subsequent run.

--- a/sources/platform/storage/request_queue.md
+++ b/sources/platform/storage/request_queue.md
@@ -306,12 +306,12 @@ await Actor.init();
 // Structure of input is defined in input_schema.json
 const {
     startUrls = ['https://docs.apify.com/'],
-    persistRquestQueueName = 'persist-request-queue',
+    persistRequestQueueName = 'persist-request-queue',
 } = await Actor.getInput<Input>() ?? {} as Input;
 
 // Open or create request queue for incremental scrape.
 // By opening same request queue, the crawler will continue where it left off and skips already visited URLs.
-const requestQueue = await Actor.openRequestQueue(persistDatasetName);
+const requestQueue = await Actor.openRequestQueue(persistRequestQueueName);
 
 const proxyConfiguration = await Actor.createProxyConfiguration();
 

--- a/sources/platform/storage/request_queue.md
+++ b/sources/platform/storage/request_queue.md
@@ -298,7 +298,7 @@ import { CheerioCrawler, Dataset } from 'crawlee';
 
 interface Input {
     startUrls: string[];
-    persistDatasetName: string;
+    persistRquestQueueName: string;
 }
 
 await Actor.init();
@@ -306,7 +306,7 @@ await Actor.init();
 // Structure of input is defined in input_schema.json
 const {
     startUrls = ['https://docs.apify.com/'],
-    persistDatasetName = 'persist-dataset',
+    persistRquestQueueName = 'persist-request-queue',
 } = await Actor.getInput<Input>() ?? {} as Input;
 
 // Open or create request queue for incremental scrape.
@@ -339,6 +339,7 @@ await Actor.exit();
 ### Batch operations {#batch-operations}
 
 Request queues support batch operations on requests to enqueue or retrieve multiple requests in bulk, to cut down on network latency and enable easier parallel processing of requests.
+You can find the batch operations in the [Apify API](https://docs.apify.com/api/v2#/reference/request-queues/batch-request-operations), as well in the Apify API client for [JavaScript](https://docs.apify.com/api/client/js/reference/class/RequestQueueClient#batchAddRequests) and [Python](https://docs.apify.com/api/client/python/reference/class/RequestQueueClient#batch_add_requests).
 
 <Tabs groupId="main">
 <TabItem value="JavaScript" label="JavaScript">
@@ -393,9 +394,11 @@ request_queue_client.batch_delete_requests([
 
 ### Distributivity {#distributivity}
 
-Request queue includes a locking mechanism to avoid concurrent processing of one request by multiple clients (for example Actor runs). You can lock a request so that no other clients receive it when they fetch the queue head, with an expiration period on the lock so that requests which fail processing are eventually unlocked and retried.
+Request queue includes a locking mechanism to avoid concurrent processing of one request by multiple clients (for example Actor runs).
+You can lock a request so that no other clients receive it when they fetch the queue head, with an expiration period on the lock so that requests which fail processing are eventually unlocked and retried.
 
-This feature is seamlessly integrated into Crawlee, requiring minimal extra setup. By default, requests are locked for the same duration as the timeout for processing requests in the crawler (`requestHandlerTimeoutSecs`) (TODO link). If the Actor processing the request fails, the lock expires, and the request is processed again eventually. For more details, refer to the Crawlee documentation (TODO link).
+This feature is seamlessly integrated into Crawlee, requiring minimal extra setup. By default, requests are locked for the same duration as the timeout for processing requests in the crawler ([`requestHandlerTimeoutSecs`](https://crawlee.dev/api/next/basic-crawler/interface/BasicCrawlerOptions#requestHandlerTimeoutSecs)).
+If the Actor processing the request fails, the lock expires, and the request is processed again eventually. For more details, refer to the [Crawlee documentation](https://crawlee.dev/docs/next/experiments/experiments-request-locking).
 
 In the following example, we demonstrate how we can use locking mechanisms to avoid concurrent processing of the same request.
 

--- a/sources/platform/storage/request_queue.md
+++ b/sources/platform/storage/request_queue.md
@@ -276,20 +276,20 @@ For further details and a breakdown of each storage API endpoint, refer to the [
 
 ## Features {#features}
 
-Request queue is a storage type built with scraping in mind, enabling developers to write scraping logic efficiently and scalable.
-The Apify tooling, including [Crawlee](https://crawlee.dev/), [Apify JS SDK](https://docs.apify.com/sdk/js/), and [Apify Python SDK](https://docs.apify.com/sdk/python/) , incorporates all these features, enabling users to leverage them effortlessly without extra configuration.
+Request queue is a storage type built with scraping in mind, enabling developers to write scraping logic efficiently and scalably.
+The Apify tooling, including [Crawlee](https://crawlee.dev/), [Apify SDK for JavaScript](https://docs.apify.com/sdk/js/), and [Apify SDK for Python](https://docs.apify.com/sdk/python/), incorporates all these features, enabling users to leverage them effortlessly without extra configuration.
 
-In the following section, we will discuss each main features in depth.
+In the following section, we will discuss each of the main features in depth.
 
 ### Persistence and retention
 
-Request queues prioritize persistence, ensuring indefinite retention of your requests in named request queues and for data retention in unnamed request queues.
-This capability facilitates incremental crawling, where you can append new URLs to the queue and resume from where you stopped in the subsequent run.
+Request queues prioritize persistence, ensuring indefinite retention of your requests in named request queues, and for the data retention period in your subscription in unnamed request queues.
+This capability facilitates incremental crawling, where you can append new URLs to the queue and resume from where you stopped in subsequent Actor runs.
 Consider the scenario of scraping an e-commerce website with thousands of products. Incremental scraping allows you to scrape only the products
-added since the last run.
+added since the last product discovery.
 
-In the following code example, we demonstrate how to use the Apify SDK and Crawlee to create an incremental crawler that saves the title of each new found page on Apify documentation to a dataset.
-By running this Actor multiple times, you can incrementally crawl the website and save only the new pages as the same request queue ensures that only not yet visited URLs are processed.
+In the following code example, we demonstrate how to use the Apify SDK and Crawlee to create an incremental crawler that saves the title of each new found page in Apify Docs to a dataset.
+By running this Actor multiple times, you can incrementally crawl the source website and save only pages added since the last crawl, as reusing a single request queue ensures that only URLs not yet visited are processed.
 
 ```ts
 // Basic example of incremental crawling with Crawlee.
@@ -326,7 +326,7 @@ const crawler = new CheerioCrawler({
         const title = $('title').text();
         log.info(`New page with ${title}`, { url: request.loadedUrl });
 
-        // Save url of new URL and title to Dataset.
+        // Save the URL and title of the loaded page to the output dataset.
         await Dataset.pushData({ url: request.loadedUrl, title });
     },
 });
@@ -338,9 +338,7 @@ await Actor.exit();
 
 ### Batch operations {#batch-operations}
 
-Request queues enhance performance and cut down on API calls and network latency for adding or removing individual requests by supporting batch operations.
-This efficiency booster enables you to enqueue or retrieve requests in bulk, enhancing efficiency when handling numerous URLs.
-Batch operations simplify process flows, decrease API calls, and reduce latency, thus accelerating your web crawling processes and enhancing reliability.
+Request queues support batch operations on requests to enqueue or retrieve multiple requests in bulk, to cut down on network latency and enable easier parallel processing of requests.
 
 <Tabs groupId="main">
 <TabItem value="JavaScript" label="JavaScript">
@@ -395,11 +393,9 @@ request_queue_client.batch_delete_requests([
 
 ### Distributivity {#distributivity}
 
-Our design facilitates the simultaneous processing of requests by multiple clients (for example,  Actor runs) or server instances, perfectly suiting large-scale web crawling projects.
-Distributivity ensures your scraping tasks can expand horizontally. The request queue includes locking mechanisms to avoid concurrent
-processing of the same request, a feature seamlessly integrated into Crawlee, requiring minimal extra setup. The lock mechanism ensures that only one client can process a request at a time. The base scenario is that
-the lock is created for the same amount of time as the timeout for processing requests in the crawler (requestHandlerTimeoutSecs), and if the request timeouts, the lock is prolonged or expired.
-For more details, refer to the Crawlee documentation.
+Request queue includes a locking mechanism to avoid concurrent processing of one request by multiple clients (for example Actor runs). You can lock a request so that no other clients receive it when they fetch the queue head, with an expiration period on the lock so that requests which fail processing are eventually unlocked and retried.
+
+This feature is seamlessly integrated into Crawlee, requiring minimal extra setup. By default, requests are locked for the same duration as the timeout for processing requests in the crawler (`requestHandlerTimeoutSecs`) (TODO link). If the Actor processing the request fails, the lock expires, and the request is processed again eventually. For more details, refer to the Crawlee documentation (TODO link).
 
 In the following example, we demonstrate how we can use locking mechanisms to avoid concurrent processing of the same request.
 
@@ -461,7 +457,7 @@ await requestQueueClientOne.delete();
 await Actor.exit();
 ```
 
-The detailed tutorial on how to crawl one request queue from multiple Actor runs can be found in [Advanced web scraping academy](https://docs.apify.com/academy/advanced-web-scraping/multiple-runs-scrape).
+A detailed tutorial on how to crawl one request queue from multiple Actor runs can be found in [Advanced web scraping academy](https://docs.apify.com/academy/advanced-web-scraping/multiple-runs-scrape).
 
 ## Sharing {#sharing}
 


### PR DESCRIPTION
This is part of announcing request queue V2. The features described here were already implemented on backend but not promoted yet.

I will create one more PR with adding new tutorial under [Advanced web scraping academy](https://docs.apify.com/academy/advanced-web-scraping) on How to scraper one request queue from multiple Actor runs.