### PR TITLE
fix: make standby headings h2

### DIFF
--- a/sources/platform/actors/development/programming_interface/actor_standby.md
+++ b/sources/platform/actors/development/programming_interface/actor_standby.md
@@ -13,7 +13,7 @@ Traditional Actors are designed to run a single task and then stop. They're most
 However, in some applications, waiting for an Actor to start is not an option. Actor Standby mode solves this problem by letting you have the Actor ready
 in the background, waiting for the incoming HTTP requests. In a sense, the Actor behaves like a real-time web server or standard API server.
 
-#### How can I develop Actors using Standby mode
+## How can I develop Actors using Standby mode
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
@@ -69,6 +69,6 @@ async def main() -> None:
 Please make sure to describe your Actors, their endpoints, and the schema for their
 inputs and ouputs in your README.
 
-#### Can I monetize my Actor in the Standby mode
+## Can I monetize my Actor in the Standby mode
 
 No, Standby mode is in Beta, and monetization is not supported.

--- a/sources/platform/actors/running/actor_standby.md
+++ b/sources/platform/actors/running/actor_standby.md
@@ -14,7 +14,7 @@ Traditional Actors are designed to run a single task and then stop. They're most
 However, in some applications, waiting for an Actor to start is not an option. Actor Standby mode solves this problem by letting you have the Actor ready
 in the background, waiting for the incoming HTTP requests. In a sense, the Actor behaves like a real-time web server or standard API server.
 
-#### How do I know if Standby mode is enabled?
+## How do I know if Standby mode is enabled?
 
 You will know that the Actor is enabled for Standby mode if you see the **Standby** tab on the Actor's detail page.
 In the tab, you will find the hostname of the server, the description of the Actor's endpoints,
@@ -25,18 +25,18 @@ hit the API endpoint and get results.
 
 ![Standby tab](./images/actor_standby/standby-tab.png)
 
-#### Can I still run the Actor in normal mode
+## Can I still run the Actor in normal mode
 
 Yes, you can still modify the input and click the Start button to run the Actor in normal mode. However, note that the Standby Actor might
 not support this mode; the run might fail or return empty results. The normal mode is always supported in Standby Beta, even for Actors that don't handle
 it well. Please head to the Actor README to learn more about the capabilities of your chosen Actor.
 
-#### Is there any scaling to accommodate the incoming requests
+## Is there any scaling to accommodate the incoming requests
 
 When you use the Actor in Standby mode, the system automatically scales the Actor to accommodate the incoming requests. Under the hood,
 the system starts new Actor runs, which you will see in the Actor runs tab, with the origin set to Standby.
 
-#### How do I customize Standby configuration
+## How do I customize Standby configuration
 
 The Standby configuration currently consists of the following properties:
 
@@ -51,15 +51,15 @@ use the Actor-level hostname, this will always use the default configuration. To
 You can then head to the Standby tab of the created Task and modify the configuration as needed. Note that the task has a specific hostname, so make
 sure to use that in your application if you wish to use the custom configuration.
 
-#### Are the Standby runs billed differently
+## Are the Standby runs billed differently
 
 No, the Standby runs are billed in the same fashion as the normal runs.
 However, running Actors in Standby mode might have unexpected costs, as the Actors run in the background and consume resources even when no requests are being sent until they are terminated after the idle timeout period.
 
-#### Are the Standby runs shared among users
+## Are the Standby runs shared among users
 
 No, even if you use the Actor-level hostname with the default configuration, the background Actor runs for your requests are not shared with other users.
 
-#### How can I develop Actors using Standby mode
+## How can I develop Actors using Standby mode
 
 See the [Actor Standby development section](../development/programming_interface/actor_standby.md).


### PR DESCRIPTION
This PR changes standby docs headings to H2 so they're displayed in the side bar.