### PR TITLE
fix(docs): add absoluteUrl to navbar sdk link

### DIFF
--- a/apify-docs-theme/src/config.js
+++ b/apify-docs-theme/src/config.js
@@ -72,7 +72,7 @@ const themeConfig = ({
             {
                 label: 'SDK',
                 type: 'dropdown',
-                to: '/sdk',
+                to: `${absoluteUrl}/sdk`,
                 activeBasePath: 'sdk',
                 position: 'left',
                 target: '_self',


### PR DESCRIPTION
### 🐛 Bug

When you go to a page that isn't served from the apify-docs, but some sub-doc (e.g. https://docs.apify.com/cli/ ) you cannot click on the 'SDK' item in the navbar.

### 🛠️ Fix

I included absoluteUrl in the link. Now it is the same as 'API', which works in production.