### PR TITLE
fix: use example.com for examples

### DIFF
--- a/sources/academy/tutorials/node_js/submitting_form_with_file_attachment.md
+++ b/sources/academy/tutorials/node_js/submitting_form_with_file_attachment.md
@@ -5,7 +5,7 @@ sidebar_position: 15.5
 slug: /node-js/submitting-form-with-file-attachment
 ---
 
-When doing web automation with Apify, it can sometimes be necessary to submit an HTML form with a file attachment. This article will cover a situation where the file is publicly accessible (e.g. hosted somewhere) and will use an Apify actor. If it is not possible to use request-promise, it might be necessary to use [Puppeteer.](http://kb.apify.com/actor/submitting-a-form-with-file-attachment-using-puppeteer)
+When doing web automation with Apify, it can sometimes be necessary to submit an HTML form with a file attachment. This article will cover a situation where the file is publicly accessible (e.g. hosted somewhere) and will use an Apify actor. If it's impossible to use request-promise, it might be necessary to use [Puppeteer](http://kb.apify.com/actor/submitting-a-form-with-file-attachment-using-puppeteer).
 
 # Downloading the file to memory
 
@@ -15,19 +15,21 @@ When doing web automation with Apify, it can sometimes be necessary to submit an
 
 After creating a new actor, the first thing to do is download the file. We can do that using the request-promise module, so make sure it is included.
 
+```js
 const request = require('request-promise');
+```
 
-The actual downloading is going to be slightly different for text and binary files. For a text file, it can simply be done like this:
+The actual downloading is going to be slightly different for text and binary files. For a text file, do it like this:
 
 ```js
-const fileData = await request('https://some-site.com/file.txt');
+const fileData = await request('https://example.com/file.txt');
 ```
 
 For a binary file, we need to provide additional parameters so as not to interpret it as text:
 
 ```js
 const fileData = await request({
-    uri: 'https://some-site.com/file.pdf',
+    uri: 'https://example.com/file.pdf',
     encoding: null,
 });
 ```
@@ -40,14 +42,14 @@ When the file is ready, we can submit the form as follows:
 
 ```js
 await request({
-    uri: 'https://other-site.com/submit-form.php',
+    uri: 'https://example.com/submit-form.php',
     method: 'POST',
 
     formData: {
         // set any form values
         name: 'John',
         surname: 'Doe',
-        email: 'john.doe@mail.com',
+        email: 'john.doe@example.com',
 
         // add the attachment
         attachment: {

--- a/sources/academy/webscraping/advanced_web_scraping/scraping_paginated_sites.md
+++ b/sources/academy/webscraping/advanced_web_scraping/scraping_paginated_sites.md
@@ -87,7 +87,7 @@ No easy way exists to get around this but the price range split works even with 
 
 #### How is the range passed to the URL? {#how-is-the-range-passed-to-the-url}
 
-In the easiest case, you can pass the range directly in the page's URL. For example, `<https://mysite.com/products?price=0-10>`. Sometimes, you will need to do some query composition because the price range might be encoded together with more information into a single parameter.
+In the easiest case, you can pass the range directly in the page's URL. For example, `https://example.com/products?price=0-10`. Sometimes, you will need to do some query composition because the price range might be encoded together with more information into a single parameter.
 
 Some sites don't have page URLs with filters and instead load the filtered products via [XHRs](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest). Those can be GET or POST requests with various **URL** and **payload** syntax.
 

--- a/sources/academy/webscraping/puppeteer_playwright/common_use_cases/logging_into_a_website.md
+++ b/sources/academy/webscraping/puppeteer_playwright/common_use_cases/logging_into_a_website.md
@@ -107,17 +107,17 @@ Here is an object we'll create which represents the three different emails we wa
 ```js
 const emailsToSend = [
     {
-        to: 'abcdef123randomFakeEmail@gmail.com',
+        to: 'alice@example.com',
         subject: 'Hello',
         body: 'This is a message.',
     },
     {
-        to: 'testingtesting12345903@aol.com',
+        to: 'bob@example.com',
         subject: 'Testing',
         body: 'I love the academy!',
     },
     {
-        to: 'jimmyJohnBillyBob420@academy.net',
+        to: 'carol@example.com',
         subject: 'Apify is awesome!',
         body: 'Some content.',
     },
@@ -299,17 +299,17 @@ import { chromium } from 'playwright';
 
 const emailsToSend = [
     {
-        to: 'abcdef123randomFakeEmail@gmail.com',
+        to: 'alice@example.com',
         subject: 'Hello',
         body: 'This is a message.',
     },
     {
-        to: 'testingtesting12345903@aol.com',
+        to: 'bob@example.com',
         subject: 'Testing',
         body: 'I love the academy!',
     },
     {
-        to: 'jimmyJohnBillyBob420@academy.net',
+        to: 'carol@example.com',
         subject: 'Apify is awesome!',
         body: 'Some content.',
     },
@@ -371,17 +371,17 @@ import puppeteer from 'puppeteer';
 
 const emailsToSend = [
     {
-        to: 'abcdef123randomFakeEmail@gmail.com',
+        to: 'alice@example.com',
         subject: 'Hello',
         body: 'This is a message.',
     },
     {
-        to: 'testingtesting12345903@aol.com',
+        to: 'bob@example.com',
         subject: 'Testing',
         body: 'I love the academy!',
     },
     {
-        to: 'jimmyJohnBillyBob420@academy.net',
+        to: 'carol@example.com',
         subject: 'Apify is awesome!',
         body: 'Some content.',
     },

--- a/sources/academy/webscraping/puppeteer_playwright/common_use_cases/submitting_a_form_with_a_file_attachment.md
+++ b/sources/academy/webscraping/puppeteer_playwright/common_use_cases/submitting_a_form_with_a_file_attachment.md
@@ -60,7 +60,7 @@ To fill in any necessary form inputs, we can use the `page.type()` function. Thi
 ```js
 await page.type('input[name=firstName]', 'John');
 await page.type('input[name=surname]', 'Doe');
-await page.type('input[name=email]', 'john.doe@mail.com');
+await page.type('input[name=email]', 'john.doe@example.com');
 ```
 
 To add the file to the appropriate input, we first need to find it and then use the [`uploadFile()`](https://pptr.dev/next/api/puppeteer.elementhandle.uploadfile) function.

--- a/sources/academy/webscraping/puppeteer_playwright/proxies.md
+++ b/sources/academy/webscraping/puppeteer_playwright/proxies.md
@@ -124,7 +124,7 @@ And that's it! Now, when we visit Google, it's in Vietnamese. Depending on the c
 The proxy in the last activity didn't require a username and password, but let's say that this one does:
 
 ```text
-my.proxy.com:3001
+proxy.example.com:3001
 ```
 
 One might automatically assume that this would be the solution:
@@ -136,7 +136,7 @@ One might automatically assume that this would be the solution:
 // This code is wrong!
 import { chromium } from 'playwright';
 
-const proxy = 'my.proxy.com:3001';
+const proxy = 'proxy.example.com:3001';
 const username = 'someUsername';
 const password = 'password123';
 
@@ -156,7 +156,7 @@ const browser = await chromium.launch({
 // This code is wrong!
 import puppeteer from 'puppeteer';
 
-const proxy = 'my.proxy.com:3001';
+const proxy = 'proxy.example.com:3001';
 const username = 'someUsername';
 const password = 'password123';
 
@@ -177,7 +177,7 @@ However, authentication parameters need to be passed in separately in order to w
 ```javascript
 import { chromium } from 'playwright';
 
-const proxy = 'my.proxy.com:3001';
+const proxy = 'proxy.example.com:3001';
 const username = 'someUsername';
 const password = 'password123';
 
@@ -198,7 +198,7 @@ const browser = await chromium.launch({
 ```javascript
 import puppeteer from 'puppeteer';
 
-const proxy = 'my.proxy.com:3001';
+const proxy = 'proxy.example.com:3001';
 const username = 'someUsername';
 const password = 'password123';
 


### PR DESCRIPTION
We should not use existing domains or e-mail addresses for examples. The example.com domain is reserved exactly for the purpose of examples, so it can cause no harm to anyone.