### PR TITLE
fix: fine-tune Vale and fix all outstanding errors

### DIFF
--- a/.github/styles/Apify/Capitalization.yml
+++ b/.github/styles/Apify/Capitalization.yml
@@ -10,11 +10,11 @@ tokens:
   # Also no . followed by a word character (avoids 'actors.md')
   - '(?<![\/\-#\w])actors(?![\/\}])(?!\.\w)'
 
-  # Before the word there should be no: /, -, #, ., word character
+  # Before the word there should be no: /, -, #, ., `, word character
   # (avoids anchors, URLs, identifiers, code, and words like 'factors')
   #
   # After the word there should be no: /, }, -, word character (avoids paths or URLs)
   # Also no " =" (avoids code like "actor = ...")
   # Also no . followed by a word character (avoids 'actor.md' or 'actor.update()')
-  - '(?<![\/\-#\.\w`])actor(?![\/\}\-\w])(?! =)(?!\.\w)'
+  - '(?<![\/\-#\.`\w])actor(?![\/\}\-\w])(?! =)(?!\.\w)'
 nonword: false

--- a/sources/academy/glossary/concepts/index.md
+++ b/sources/academy/glossary/concepts/index.md
@@ -12,8 +12,8 @@ slug: /concepts
 
 ---
 
-There are some terms and concepts you'll see frequently repeated throughout various courses in the academy. Many of these concepts are common, and even fundamental in the scraping world, which makes it necessary to explain them to our course-takers; however it would be inconvenient for our readers to explain these terms each time they appear in a lesson.
+You'll see some terms and concepts frequently repeated throughout various courses in the academy. Many of these concepts are common, and even fundamental in the scraping world, which makes it necessary to explain them to our course-takers; however it would be inconvenient for our readers to explain these terms each time they appear in a lesson.
 
-Because of this slight dilemma, and because there are no outside resources which compile all of these concepts into an educational and digestible form, we've decided to do just that. So, welcome to the **Concepts** section of the Apify Academy's **Glossary**!
+Because of this slight dilemma, and because there are no outside resources which compile all of these concepts into an educational and digestible form, we've decided to do just that. Welcome to the **Concepts** section of the Apify Academy's **Glossary**!
 
 > It's important to note that there is no specific order to these concepts. All of them range in their relevance and importance to your every day scraping endeavors.

--- a/sources/academy/platform/expert_scraping_with_apify/index.md
+++ b/sources/academy/platform/expert_scraping_with_apify/index.md
@@ -26,7 +26,7 @@ Before developing a pro-level Apify scraper, there are some important things you
 
 ### Crawlee, Apify SDK, and the Apify CLI {#crawlee-apify-sdk-and-cli}
 
-If you're feeling ambitious, you don't need to have any prior experience with Crawlee to get started with this course; however, at least 5–10 minutes of exposure is recommended. If you haven't yet tried out Crawlee, you can refer to [this lesson](../../webscraping/web_scraping_for_beginners/crawling/pro_scraping.md) in the **Web scraping for beginners** course (and ideally follow along). To familiarize yourself with the Apify SDK, you can refer to the [Apify Platform](../apify_platform.md) category.
+If you're feeling ambitious, you don't need to have any prior experience with Crawlee to get started with this course; however, at least 5–10 minutes of exposure is recommended. If you haven't yet tried out Crawlee, you can refer to [this lesson](../../webscraping/scraping_basics_javascript/crawling/pro_scraping.md) in the **Web scraping for beginners** course (and ideally follow along). To familiarize yourself with the Apify SDK, you can refer to the [Apify Platform](../apify_platform.md) category.
 
 The Apify CLI will play a core role in the running and testing of the Actor you will build, so if you haven't gotten it installed already, please refer to [this short lesson](../../glossary/tools/apify_cli.md).
 

--- a/sources/academy/platform/expert_scraping_with_apify/index.md
+++ b/sources/academy/platform/expert_scraping_with_apify/index.md
@@ -26,7 +26,7 @@ Before developing a pro-level Apify scraper, there are some important things you
 
 ### Crawlee, Apify SDK, and the Apify CLI {#crawlee-apify-sdk-and-cli}
 
-If you're feeling ambitious, you don't need to have any prior experience with Crawlee to get started with this course; however, at least 5-10 minutes of exposure is recommended. If you haven't yet tried out Crawlee, you can refer to [this lesson](../../webscraping/scraping_basics_javascript/crawling/pro_scraping.md) in the **Web scraping for beginners** course (and ideally follow along). To familiarize yourself with the Apify SDK, you can refer to the [Apify Platform](../apify_platform.md) category.
+If you're feeling ambitious, you don't need to have any prior experience with Crawlee to get started with this course; however, at least 5–10 minutes of exposure is recommended. If you haven't yet tried out Crawlee, you can refer to [this lesson](../../webscraping/web_scraping_for_beginners/crawling/pro_scraping.md) in the **Web scraping for beginners** course (and ideally follow along). To familiarize yourself with the Apify SDK, you can refer to the [Apify Platform](../apify_platform.md) category.
 
 The Apify CLI will play a core role in the running and testing of the Actor you will build, so if you haven't gotten it installed already, please refer to [this short lesson](../../glossary/tools/apify_cli.md).
 

--- a/sources/academy/platform/expert_scraping_with_apify/solutions/saving_stats.md
+++ b/sources/academy/platform/expert_scraping_with_apify/solutions/saving_stats.md
@@ -160,7 +160,7 @@ router.addHandler(labels.OFFERS, async ({ $, request }) => {
 
 **Q: Is storing these types of values necessary for every single Actor?**
 
-**A:** For small Actors, it might be a waste of time to do this. For large-scale Actors, it can be extremely helpful when debugging and most definitely worth the extra 10-20 minutes of development time. Usually though, the default statistics from the Crawlee and the SDK might be enough for simple run stats.
+**A:** For small Actors, it might be a waste of time to do this. For large-scale Actors, it can be extremely helpful when debugging and most definitely worth the extra 10–20 minutes of development time. Usually though, the default statistics from the Crawlee and the SDK might be enough for simple run stats.
 
 **Q: What is the difference between the `failedRequestHandler` and `errorHandler`?**
 

--- a/sources/academy/platform/get_most_of_actors/index.md
+++ b/sources/academy/platform/get_most_of_actors/index.md
@@ -22,4 +22,4 @@ In this section, we will go over some of the practical steps you can take to ens
 
 ## Next up {#next}
 
-So, without further ado, let's jump [right into the next lesson](./naming_your_actor.md)!
+Without further ado, let's jump [right into the next lesson](./naming_your_actor.md)!

--- a/sources/academy/platform/get_most_of_actors/naming_your_actor.md
+++ b/sources/academy/platform/get_most_of_actors/naming_your_actor.md
@@ -13,7 +13,7 @@ slug: /get-most-of-actors/naming-your-actor
 
 Naming your Actor can be tricky. Especially when you've spent a long time coding and are excited to show your brand-new creation to the world. To help users find your Actor, we've introduced naming standards. These standards improve your Actor's [search engine optimization (SEO)](https://en.wikipedia.org/wiki/Search_engine_optimization) and maintain consistency in the [Apify Store](https://apify.com/store).
 
-> Your Actor's name should be 3-63 characters long.
+> Your Actor's name should be 3–63 characters long.
 
 ## Scrapers {#scrapers}
 

--- a/sources/academy/tutorials/api/retry_failed_requests.md
+++ b/sources/academy/tutorials/api/retry_failed_requests.md
@@ -9,9 +9,9 @@ slug: /api/retry-failed-requests
 
 ---
 
-There are many reasons why requests for a scraper could fail. The most common causes are different page layouts or proxy blocking issues ([check here on how to effectively analyze errors](https://docs.apify.com/academy/node-js/analyzing-pages-and-fixing-errors)). Both [Apify](https://apify.com) and [Crawlee](https://crawlee.dev/) allow you to restart your scraper run from the point where it ended, but there is no native functionality to re-scrape only failed requests. Usually, you also want to first analyze the problem, update the code, and build it before trying again.
+Requests of a scraper can fail for many reasons. The most common causes are different page layouts or proxy blocking issues ([check here on how to effectively analyze errors](https://docs.apify.com/academy/node-js/analyzing-pages-and-fixing-errors)). Both [Apify](https://apify.com) and [Crawlee](https://crawlee.dev/) allow you to restart your scraper run from the point where it ended, but there is no native functionality to re-scrape only failed requests. Usually, you also want to first analyze the problem, update the code, and build it before trying again.
 
-If you attempt to restart an already finished run, it will likely immediately finish because all the requests in the [request queue](https://crawlee.dev/docs/guides/request-storage) are marked as handled. So you need to update the failed requests in the queue to be marked as pending again.
+If you attempt to restart an already finished run, it will likely immediately finish because all the requests in the [request queue](https://crawlee.dev/docs/guides/request-storage) are marked as handled. You need to update the failed requests in the queue to be marked as pending again.
 
 The additional complication is that the [Request](https://crawlee.dev/api/core/class/Request) object doesn't have anything like the `isFailed` property. We have to approximate it using other fields. Fortunately, we can use the `errorMessages` and `retryCount` properties to identify failed requests. Unless the user explicitly has overridden these properties, we can identify failed requests with a larger amount of `errorMessages` than `retryCount`. That happens because the last error that doesn't cause a retry anymore is added to `errorMessages`.
 

--- a/sources/academy/tutorials/node_js/analyzing_pages_and_fixing_errors.md
+++ b/sources/academy/tutorials/node_js/analyzing_pages_and_fixing_errors.md
@@ -77,14 +77,14 @@ Read more information about logging and error handling in our developer [best pr
 
 By snapshots, we mean **screenshots** if you use a [browser with Puppeteer/Playwright](../../webscraping/puppeteer_playwright/index.md) and HTML saved into a [key-value store](https://crawlee.dev/api/core/class/KeyValueStore) that you can easily display in your own browser. Snapshots are useful throughout your code but especially important in error handling.
 
-Note that an error can happen only in a few pages out of a thousand and look completely random. There is not much you can do other than save and analyze a snapshot.
+Note that an error can happen only in a few pages out of a thousand and look completely random. You cannot do much else than to save and analyze a snapshot.
 
 Snapshots can tell you if:
 
 - A website has changed its layout. This can also mean A/B testing or different content for different locations.
-- You have been blocked – you open a [CAPTCHA](https://en.wikipedia.org/wiki/CAPTCHA) or an **Access Denied** page.
-- Data load later dynamically – the page is empty.
-- The page was redirected – the content is different.
+- You have been blocked—you open a [CAPTCHA](https://en.wikipedia.org/wiki/CAPTCHA) or an **Access Denied** page.
+- Data load later dynamically—the page is empty.
+- The page was redirected—the content is different.
 
 You can learn how to take snapshots in Puppeteer or Playwright in [this short lesson](../../webscraping/puppeteer_playwright/page/page_methods.md)
 

--- a/sources/academy/tutorials/node_js/dealing_with_dynamic_pages.md
+++ b/sources/academy/tutorials/node_js/dealing_with_dynamic_pages.md
@@ -93,7 +93,7 @@ https://demo-webstore.apify.org/_next/image?url=https%3A%2F%2Fm.media-amazon.com
 
 The reason this is happening is because CheerioCrawler makes static HTTP requests, so it only manages to capture the content from the `DOMContentLoaded` event. Any elements or attributes generated dynamically thereafter using JavaScript (and usually XHR/Fetch requests) are not part of the downloaded HTML, and therefore are not accessible through the `$` object.
 
-So, what's the solution? We need to use something that is able to allow the page to follow through with the entire load process - a headless browser.
+What's the solution? We need to use something that is able to allow the page to follow through with the entire load process - a headless browser.
 
 ## Scraping dynamic content {#scraping-dynamic-content}
 
@@ -142,7 +142,7 @@ After running this one, we can see that our results look different from before. 
 
 Well... Not quite. It seems that the only images which we got the full links to were the ones that were being displayed within the view of the browser. This means that the images are lazy-loaded. **Lazy-loading** is a common technique used across the web to improve performance. Lazy-loaded items allow the user to load content incrementally, as they perform some action. In most cases, including our current one, this action is scrolling.
 
-So, we've gotta scroll down the page to load these images. Luckily, because we're using Crawlee, we don't have to write the logic that will achieve that, because a utility function specifically for Puppeteer called [`infiniteScroll`](https://crawlee.dev/api/puppeteer-crawler/namespace/puppeteerUtils#infiniteScroll) already exists right in the library, and can be accessed through `utils.puppeteer`. Let's add it to our code now:
+We've gotta scroll down the page to load these images. Luckily, because we're using Crawlee, we don't have to write the logic that will achieve that, because a utility function specifically for Puppeteer called [`infiniteScroll`](https://crawlee.dev/api/puppeteer-crawler/namespace/puppeteerUtils#infiniteScroll) already exists right in the library, and can be accessed through `utils.puppeteer`. Let's add it to our code now:
 
 <RunnableCodeBlock className="language-js" type="puppeteer">
     {Example}

--- a/sources/academy/tutorials/node_js/js_in_html.md
+++ b/sources/academy/tutorials/node_js/js_in_html.md
@@ -29,7 +29,7 @@ These data objects will usually be attached to the window object (often prefixed
 
 ## Parsing {#parsing-objects}
 
-There are two ways to go about obtaining these objects to be used and manipulated in JavaScript code:
+You can obtain these objects to be used and manipulated in JavaScript in two ways:
 
 ### 1. Parsing them directly from the HTML
 

--- a/sources/academy/tutorials/node_js/processing_multiple_pages_web_scraper.md
+++ b/sources/academy/tutorials/node_js/processing_multiple_pages_web_scraper.md
@@ -5,7 +5,7 @@ sidebar_position: 15.6
 slug: /node-js/processing-multiple-pages-web-scraper
 ---
 
-There is a certain scraping scenario in which you need to process the same URL many times, but each time with a different setup (e.g. filling in a form with different data each time). This is easy to do with Apify, but how to go about it may not be obvious at first glance.
+Sometimes when scraping, you need to process the same URL many times, but each time with a different setup (e.g. filling in a form with different data each time). This is easy to do with Apify, but how to go about it may not be obvious at first glance.
 
 We'll show you how to do this with a simple example: starting a scraper with an array of keywords, inputting each of the keywords separately into Google, and retrieving the results on the last page. The tutorial will be split into these three main parts.
 

--- a/sources/academy/tutorials/node_js/request_labels_in_apify_actors.md
+++ b/sources/academy/tutorials/node_js/request_labels_in_apify_actors.md
@@ -25,7 +25,7 @@ await requestQueue.addRequest({
 });
 ```
 
-So right now, we have one request in the queue that has the label "START".  Now we can specify which code should be executed for this request in the handlePageFunction.
+Right now, we have one request in the queue that has the label "START".  Now we can specify which code should be executed for this request in the handlePageFunction.
 
 ```js
 if (request.userData.label === 'START') {
@@ -38,7 +38,7 @@ if (request.userData.label === 'START') {
 
 And in the same way you can keep adding requests in the handlePageFunction.
 
-You can also handle the passing of data to the request like this. For example, when we have extracted the item from the shop above, we want to extract some information about the seller. So we need to pass the item object to the seller page, where we save the rating of a seller, e.g..
+You can also handle the passing of data to the request like this. For example, when we have extracted the item from the shop above, we want to extract some information about the seller. We need to pass the item object to the seller page, where we save the rating of a seller, e.g..
 
 ```js
 await requestQueue.addRequest({
@@ -56,7 +56,7 @@ Now, in the "SELLERDETAIL" url, we can just evaluate the page and extracted data
 const result = { ...request.userData.data, ...sellerDetail };
 ```
 
-So next just save the results and we're done!
+Next just save the results and we're done!
 
 ```js
 await Apify.pushData(result);

--- a/sources/academy/tutorials/node_js/scraping_shadow_doms.md
+++ b/sources/academy/tutorials/node_js/scraping_shadow_doms.md
@@ -34,7 +34,7 @@ const urls = links.map((obj, el) => el.href);
 
 However, this isn't very convenient, because you have to find the root element of each component you want to work with, and you can't easily take advantage of all the scripts and tools you already have.
 
-So instead of that, we can replace the content of each element containing shadow DOM with the HTML of shadow DOM.
+Instead of that, we can replace the content of each element containing shadow DOM with the HTML of shadow DOM.
 
 ```js
 // Iterate over all elements in the main DOM.

--- a/sources/academy/webscraping/anti_scraping/mitigation/proxies.md
+++ b/sources/academy/webscraping/anti_scraping/mitigation/proxies.md
@@ -15,7 +15,7 @@ A proxy server provides a gateway between users and the internet, to be more spe
 
 Many websites have [rate-limiting](../techniques/rate_limiting.md) set up, which is when a website **limits** the **rate** at which requests can be sent from a single IP address. In cases when a higher number of requests is expected for the crawler - using a proxy is essential to let the crawler run as smoothly as possible and avoid being blocked.
 
-There are a few factors that determine the quality of a proxy IP:
+The following factors determine the quality of a proxy IP:
 
 - How many users share the same proxy IP address?
 - How did the previous user use (or overuse) the proxy?

--- a/sources/academy/webscraping/anti_scraping/techniques/captchas.md
+++ b/sources/academy/webscraping/anti_scraping/techniques/captchas.md
@@ -31,7 +31,7 @@ Have you expended all of the possible options to make your scraper appear more h
 
 If you've tried everything you can to avoid being presented the captcha and are still facing this roadblock, there are methods to programmatically solve captchas.
 
-There are tons of different types of captchas, but one of the most popular is Google's [**reCAPTCHA**](https://www.google.com/recaptcha/about/).
+Tons of different types of captchas exist, but one of the most popular is Google's [**reCAPTCHA**](https://www.google.com/recaptcha/about/).
 
 ![Google's reCAPTCHA](https://miro.medium.com/max/1400/1*4NhFKMxr-qXodjYpxtiE0w.gif)
 

--- a/sources/academy/webscraping/anti_scraping/techniques/rate_limiting.md
+++ b/sources/academy/webscraping/anti_scraping/techniques/rate_limiting.md
@@ -52,7 +52,7 @@ const myCrawler = new PuppeteerCrawler({
 
 ### Configuring a session pool {#configuring-session-pool}
 
-There are various configuration options available in `sessionPoolOptions` that can be used to set up the SessionPool for different rate-limiting scenarios. In the example above, we used `maxUsageCount` within `sessionOptions` to prevent more than 15 requests from being sent using a session before it was thrown away; however, a maximum age can also be set using `maxAgeSecs`.
+To set up the SessionPool for different rate-limiting scenarios, you can use various configuration options in `sessionPoolOptions`. In the example above, we used `maxUsageCount` within `sessionOptions` to prevent more than 15 requests from being sent using a session before it was thrown away; however, a maximum age can also be set using `maxAgeSecs`.
 
 When dealing with frequent and unpredictable blockage, the `maxErrorScore` option can be set to trash a session after it's hit a certain number of errors.
 

--- a/sources/academy/webscraping/puppeteer_playwright/browser.md
+++ b/sources/academy/webscraping/puppeteer_playwright/browser.md
@@ -78,7 +78,7 @@ Now we'll actually see a browser open up.
 
 ![Chromium browser opened by Puppeteer/Playwright](./images/chromium.jpg)
 
-There are a whole lot more options that we can pass into the `launch()` function, which we'll be getting into a little bit later on.
+You can pass a whole lot more options to the `launch()` function. We'll be getting into those a little bit later on.
 
 ## Browser methods {#browser-methods}
 

--- a/sources/academy/webscraping/puppeteer_playwright/executing_scripts/index.md
+++ b/sources/academy/webscraping/puppeteer_playwright/executing_scripts/index.md
@@ -44,7 +44,7 @@ When we try and run this, we get this error:
 ReferenceError: document is not defined
 ```
 
-The reason this is happening is because we're trying to run browser-side code on the server-side where it is not supported. [`document`](https://developer.mozilla.org/en-US/docs/Web/API/Document) is a property of the browser [**Window**](https://developer.mozilla.org/en-US/docs/Web/API/Window) instance that holds the rendered website; therefore, this API is not available in Node.js. So how are we supposed to run code within the context of the browser?
+The reason this is happening is because we're trying to run browser-side code on the server-side where it is not supported. [`document`](https://developer.mozilla.org/en-US/docs/Web/API/Document) is a property of the browser [**Window**](https://developer.mozilla.org/en-US/docs/Web/API/Window) instance that holds the rendered website; therefore, this API is not available in Node.js. How are we supposed to run code within the context of the browser?
 
 ## Running code in the context of the browser {#running-in-browser-context}
 

--- a/sources/academy/webscraping/puppeteer_playwright/index.md
+++ b/sources/academy/webscraping/puppeteer_playwright/index.md
@@ -19,7 +19,7 @@ import TabItem from '@theme/TabItem';
 
 > A headless browser is just a regular browser like the one you're using right now, but without the user-interface. Because they don't have a UI, they generally perform faster as they don't render any visual content. For an in-depth understanding of headless browsers, check out [this short article](https://blog.arhg.net/2009/10/what-is-headless-browser.html) about them.
 
-Both packages were developed by the same team and are very similar, which is why we have combined the Puppeteer course and the Playwright course into one super-course that shows code examples for both technologies. There are some small differences between the two, which will be highlighted in the examples.
+Both packages were developed by the same team and are very similar, which is why we have combined the Puppeteer course and the Playwright course into one super-course that shows code examples for both technologies. The two differ in only small ways, and those will always be highlighted in the examples.
 
 > Each lesson's activity will contain examples for both libraries, but we recommend using Playwright, as it is newer and has more features and better [documentation](https://playwright.dev/docs/intro)
 

--- a/sources/academy/webscraping/scraping_basics_javascript/crawling/finding_links.md
+++ b/sources/academy/webscraping/scraping_basics_javascript/crawling/finding_links.md
@@ -13,7 +13,7 @@ import Example from '!!raw-loader!roa-loader!./finding_links.js';
 
 ---
 
-There are many kinds of links on the internet, which we'll cover in the advanced Academy courses. For now, let's think of links as [HTML anchor elements](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a) with `<a>` tags. A typical link looks like this:
+Many kinds of links exist on the internet, and we'll cover all the types in the advanced Academy courses. For now, let's think of links as [HTML anchor elements](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a) with `<a>` tags. A typical link looks like this:
 
 ```HTML
 <a href="https://example.com">This is a link to example.com</a>
@@ -25,7 +25,7 @@ On a webpage, the link above will look like this: [This is a link to example.com
 
 ## Extracting links 🔗 {#extracting-links}
 
-So, if a link is just an HTML element, and the URL is just an attribute, this means that we can extract links exactly the same way as we extracted data.💡 Easy!
+If a link is just an HTML element, and the URL is just an attribute, this means that we can extract links exactly the same way as we extracted data.💡 Easy!
 
 To test this theory in the browser, we can try running the following code in our DevTools console on any website.
 

--- a/sources/academy/webscraping/scraping_basics_javascript/crawling/first_crawl.md
+++ b/sources/academy/webscraping/scraping_basics_javascript/crawling/first_crawl.md
@@ -11,7 +11,7 @@ slug: /web-scraping-for-beginners/crawling/first-crawl
 
 ---
 
-In the previous lessons, we learned what crawling is and how to extract URLs from a page's HTML. The only thing that remains is to write the code - so let's get right to it!
+In the previous lessons, we learned what crawling is and how to extract URLs from a page's HTML. The only thing that remains is to write the code—let's get right to it!
 
 > If the code starts to look too complex to you, don't worry. We're showing it for educational purposes, so that you can learn how crawling works. Near the end of this course, we'll show you a much easier and faster way to crawl, using a specialized scraping library. If you want, you can skip the details and [go there now](./pro_scraping.md).
 

--- a/sources/academy/webscraping/scraping_basics_javascript/crawling/headless_browser.md
+++ b/sources/academy/webscraping/scraping_basics_javascript/crawling/headless_browser.md
@@ -85,7 +85,7 @@ The `parseWithCheerio` function is available even in `CheerioCrawler` and all th
 
 When you run the code with `node browser.js`, you'll see a browser window open and then the individual pages getting scraped, each in a new browser tab.
 
-So, that's it. In 4 lines of code, we transformed our crawler from a static HTTP crawler to a headless browser crawler. The crawler now runs exactly the same as before, but uses a Chromium browser instead of plain HTTP requests. This simply is not possible without Crawlee.
+That's it. In 4 lines of code, we transformed our crawler from a static HTTP crawler to a headless browser crawler. The crawler now runs exactly the same as before, but uses a Chromium browser instead of plain HTTP requests. This simply is not possible without Crawlee.
 
 Using Playwright in combination with Cheerio like this is only one of many ways how you can utilize Playwright (and Puppeteer) with Crawlee. In the advanced courses of the Academy, we will go deeper into using headless browsers for scraping and web automation (RPA) use cases.
 

--- a/sources/academy/webscraping/scraping_basics_javascript/data_extraction/index.md
+++ b/sources/academy/webscraping/scraping_basics_javascript/data_extraction/index.md
@@ -12,7 +12,7 @@ slug: /web-scraping-for-beginners/data-extraction
 
 ---
 
-Every web scraping project starts with some detective work. To a human, it's completely obvious where the data is on the web page, but a computer needs very precise instructions to find the data we want. There are three elementary components of each website that we can leverage to give those instructions: HTML, CSS, and JavaScript.
+Every web scraping project starts with some detective work. To a human, it's completely obvious where the data is on the web page, but a computer needs very precise instructions to find the data we want. We can leverage three elementary components of each website to give those instructions: HTML, CSS, and JavaScript
 
 ## HTML {#html}
 

--- a/sources/academy/webscraping/scraping_basics_javascript/data_extraction/save_to_csv.md
+++ b/sources/academy/webscraping/scraping_basics_javascript/data_extraction/save_to_csv.md
@@ -132,7 +132,7 @@ const csv = parse(results);
 writeFileSync('products.csv', csv); // <---- added writing of CSV to file
 ```
 
-Finally, run it with `node main.js` in your terminal. After running it, you will find the **products.csv** file in your project folder. And when you open it with Excel/Google Sheets – voila!
+Finally, run it with `node main.js` in your terminal. After running it, you will find the **products.csv** file in your project folder. And when you open it with Excel/Google Sheets—voila!
 
 ![Displaying CSV data in Google Sheets](./images/csv-data-in-sheets.png)
 

--- a/sources/academy/webscraping/scraping_basics_javascript/data_extraction/using_devtools.md
+++ b/sources/academy/webscraping/scraping_basics_javascript/data_extraction/using_devtools.md
@@ -87,7 +87,7 @@ The list is called a `NodeList`, because browsers understand a HTML document as 
 
 ## How to choose good selectors {#choose-good-selectors}
 
-There are always multiple ways to select an element using CSS selectors. Try to choose selectors that are **simple**, **human-readable**, **unique** and **semantically connected** to the data. Selectors that meet these criteria are sometimes called **resilient selectors**, because they're the most reliable and least likely to change with website updates. If you can, avoid randomly generated attributes like `class="F4jsL8"`. They change often and without warning.
+Often you can select the same element with different CSS selectors. Try to choose selectors that are **simple**, **human-readable**, **unique** and **semantically connected** to the data. Selectors that meet these criteria are sometimes called **resilient selectors**, because they're the most reliable and least likely to change with website updates. If you can, avoid randomly generated attributes like `class="F4jsL8"`. They change often and without warning.
 
 The `product-item` class is simple, human-readable, and semantically connected with the data. The subwoofer is one of the products. A product item. Those are strong signals that this is a good selector. It's also sufficiently unique in the website's context. If the selector was only an `item`, for example, there would be a higher chance that the website's developers would add this class to something unrelated. Like an advertisement. And it could break your extraction code.
 

--- a/sources/academy/webscraping/scraping_basics_javascript/introduction.md
+++ b/sources/academy/webscraping/scraping_basics_javascript/introduction.md
@@ -16,7 +16,7 @@ Web scraping or crawling? Web data extraction, mining, or collection? You can fi
 
 ## What is web data extraction? {#what-is-data-extraction}
 
-Web data extraction (or collection) is a process that takes a web page, like an Amazon product page, and collects useful information from the page, such as the product's name and price. Web pages are an unstructured data source and the goal of web data extraction is to make information from websites structured, so that it can be easily processed by data analysis tools or integrated with computer systems. The main sources of data on a web page are HTML documents and API calls, but also images, PDFs, and so on.
+Web data extraction (or collection) is a process that takes a web page, like an Amazon product page, and collects useful information from the page, such as the product's name and price. Web pages are an unstructured data source and the goal of web data extraction is to make information from websites structured, so that it can be easily processed by data analysis tools or integrated with computer systems. The main sources of data on a web page are HTML documents and API calls, but also images, PDFs, etc.
 
 ![product data extraction from Amazon](./images/beginners-data-extraction.png)
 

--- a/sources/platform/actors/development/builds_and_runs/state_persistence.md
+++ b/sources/platform/actors/development/builds_and_runs/state_persistence.md
@@ -33,11 +33,11 @@ A migration is when a process running on a server has to stop and move to anothe
 
 ## [](#how-often-do-migrations-occur)How often do migrations occur?
 
-There is no specified interval at which migrations happen. They are caused by the [above events](#why-do-migrations-happen), so they can happen at any time.
+Migrations have no specific interval at which they happen. They are caused by the [above events](#why-do-migrations-happen), so they can happen at any time.
 
 ## [](#why-is-state-lost-during-migration)Why is state lost during migration?
 
-Unless instructed to save its output or state to a [storage](../../../storage/index.md), an Actor keeps them in the server's memory. So, when it switches servers, the run loses access to the previous server's memory. Even if data were saved on the server's disk, we would also lose access to that.
+Unless instructed to save its output or state to a [storage](../../../storage/index.md), an Actor keeps them in the server's memory. When it switches servers, the run loses access to the previous server's memory. Even if data were saved on the server's disk, we would also lose access to that.
 
 ## [](#how-to-persist-state)How to persist state
 

--- a/sources/platform/actors/development/deployment/automated_tests.md
+++ b/sources/platform/actors/development/deployment/automated_tests.md
@@ -17,7 +17,7 @@ We recommend using the Actor Testing Actor for specific and advanced use cases. 
 
 ## Step-by-step guide
 
-1. Prepare 1-5 separate testing tasks for your Actor. ([See below](#set-up-tasks-you-will-test)).
+1. Prepare 1–5 separate testing tasks for your Actor. ([See below](#set-up-tasks-you-will-test)).
 2. Set up a task from the Actor Testing Actor. ([See below](#set-up-a-task-from-the-actor-testing-actor)).
 3. Run the test task until all tests succeed (a few times).
 4. Schedule the test to run at the frequency of your choice (recommended daily) and choose a communication channel receiving info about it ([Slack](https://apify.com/katerinahronik/slack-message) or [email](https://apify.com/apify/send-mail)).
@@ -27,7 +27,7 @@ We recommend using the Actor Testing Actor for specific and advanced use cases. 
 
 ![Tasks that test an Actor's configurations](./images/testing-tasks.png)
 
-We also advise you to test your Actor's default run – one that uses the pre-filled inputs. It is often the first task your users run, and they may be put off if it doesn't work.
+We also advise you to test your Actor's default run—one that uses the pre-filled inputs. It is often the first task your users run, and they may be put off if it doesn't work.
 
 Set a low `maxItem` value for your testing tasks, so that you don't burn your credit. If you need to test your Actor with a large amount of data, set the scheduler to run less frequently.
 

--- a/sources/platform/actors/development/deployment/index.md
+++ b/sources/platform/actors/development/deployment/index.md
@@ -32,7 +32,7 @@ When you deploy an Actor using the CLI, the code gets deployed as "multiple sour
 
 ## Other ways (Zip, Git, Gist)
 
-There are more ways how to deploy your Actor to the Apify platform. But in this case, you need to first manually create the Actor in [Apify Console](https://my.apify.com/actors), and then you can switch its source type:
+If you want to deploy an Actor in a different way, you need to first manually create the Actor in [Apify Console](https://my.apify.com/actors). Then switch its source type:
 
 ![Actor source types](./images/actor-source-types.png)
 

--- a/sources/platform/actors/development/performance.md
+++ b/sources/platform/actors/development/performance.md
@@ -9,7 +9,7 @@ slug: /actors/development/performance
 
 ---
 
-There are many ways to improve the performance of your Actors. This guide will help you understand the different ways to improve your performance and how to measure it.
+You can improve performance of your Actors in many ways. This guide will help you understand the different ways to improve your performance and how to measure it.
 
 ## Optimization Tips
 

--- a/sources/platform/actors/development/programming_interface/environment_variables.md
+++ b/sources/platform/actors/development/programming_interface/environment_variables.md
@@ -42,8 +42,9 @@ The Actor's process has several environment variables set to provide it with con
 | `ACTOR_WEB_SERVER_PORT`            | TCP port on which the Actor can start an HTTP server to receive messages from the outside world.                                                                                                                                                       |
 | `ACTOR_WEB_SERVER_URL`             | A unique public URL under which the Actor run web server is accessible from the outside world.                                                                                                                                                         |
 
-
+<!-- vale Microsoft.RangeFormat = NO -->
 Dates are always in the UTC timezone and are represented in simplified extended ISO format ([ISO 8601](https://en.wikipedia.org/wiki/ISO_8601)), e.g. **2022-07-13T14:23:37.281Z**.
+<!-- vale Microsoft.RangeFormat = YES -->
 
 <Tabs groupId="main">
 <TabItem value="JavaScript" label="JavaScript">

--- a/sources/platform/actors/development/programming_interface/metamorph.md
+++ b/sources/platform/actors/development/programming_interface/metamorph.md
@@ -16,7 +16,7 @@ This feature is useful if you want to use another Actor to finish the work of yo
 
 Internally, the system stops the Docker container corresponding to the Actor run and starts a new container using a different Docker image. All the default storages are preserved, and the new input is stored under the **INPUT-METAMORPH-1** key in the same default key-value store.
 
-There is a limit on how many times you can metamorph a single run. You can check the limit in [the Actor runtime limits](/platform/limits#actor-limits).
+You are limited in how many times you can metamorph a single run. Check the limit in [the Actor runtime limits](/platform/limits#actor-limits).
 
 To make your Actor compatible with the metamorph operation, use `Actor.getInput()` instead of `Actor.getValue('INPUT')`. This method will fetch the input using the right key **INPUT-METAMORPH-1** in case of a metamorphed run.
 

--- a/sources/platform/actors/development/quick_start/index.mdx
+++ b/sources/platform/actors/development/quick_start/index.mdx
@@ -5,7 +5,7 @@ description: Create your first Actor using the Apify Console IDE or locally.
 slug: /actors/development/quick-start
 ---
 
-# Development: quick start
+# Development: Quick start
 
 **Create your first Actor using the Apify Console IDE or locally.**
 
@@ -28,7 +28,7 @@ For these languages, you can also choose from many code templates that help you 
 
 ## [](#local-development)Local development
 
-There are two ways to create an Actor:
+You can create Actor in two ways:
 
 - Using the **Web IDE** in [Apify Console](https://console.apify.com). This is the fastest way to kick-start your Actor development and try out the Apify platform.
 - Develop your Actor **locally** and only deploy to the Apify platform when it is production ready. This way, you benefit from your local setup for a better development and debugging experience. After you are done with the development, you can easily [deploy](./deployment) your Actor to Apify platform.

--- a/sources/platform/actors/development/quick_start/start_locally.md
+++ b/sources/platform/actors/development/quick_start/start_locally.md
@@ -45,7 +45,7 @@ apify create
 
 The CLI will prompt you to:
 
-1. _Name your Actor_: Enter a descriptive name for your actor, such as `your-actor-name`
+1. _Name your Actor_: Enter a descriptive name for your Actor, such as `your-actor-name`
 1. _Choose a programming language_: Select the language you want to use for your Actor (JavaScript, TypeScript, or Python).
 1. _Select a development template_: Choose a template from the list of available options.
 

--- a/sources/platform/actors/development/quick_start/start_web_ide.md
+++ b/sources/platform/actors/development/quick_start/start_web_ide.md
@@ -30,7 +30,7 @@ You will be redirected to a page containing various Actor development templates 
 
 ![Templates](./images/actor-create-templates.png)
 
-After choosing the template your actor will be automatically named and you will be redirected to its page.
+After choosing the template your Actor will be automatically named and you will be redirected to its page.
 
 ### Explore the source code
 

--- a/sources/platform/actors/publishing/index.mdx
+++ b/sources/platform/actors/publishing/index.mdx
@@ -11,7 +11,7 @@ slug: /actors/publishing
 
 > Sharing is caring but you can also make money from your Actors. Our [blog post](https://blog.apify.com/make-regular-passive-income-developing-web-automation-actors-b0392278d085/) contains all the information you need.
 
-There are four main stages of building a public Actor:
+To build a public Actor, you'll go through the following four main stages:
 
 1. [Development](../development/index.md).
 2. [Publication](./publishing/publish) and set up of [monetization](./publishing/monetize).
@@ -22,7 +22,7 @@ While you don't necessarily have to maintain your private Actors, public Actors 
 
 As the name implies, Public Actors are available to the public on [Apify Store](https://apify.com/store), which means that an unmaintained public Actor could negatively affect all the other users that depend on it for their own activities on the platform.
 
-Public Actors are regularly submitted to [automated tests](./testing.mdx) to ensure they are functioning properly. So, before making an Actor public, we recommend you reserve enough time to maintain the project (~2 hours weekly). This will ensure that your Actor maintains its long-term quality, improving your chances of successfully [monetizing your Actors](./monetize.mdx).
+Public Actors are regularly submitted to [automated tests](./testing.mdx) to ensure they are functioning properly. Before making an Actor public, we recommend you reserve enough time to maintain the project (~2 hours weekly). This will ensure that your Actor maintains its long-term quality, improving your chances of successfully [monetizing your Actors](./monetize.mdx).
 
  <img src={require("./images/apify-store.png").default} title="Apify Store" width="60%" />
 

--- a/sources/platform/actors/publishing/index.mdx
+++ b/sources/platform/actors/publishing/index.mdx
@@ -30,7 +30,7 @@ If you decide to make your Actor code publicly available on [GitHub](https://git
 
 Naturally, your Actor's code should be open to changes and updates, so don't be afraid of refactoring. However, beware of making changes that could potentially break the Actor for its existing users.
 
-If you plan on making a breaking change, please get in touch with us ahead of time at community@apify.com, and we will help you to communicate the change to your users.
+If you plan on making a breaking change, please get in touch with us ahead of time at [community@apify.com](mailto:community@apify.com), and we will help you to communicate the change to your users.
 
 Also, pay special attention to your Actor's documentation ([README](../../academy/get-most-of-actors/actor-readme)). It should be clear, detailed, and readable. Think of the users, who might not be developers, so try to use simple, easy-to-understand language and avoid technical jargon.
 

--- a/sources/platform/actors/publishing/publish.mdx
+++ b/sources/platform/actors/publishing/publish.mdx
@@ -21,7 +21,7 @@ The Actor's description is a short paragraph describing the Actor's purpose. It 
 
 ![Actor title and description](./images/actor-title-description.webp)
 
-While writing your Actor's description, you also have the option to write an SEO title and description. The SEO title and description are used in place of the Actor name and description on search engine results pages. Good SEO titles and descriptions utilize popular keywords, summarize the Actor functionality, and are between 40-50 and 140-156 characters long respectively.
+While writing your Actor's description, you also have the option to write an SEO title and description. The SEO title and description are used in place of the Actor name and description on search engine results pages. Good SEO titles and descriptions utilize popular keywords, summarize the Actor functionality, and are between 40–50 and 140–156 characters long respectively.
 
 ![SEO title and description](./images/actor-SEO.webp)
 

--- a/sources/platform/actors/running/index.md
+++ b/sources/platform/actors/running/index.md
@@ -38,7 +38,7 @@ Alternatively, you can play around with the settings to make the results more in
 
 The Actor might take a while to gather its first results and finish its run. Meanwhile, let's take some time to explore the platform options:
 
-- There are more tabs providing you with information about the Actor run. For example, you can access the run **Log** and **Storage**.
+- Note the other tabs, which provide you with information about the Actor run. For example, you can access the run **Log** and **Storage**.
 - At the top right, you can click on the API button to explore the related API endpoints
 
 ![Run](./images/actor-google-maps-scraper-running.png)
@@ -70,7 +70,7 @@ An Actor's input and its content type can be passed as a payload of the POST req
 
 ## Running programmatically
 
-Actors can also be invoked programmatically from your own applications or from other actors.
+Actors can also be invoked programmatically from your own applications or from other Actors.
 
 To start an Actor from your own application, we recommend using our API client libraries for [JavaScript](/api/client/js/reference/class/ActorClient#call) or [Python](/api/client/python/reference/class/ActorClient#call).
 

--- a/sources/platform/actors/running/usage_and_resources.md
+++ b/sources/platform/actors/running/usage_and_resources.md
@@ -56,7 +56,7 @@ The Actor has hard disk space limited by twice the amount of memory. For example
 
 ## Requirements
 
-Actors built with [Crawlee](https://crawlee.dev/) use autoscaling. This means that they will always run as efficiently as they can based on the allocated memory. So, if you double the allocated memory, the run should be twice as fast and consume the same amount of compute units (1 * 1 = 0.5 * 2).
+Actors built with [Crawlee](https://crawlee.dev/) use autoscaling. This means that they will always run as efficiently as they can based on the allocated memory. If you double the allocated memory, the run should be twice as fast and consume the same amount of compute units (1 * 1 = 0.5 * 2).
 
 A good middle ground is `4096MB`. If you need the results faster, increase the memory (bear in mind the [next point](#maximum-memory), though). You can also try decreasing it to lower the pressure on the target site.
 

--- a/sources/platform/collaboration/index.md
+++ b/sources/platform/collaboration/index.md
@@ -10,7 +10,7 @@ slug: /collaboration
 
 ---
 
-By default, each system resource (Actor, key-value store, run, ...) you create is only available to you, the owner. There are three ways you can grant access to your resources:
+By default, each system resource (Actor, key-value store, run, ...) you create is only available to you, the owner. You can grant access to your resources in three ways:
 
 <table>
     <tr>

--- a/sources/platform/collaboration/organization_account/how_to_use.md
+++ b/sources/platform/collaboration/organization_account/how_to_use.md
@@ -23,7 +23,7 @@ You can switch into **Organization account** view using the account button in th
 
 ![Switch to organization account](../images/organizations/switch-to-organization.png)
 
-In the menu, the account you are currently using is displayed at the top, with all the accounts you can switch to displayed below. When you need to get back to your personal account, you can just switch right back to it – no need to log in and out.
+In the menu, the account you are currently using is displayed at the top, with all the accounts you can switch to displayed below. When you need to get back to your personal account, you can just switch right back to it—no need to log in and out.
 
 The resources you can access and account details you can edit will depend on your [permissions](../list_of_permissions.md) in the organization.
 

--- a/sources/platform/console/billing.md
+++ b/sources/platform/console/billing.md
@@ -34,7 +34,7 @@ Since billing cycles can shift, the data in the **Historical usage** tab is show
 
 Below the bar chart, there is a table titled **Usage by Actors**. This table presents a detailed breakdown of the Compute units used per Actor and the associated costs. It clearly explains how each Actor contributes to your overall platform usage and expenses.
 
-![Apify Console historical usage by actor view](./images/console-billing-historical-usage-by-actors.png)
+![Apify Console historical usage by Actor view](./images/console-billing-historical-usage-by-actors.png)
 
 ## Subscription
 
@@ -53,7 +53,7 @@ Another feature of this tab is the visibility of any special offers currently ap
 
 _This option is available only if you are on a subscription plan_.
 
-You can extend your subscription plans with add-ons, like extra proxies, actor memory, and more.
+You can extend your subscription plans with add-ons, like extra proxies, Actor memory, and more.
 Navigate to [Subscription](https://console.apify.com/billing/subscription) section in Apify Console, and click the **Buy add-ons** button to explore the available options.
 
 :::

--- a/sources/platform/integrations/integrate_with_apify.md
+++ b/sources/platform/integrations/integrate_with_apify.md
@@ -18,7 +18,7 @@ and many more that you can see at [integrations](./index.mdx).
 
 To integrate your service with Apify, you have two options. You can either:
 
-- build an [Apify actor](https://apify.com/docs/actor) that will be used as integration within the [Apify Console](https://console.apify.com)
+- build an [Apify Actor](https://apify.com/docs/actor) that will be used as integration within the [Apify Console](https://console.apify.com)
 - build an external integration, such as [Zapier](./workflows-and-notifications/zapier.md).
 
 ![Integration-ready Actors](./images/integration-ready-actors.png)

--- a/sources/platform/integrations/programming/webhooks/actions.md
+++ b/sources/platform/integrations/programming/webhooks/actions.md
@@ -138,6 +138,6 @@ Description is an optional string that you can add to the webhook. It serves for
 
 #### Resource
 
-The `resource` variable represents the triggering system resource. For example, when using the `ACTOR.RUN.SUCCEEDED` event, the resource is the Actor run. The variable will be replaced by the `Object` that you would receive as a response from the relevant API at the moment when the webhook is triggered. So for the Actor run resource, it would be the response of the [Get Actor run](/api/v2#/reference/actors/run-object-deprecated/get-run) API endpoint.
+The `resource` variable represents the triggering system resource. For example, when using the `ACTOR.RUN.SUCCEEDED` event, the resource is the Actor run. The variable will be replaced by the `Object` that you would receive as a response from the relevant API at the moment when the webhook is triggered. For the Actor run resource, it would be the response of the [Get Actor run](/api/v2#/reference/actors/run-object-deprecated/get-run) API endpoint.
 
 In addition to Actor runs, webhooks also support various events related to Actor builds. In such cases, the resource object will look like the response of the [Get Actor build](/api/v2#/reference/actor-builds/build-object/get-build) API endpoint.

--- a/sources/platform/monitoring/index.md
+++ b/sources/platform/monitoring/index.md
@@ -78,7 +78,7 @@ While the in-app notification will contain less information, it will point you d
 
 ### What should I monitor when scraping?
 
-There are many metrics you might want to monitor when you are scraping the web. Here are some examples:
+You might want to monitor various metrics when you're scraping the web. Here are some examples:
 
 **Data quality**:
 

--- a/sources/platform/proxy/datacenter_proxy.md
+++ b/sources/platform/proxy/datacenter_proxy.md
@@ -37,7 +37,7 @@ When using Apify's datacenter proxies, you can either select a proxy group, or t
 
 ### Shared proxy groups {#shared-proxy-groups}
 
-Each user has access to a selected number of proxy servers from a shared pool. These servers are spread into groups (called proxy groups). Each group shares a common feature (location, provider, speed and so on).
+Each user has access to a selected number of proxy servers from a shared pool. These servers are spread into groups (called proxy groups). Each group shares a common feature (location, provider, speed, etc.).
 
 For a full list of plans and number of allocated proxy servers for each plan, see our [pricing](https://apify.com/pricing). To get access to more servers, you can upgrade your plan in the [subscription settings](https://console.apify.com/billing/subscription);
 
@@ -185,7 +185,7 @@ When you use datacenter proxy with the `session` [parameter](./usage.md#sessions
 
 This IP/session ID combination is persisted and expires 26 hours later. Each additional request resets the expiration time to 26 hours.
 
-So, if you use the session at least once a day, it will never expire, with two possible exceptions:
+If you use the session at least once a day, it will never expire, with two possible exceptions:
 
 * The proxy server stops responding and is marked as dead during a health check.
 * If the proxy server is part of a proxy group that is refreshed monthly and is rotated out.

--- a/sources/platform/storage/usage.md
+++ b/sources/platform/storage/usage.md
@@ -31,7 +31,7 @@ The [key-value store](./key_value_store.md) is ideal for saving data records suc
 
 ## Basic usage {#basic-usage}
 
-There are several ways to access your storage:
+You can access your storage in several ways:
 
 * [Apify Console](https://console.apify.com/storage) - provides an easy-to-use interface.
 * [Apify API](/api/v2#/reference/key-value-stores) - to access your storages programmatically.
@@ -52,7 +52,9 @@ Additionally, you can quickly share the contents and details of your storage by 
 
 ![Storage API](./images/overview-api.png)
 
+<!-- vale Microsoft.Dashes = NO -->
 These URLs link to API _endpoints_—the places where your data is stored. Endpoints that allow you to _read_ stored information do not require an [authentication token](/api/v2#/introduction/authentication). Calls are authenticated using a hard-to-guess ID, allowing for secure sharing. However, operations such as _update_ or _delete_ require the authentication token.
+<!-- vale Microsoft.Dashes = YES -->
 
 > Never share a URL containing your authentication token, to avoid compromising your account's security. <br/>
 > If the data you want to share requires a token, first download the data, then share it as a file.

--- a/vale.ini
+++ b/vale.ini
@@ -12,9 +12,6 @@ mdx = md
 [*.md]
 BasedOnStyles = Apify, write-good, Microsoft
 
-# Ignore code surrounded by backticks or plus sign, parameters defaults, URLs.
-TokenIgnores = (\x60[^\n\x60]+\x60), ([^\n]+=[^\n]*), (\[(?=.*\.com(?:\/.*)?).+?])
-
 # Disabling rules (NO)
 Microsoft.Contractions = NO
 Microsoft.Foreign = NO


### PR DESCRIPTION
I removed `TokenIgnores`, as it clashes with rules being applied to link texts.

<img width="402" alt="Screenshot 2024-06-17 at 13 28 59" src="https://github.com/apify/apify-docs/assets/283441/0c42fc51-5d64-437b-a11f-a39eb979fc35">

Let's observe which annoying situations we have without it. For those we want to solve, let's create a separate GitHub Issue and I'll do my best with my regexp-fu to fine-tune Vale so that it's less annoying.

When I was at it, I accidentally fixed all outstanding errors. Just errors, not warnings 😅 