### PR TITLE
fix: remove cli image dimensions in landing page

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -235,8 +235,6 @@ export default function Home() {
                     <CardWithImageAndContent
                         image={
                             <ThemedImage
-                                height={24}
-                                width={24}
                                 sources={{
                                     light: useBaseUrl('/img/landing-pages/cli.svg'),
                                     dark: useBaseUrl('/img/landing-pages/cli_dark.svg'),


### PR DESCRIPTION
Somehow slipped in in my previous PR