### PR TITLE
chore: add myself to codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,6 @@
-# Documentation codeowner
-
+# Documentation
 *.md @TC-MO
 *.mdx @TC-MO
+
+# Academy
+/sources/academy/ @honzajavorek


### PR DESCRIPTION
According to https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners, this should let me know about everything that happens in the Academy. I don't necessarily aim to review everything, but I want to be aware of what's going on. Following the whole repository is too noisy for me.