### PR TITLE
fix: split the `@font-face` rule to make it valid

### DIFF
--- a/apify-docs-theme/src/theme/custom.css
+++ b/apify-docs-theme/src/theme/custom.css
@@ -340,11 +340,86 @@ body {
 }
 
 @font-face {
-    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI',
-        'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans',
-        'Helvetica Neue', sans-serif;
+    font-family: -apple-system;
     src: url('/font/lota.woff2') format('woff2'),
-        url('/font/lota.woff') format('woff');
+    url('/font/lota.woff') format('woff');
+    font-weight: 600;
+}
+
+@font-face {
+    font-family: BlinkMacSystemFont;
+    src: url('/font/lota.woff2') format('woff2'),
+    url('/font/lota.woff') format('woff');
+    font-weight: 600;
+}
+
+@font-face {
+    font-family: 'Segoe UI';
+    src: url('/font/lota.woff2') format('woff2'),
+    url('/font/lota.woff') format('woff');
+    font-weight: 600;
+}
+
+@font-face {
+    font-family: 'Roboto';
+    src: url('/font/lota.woff2') format('woff2'),
+    url('/font/lota.woff') format('woff');
+    font-weight: 600;
+}
+
+@font-face {
+    font-family: 'Oxygen';
+    src: url('/font/lota.woff2') format('woff2'),
+    url('/font/lota.woff') format('woff');
+    font-weight: 600;
+}
+
+@font-face {
+    font-family: 'Ubuntu';
+    src: url('/font/lota.woff2') format('woff2'),
+    url('/font/lota.woff') format('woff');
+    font-weight: 600;
+}
+
+@font-face {
+    font-family: 'Cantarell';
+    src: url('/font/lota.woff2') format('woff2'),
+    url('/font/lota.woff') format('woff');
+    font-weight: 600;
+}
+
+@font-face {
+    font-family: 'Fira Sans';
+    src: url('/font/lota.woff2') format('woff2'),
+    url('/font/lota.woff') format('woff');
+    font-weight: 600;
+}
+
+@font-face {
+    font-family: 'Droid Sans';
+    src: url('/font/lota.woff2') format('woff2'),
+    url('/font/lota.woff') format('woff');
+    font-weight: 600;
+}
+
+@font-face {
+    font-family: 'Helvetica Neue';
+    src: url('/font/lota.woff2') format('woff2'),
+    url('/font/lota.woff') format('woff');
+    font-weight: 600;
+}
+
+@font-face {
+    font-family: 'Lota Grotesque';
+    src: url('/font/lota.woff2') format('woff2'),
+    url('/font/lota.woff') format('woff');
+    font-weight: 600;
+}
+
+@font-face {
+    font-family: sans-serif;
+    src: url('/font/lota.woff2') format('woff2'),
+    url('/font/lota.woff') format('woff');
     font-weight: 600;
 }
 


### PR DESCRIPTION
According to the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-family#formal_syntax), the `@font-face { font-family }` descriptor can only be a single `string | custom ident`.

Compare to [`font-family` CSS property](https://developer.mozilla.org/en-US/docs/Web/CSS/font-family#formal_syntax), which can be a priority list.

This discrepancy is causing the tagline in the subprojects to look like ass (fig. 1)

![obrazek](https://github.com/apify/apify-docs/assets/61918049/9e58ab97-8ea1-447c-aeb2-d7539afccd63)
