### PR TITLE
fix: mention enabling ESM support

### DIFF
--- a/sources/academy/webscraping/scraping_basics_javascript/crawling/pro_scraping.md
+++ b/sources/academy/webscraping/scraping_basics_javascript/crawling/pro_scraping.md
@@ -61,6 +61,19 @@ import { CheerioCrawler } from 'crawlee';
 console.log('Crawlee works!');
 ```
 
+We are using the new ESM `import` syntax here (see [Node.js docs](https://nodejs.org/dist/latest-v16.x/docs/api/esm.html#enabling)). To be able to use it, we need to turn our project to `module` in the `package.json` file:
+
+```json title=package.json
+{
+    "name": "my-scraping-project",
+    // highlight-next-line
+    "type": "module",
+    "dependencies": {
+        "crawlee": "^3.0.0"
+    }
+}
+```
+
 Then, run the code using `node` as usual:
 
 ```shell


### PR DESCRIPTION
Adds a short paragraph with example package.json about the ESM modules.

https://docs.apify.com/academy/web-scraping-for-beginners/crawling/pro-scraping#crawlee-installation

<img width="789" alt="image" src="https://github.com/user-attachments/assets/8a8c5fcf-967b-4a2a-86b0-27980c400ca4">

Closes #1063