### PR TITLE
feat(ci): Add redirects for Crawlee to `nginx.conf`

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -1,5 +1,7 @@
 server {
   listen 0.0.0.0:8080;
+  server_name 'docs.apify.com';
+
   location / {
     proxy_pass https://apify.github.io/apify-docs/;
   }
@@ -299,4 +301,17 @@ server {
   # Removed pages
   # GPT plugins were discontinued April 9th, 2024 - https://help.openai.com/en/articles/8988022-winding-down-the-chatgpt-plugins-beta
   rewrite ^/platform/integrations/chatgpt-plugin$            https://blog.apify.com/add-custom-actions-to-your-gpts/ redirect;
+}
+
+# Temporarily used to route crawlee.dev to the Crawlee GitHub pages.
+# TODO: create a separate nginx deployment for Crawlee and move this there.
+server {
+  listen 0.0.0.0:8080;
+  server_name 'crawlee.dev';
+  location / {
+    proxy_pass https://apify.github.io/crawlee/;
+  }
+  location /python {
+    proxy_pass https://apify.github.io/crawlee-python/;
+  }
 }


### PR DESCRIPTION
This adds config for handling the `crawlee.dev` domain in the Apify Docs nginx. In the future, we should separate it into a separate nginx.

I've tested it locally and it seems to work when accessing the server with the right `Host` header.