### PR TITLE
refactor: change link to langchain docs

### DIFF
--- a/sources/platform/integrations/langchain.md
+++ b/sources/platform/integrations/langchain.md
@@ -10,7 +10,7 @@ slug: /integrations/langchain
 
 ---
 
-> For more information on LangChain visit its [documentation](https://python.langchain.com/v0.1/docs/get_started/introduction/).
+> For more information on LangChain visit its [documentation](https://python.langchain.com/docs/).
 
 In this example, we'll use the [Website Content Crawler](https://apify.com/apify/website-content-crawler) Actor, which can deeply crawl websites such as documentation, knowledge bases, help centers, or blogs and extract text content from the web pages.
 Then we feed the documents into a vector index and answer questions from it.


### PR DESCRIPTION
They've released a new version of the docs, so I'm updating the link to something which seems to automatically redirect to the latest version: https://python.langchain.com/docs/

Follow up to https://github.com/apify/apify-docs/pull/998/