### PR TITLE
fix: rewrite the P&P course intro

### DIFF
--- a/sources/academy/webscraping/puppeteer_playwright/index.md
+++ b/sources/academy/webscraping/puppeteer_playwright/index.md
@@ -15,9 +15,7 @@ import TabItem from '@theme/TabItem';
 
 ---
 
-[Puppeteer](https://pptr.dev/) and [Playwright](https://playwright.dev/) are both libraries which allow you to write code in Node.js which automates a headless browser.
-
-> A headless browser is just a regular browser like the one you're using right now, but without the user-interface. Because they don't have a UI, they generally perform faster as they don't render any visual content. For an in-depth understanding of headless browsers, check out [this short article](https://blog.arhg.net/2009/10/what-is-headless-browser.html) about them.
+[Puppeteer](https://pptr.dev/) and [Playwright](https://playwright.dev/) are libraries that allow you to automate browsing. Based on your instructions, they can open a browser window, load a website, click on links, etc. They can also do this _headlessly_, i.e., in a way that the browser window isn't visible, which is faster.
 
 Both packages were developed by the same team and are very similar, which is why we have combined the Puppeteer course and the Playwright course into one super-course that shows code examples for both technologies. The two differ in only small ways, and those will always be highlighted in the examples.
 


### PR DESCRIPTION
I decided not to replace https://blog.arhg.net/2009/10/what-is-headless-browser.html with anything else (e.g. https://en.wikipedia.org/wiki/Headless_browser). I don't think it's necessary to link any external content in the intro. The https://docs.apify.com/academy/web-scraping-for-beginners/crawling/headless-browser lesson already does a good enough job explaining what a headless browser is and has sufficient SEO qualities for the phrase.

Closes https://github.com/apify/apify-docs/issues/957