### PR TITLE
fix: remove hero section gradient

### DIFF
--- a/src/components/Hero/styles.module.css
+++ b/src/components/Hero/styles.module.css
@@ -38,22 +38,6 @@
     margin-bottom: 24px;
 }
 
-.heroBanner::after {
-    content: "";
-    position: absolute;
-    left: 0;
-    height: 56px;
-    width: 100%;
-    background: linear-gradient(180deg, #FFFFFF 0%, rgba(255, 255, 255, 0) 100%);
-    transform: matrix(1, 0, 0, -1, 0, 0);
-    pointer-events: none;
-}
-
-html[data-theme='dark'] .heroBanner::after {
-    background: linear-gradient(180deg, #1A1B21 0%, rgba(26, 27, 33, 0) 100%);
-    transform: matrix(1, 0, 0, -1, 0, 0);
-}
-
 .heroBanner .heroDescription {
    color: var(--color-neutral-text-muted);
 }


### PR DESCRIPTION
I haven't found that it was visible somewhere and it caused problems on mobile because it was covering content under it.

reported here:
https://apify.slack.com/archives/C0L33UM7Z/p1722246967335289