### PR TITLE
docs: Added redirects for removed api clients pages

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -192,6 +192,17 @@ server {
   rewrite ^/academy/php/using-apify-scraper-with-php$ /academy/php/use-apify-from-php permanent;
   rewrite ^/api/client/?$ /api redirect;
 
+  # unified api clients docs pages -> getting started page
+  rewrite ^/api/client/python/docs/quick-start$ /api/client/python/docs permanent;
+  rewrite ^/api/client/python/docs/features$ /api/client/python/docs permanent;
+  rewrite ^/api/client/python/docs/usage-concepts$ /api/client/python/docs permanent;
+  rewrite ^/api/client/python/docs/change-log$ /api/client/python/docs permanent;
+
+  rewrite ^/api/client/js/docs/quick-start$ /api/client/js/docs permanent;
+  rewrite ^/api/client/js/docs/features$ /api/client/js/docs permanent;
+  rewrite ^/api/client/js/docs/usage-concepts$ /api/client/js/docs permanent;
+  rewrite ^/api/client/js/docs/change-log$ /api/client/js/docs permanent;
+
   # sdk/js/api -> sdk/js/reference
   rewrite ^/sdk/js/api/apify(.*)$ /sdk/js/reference$1 permanent;
   rewrite ^/sdk/js/api(.*)$ /sdk/js/reference$1 permanent;

--- a/nginx.conf
+++ b/nginx.conf
@@ -196,12 +196,10 @@ server {
   rewrite ^/api/client/python/docs/quick-start$ /api/client/python/docs permanent;
   rewrite ^/api/client/python/docs/features$ /api/client/python/docs permanent;
   rewrite ^/api/client/python/docs/usage-concepts$ /api/client/python/docs permanent;
-  rewrite ^/api/client/python/docs/change-log$ /api/client/python/docs permanent;
 
   rewrite ^/api/client/js/docs/quick-start$ /api/client/js/docs permanent;
   rewrite ^/api/client/js/docs/features$ /api/client/js/docs permanent;
   rewrite ^/api/client/js/docs/usage-concepts$ /api/client/js/docs permanent;
-  rewrite ^/api/client/js/docs/change-log$ /api/client/js/docs permanent;
 
   # sdk/js/api -> sdk/js/reference
   rewrite ^/sdk/js/api/apify(.*)$ /sdk/js/reference$1 permanent;


### PR DESCRIPTION
Pages were removed in https://github.com/apify/apify-client-python/pull/232 and https://github.com/apify/apify-client-js/pull/542