### PR TITLE
fix(docs): add babel plugin for styled components

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,3 +1,4 @@
 module.exports = {
     presets: [require.resolve('@docusaurus/core/lib/babel/preset')],
+    plugins: ['babel-plugin-styled-components'],
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,7 @@
                 "@types/react": "^18.2.8",
                 "@typescript-eslint/eslint-plugin": "^7.0.0",
                 "@typescript-eslint/parser": "^7.0.0",
+                "babel-plugin-styled-components": "^2.1.4",
                 "cross-env": "^7.0.3",
                 "eslint": "^8.46.0",
                 "eslint-plugin-json": "^3.1.0",
@@ -62,7 +63,7 @@
         },
         "apify-docs-theme": {
             "name": "@apify/docs-theme",
-            "version": "1.0.115",
+            "version": "1.0.116",
             "license": "ISC",
             "dependencies": {
                 "@apify/docs-search-modal": "^1.0.25",
@@ -6665,6 +6666,22 @@
             },
             "peerDependencies": {
                 "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
+            }
+        },
+        "node_modules/babel-plugin-styled-components": {
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/babel-plugin-styled-components/-/babel-plugin-styled-components-2.1.4.tgz",
+            "integrity": "sha512-Xgp9g+A/cG47sUyRwwYxGM4bR/jDRg5N6it/8+HxCnbT5XNKSKDT9xm4oag/osgqjC2It/vH0yXsomOG6k558g==",
+            "dev": true,
+            "dependencies": {
+                "@babel/helper-annotate-as-pure": "^7.22.5",
+                "@babel/helper-module-imports": "^7.22.5",
+                "@babel/plugin-syntax-jsx": "^7.22.5",
+                "lodash": "^4.17.21",
+                "picomatch": "^2.3.1"
+            },
+            "peerDependencies": {
+                "styled-components": ">= 2"
             }
         },
         "node_modules/bail": {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
         "@types/react": "^18.2.8",
         "@typescript-eslint/eslint-plugin": "^7.0.0",
         "@typescript-eslint/parser": "^7.0.0",
+        "babel-plugin-styled-components": "^2.1.4",
         "cross-env": "^7.0.3",
         "eslint": "^8.46.0",
         "eslint-plugin-json": "^3.1.0",


### PR DESCRIPTION
### 🐛 Bug

Some styling is completely messed up. This is most visible in the SDK landing page for some reason. But also there is a padding missing in the docs hompage.
![image](https://github.com/apify/apify-docs/assets/37815707/728d3ec2-d3ad-48c4-8aab-1f7d71b9e2f0)
![image](https://github.com/apify/apify-docs/assets/37815707/ac8f541c-f702-4715-bb4a-60a54a9a826d)
The reason for this is that classes generated by styled-components are not being added correctly.

### 🛠️ Fix

It seems that [CSS-in-JS](https://docusaurus.io/docs/styling-layout#css-in-js) is not supported by Docusaurus natively. I don't know why until now it has somehow worked and started breaking just now...
In any case, by adding a babel plugin it seems that the code is now transpiled correctly and the final build works with styled-components as it should.

### 📝 Side-note

Sometimes the code blockets' text does not follow the ui theme correctly (resulting in black text on black background). However this seems to be related to something different, so this PR does not fix that.