### PR TITLE
docs: disable unnecessary link

### DIFF
--- a/sources/academy/webscraping/web_scraping_for_beginners/crawling/finding_links.md
+++ b/sources/academy/webscraping/web_scraping_for_beginners/crawling/finding_links.md
@@ -59,7 +59,7 @@ We'll start from a boilerplate that's very similar to the scraper we built in [B
 
 Aside from importing libraries and downloading HTML, we load the HTML into Cheerio and then use it to retrieve all the `<a>` elements. After that, we iterate over the collected links and print their `href` attributes, which we access using the [`.attr()`](https://cheerio.js.org/docs/api/classes/Cheerio#attr) method.
 
-When you run the above code, you'll see quite a lot of links in the terminal. Some of them may look wrong, because they don't start with the regular **https:\/\/** protocol. We'll learn what to do with them in the following lessons.
+When you run the above code, you'll see quite a lot of links in the terminal. Some of them may look wrong, because they don't start with the regular `https://` protocol. We'll learn what to do with them in the following lessons.
 
 ## Next Up {#next}
 

--- a/sources/academy/webscraping/web_scraping_for_beginners/crawling/finding_links.md
+++ b/sources/academy/webscraping/web_scraping_for_beginners/crawling/finding_links.md
@@ -59,7 +59,7 @@ We'll start from a boilerplate that's very similar to the scraper we built in [B
 
 Aside from importing libraries and downloading HTML, we load the HTML into Cheerio and then use it to retrieve all the `<a>` elements. After that, we iterate over the collected links and print their `href` attributes, which we access using the [`.attr()`](https://cheerio.js.org/docs/api/classes/Cheerio#attr) method.
 
-When you run the above code, you'll see quite a lot of links in the terminal. Some of them may look wrong, because they don't start with the regular **<https://>** protocol. We'll learn what to do with them in the following lessons.
+When you run the above code, you'll see quite a lot of links in the terminal. Some of them may look wrong, because they don't start with the regular **https:\/\/** protocol. We'll learn what to do with them in the following lessons.
 
 ## Next Up {#next}
 


### PR DESCRIPTION
Supersedes https://github.com/apify/apify-docs/pull/896:

- better commit names
- made on top of current `master`, properly using `git` and not a GitHub pencil 😅 
- using inline code per @B4nan's comment https://github.com/apify/apify-docs/pull/896#pullrequestreview-1960109697 