### PR TITLE
fix(docs): codeblock correct theme

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -63,7 +63,7 @@
         },
         "apify-docs-theme": {
             "name": "@apify/docs-theme",
-            "version": "1.0.116",
+            "version": "1.0.118",
             "license": "ISC",
             "dependencies": {
                 "@apify/docs-search-modal": "^1.0.25",

--- a/src/components/UiLibraryWrapper.tsx
+++ b/src/components/UiLibraryWrapper.tsx
@@ -2,15 +2,21 @@ import { UiDependencyProvider } from '@apify-packages/ui-library';
 import Link from '@docusaurus/Link';
 import { useColorMode } from '@docusaurus/theme-common';
 import useBaseUrl from '@docusaurus/useBaseUrl';
-import React, { PropsWithChildren } from 'react';
+import React, { PropsWithChildren, useEffect, useState } from 'react';
 
 export default function UiLibraryWrapper({ children }: PropsWithChildren) {
+    const [themeIsDark, setThemeIsDark] = useState(useColorMode().isDarkTheme);
+    const isDark = useColorMode().isDarkTheme;
+    useEffect(() => {
+        setThemeIsDark(isDark);
+    }, [isDark]);
+
     return (
         <UiDependencyProvider dependencies={{
             InternalLink: (props) => <Link {...props} />,
             windowLocationHost: useBaseUrl(''),
             isHrefTrusted: () => true,
-            uiTheme: useColorMode().isDarkTheme ? 'DARK' : 'LIGHT',
+            uiTheme: themeIsDark ? 'DARK' : 'LIGHT',
         }}>{children}</UiDependencyProvider>
     );
 }

--- a/src/components/UiLibraryWrapper.tsx
+++ b/src/components/UiLibraryWrapper.tsx
@@ -5,7 +5,7 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 import React, { PropsWithChildren, useEffect, useState } from 'react';
 
 export default function UiLibraryWrapper({ children }: PropsWithChildren) {
-    const [themeIsDark, setThemeIsDark] = useState(useColorMode().isDarkTheme);
+    const [themeIsDark, setThemeIsDark] = useState(true);
     const isDark = useColorMode().isDarkTheme;
     useEffect(() => {
         setThemeIsDark(isDark);


### PR DESCRIPTION
In page /sdk and /api expecially, now the color of the Codeblock texts is working with the color theme of the page