### PR TITLE
feat: change link checking to periodic

### DIFF
--- a/.github/workflows/lychee.yml
+++ b/.github/workflows/lychee.yml
@@ -1,55 +1,55 @@
 name: Periodic Link Checker
 
 on:
-  schedule:
-    - cron: '0 0 * * *'  # Run daily at midnight UTC
-  workflow_dispatch:  # Allow manual triggering
+    schedule:
+        - cron: '0 0 * * *'  # Run daily at midnight UTC
+    workflow_dispatch:  # Allow manual triggering
 
 jobs:
-  link-check:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
+    link-check:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
 
-      - name: Use Node.js 20
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: 'npm'
-          cache-dependency-path: 'package-lock.json'
-          always-auth: 'true'
-          registry-url: 'https://npm.pkg.github.com/'
-          scope: '@apify-packages'
+            - name: Use Node.js 20
+              uses: actions/setup-node@v4
+              with:
+                  node-version: 20
+                  cache: 'npm'
+                  cache-dependency-path: 'package-lock.json'
+                  always-auth: 'true'
+                  registry-url: 'https://npm.pkg.github.com/'
+                  scope: '@apify-packages'
 
-      - name: Build docs
-        run: |
-          npm ci --force
-          npm update @apify/openapi
-          npm run build
-        env:
-          APIFY_SIGNING_TOKEN: ${{ secrets.APIFY_SIGNING_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-          SMARTLOOK_PROJECT_KEY: ${{ secrets.SMARTLOOK_PROJECT_KEY }}
+            - name: Build docs
+              run: |
+                  npm ci --force
+                  npm update @apify/openapi
+                  npm run build
+              env:
+                  APIFY_SIGNING_TOKEN: ${{ secrets.APIFY_SIGNING_TOKEN }}
+                  NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+                  SMARTLOOK_PROJECT_KEY: ${{ secrets.SMARTLOOK_PROJECT_KEY }}
 
-      - name: Run Lychee Link Checker
-        id: lychee
-        uses: lycheeverse/lychee-action@v1.10.0
-        env:
-          GITHUB_TOKEN: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}
-        with:
-          fail: false
-          args: >
-            --base https://docs.apify.com
-            --exclude-path 'build/versions.html'
-            --max-retries 6
-            --verbose
-            --no-progress
-            --accept '100..=103,200..=299,403..=403,429'
-            --output ./lychee/out.md
-            --format markdown
-            './build/**/*.html'
-        continue-on-error: true
+            - name: Run Lychee Link Checker
+              id: lychee
+              uses: lycheeverse/lychee-action@v1.10.0
+              env:
+                  GITHUB_TOKEN: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}
+              with:
+                  fail: false
+                  args: >
+                      --base https://docs.apify.com
+                      --exclude-path 'build/versions.html'
+                      --max-retries 6
+                      --verbose
+                      --no-progress
+                      --accept '100..=103,200..=299,403..=403,429'
+                      --output ./lychee/out.md
+                      --format markdown
+                      './build/**/*.html'
+              continue-on-error: true
 
-      - name: Add job summary
-        if: always()
-        run: cat ./lychee/out.md >> $GITHUB_STEP_SUMMARY
+            - name: Add job summary
+              if: always()
+              run: cat ./lychee/out.md >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/lychee.yml
+++ b/.github/workflows/lychee.yml
@@ -2,54 +2,54 @@ name: Periodic Link Checker
 
 on:
     schedule:
-        - cron: '0 0 * * *'  # Run daily at midnight UTC
+        -   cron: '0 0 * * *'  # Run daily at midnight UTC
     workflow_dispatch:  # Allow manual triggering
 
 jobs:
     link-check:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v4
+            -   uses: actions/checkout@v4
 
-            - name: Use Node.js 20
-              uses: actions/setup-node@v4
-              with:
-                  node-version: 20
-                  cache: 'npm'
-                  cache-dependency-path: 'package-lock.json'
-                  always-auth: 'true'
-                  registry-url: 'https://npm.pkg.github.com/'
-                  scope: '@apify-packages'
+            -   name: Use Node.js 20
+                uses: actions/setup-node@v4
+                with:
+                    node-version: 20
+                    cache: 'npm'
+                    cache-dependency-path: 'package-lock.json'
+                    always-auth: 'true'
+                    registry-url: 'https://npm.pkg.github.com/'
+                    scope: '@apify-packages'
 
-            - name: Build docs
-              run: |
-                  npm ci --force
-                  npm update @apify/openapi
-                  npm run build
-              env:
-                  APIFY_SIGNING_TOKEN: ${{ secrets.APIFY_SIGNING_TOKEN }}
-                  NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-                  SMARTLOOK_PROJECT_KEY: ${{ secrets.SMARTLOOK_PROJECT_KEY }}
+            -   name: Build docs
+                run: |
+                    npm ci --force
+                    npm update @apify/openapi
+                    npm run build
+                env:
+                    APIFY_SIGNING_TOKEN: ${{ secrets.APIFY_SIGNING_TOKEN }}
+                    NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+                    SMARTLOOK_PROJECT_KEY: ${{ secrets.SMARTLOOK_PROJECT_KEY }}
 
-            - name: Run Lychee Link Checker
-              id: lychee
-              uses: lycheeverse/lychee-action@v1.10.0
-              env:
-                  GITHUB_TOKEN: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}
-              with:
-                  fail: false
-                  args: >
-                      --base https://docs.apify.com
-                      --exclude-path 'build/versions.html'
-                      --max-retries 6
-                      --verbose
-                      --no-progress
-                      --accept '100..=103,200..=299,403..=403,429'
-                      --output ./lychee/out.md
-                      --format markdown
-                      './build/**/*.html'
-              continue-on-error: true
+            -   name: Run Lychee Link Checker
+                id: lychee
+                uses: lycheeverse/lychee-action@v1.10.0
+                env:
+                    GITHUB_TOKEN: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}
+                with:
+                    fail: false
+                    args: >
+                        --base https://docs.apify.com
+                        --exclude-path 'build/versions.html'
+                        --max-retries 6
+                        --verbose
+                        --no-progress
+                        --accept '100..=103,200..=299,403..=403,429'
+                        --output ./lychee/out.md
+                        --format markdown
+                        './build/**/*.html'
+                continue-on-error: true
 
-            - name: Add job summary
-              if: always()
-              run: cat ./lychee/out.md >> $GITHUB_STEP_SUMMARY
+            -   name: Add job summary
+                if: always()
+                run: cat ./lychee/out.md >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/lychee.yml
+++ b/.github/workflows/lychee.yml
@@ -1,36 +1,61 @@
-name: Lychee Link Checker
+name: Periodic Link Checker
 
-on: [ pull_request ]
+on:
+  schedule:
+    - cron: '0 0 */3 * *'  # Run every 3 days at midnight UTC
+  workflow_dispatch:  # Allow manual triggering
 
 jobs:
-    link-check:
-        runs-on: ubuntu-latest
-        steps:
-            -   uses: actions/checkout@v4
+  link-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
 
-            -   name: Use Node.js 20
-                uses: actions/setup-node@v4
-                with:
-                    node-version: 20
-                    cache: 'npm'
-                    cache-dependency-path: 'package-lock.json'
-                    always-auth: 'true'
-                    registry-url: 'https://npm.pkg.github.com/'
-                    scope: '@apify-packages'
+      - name: Use Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+          cache-dependency-path: 'package-lock.json'
+          always-auth: 'true'
+          registry-url: 'https://npm.pkg.github.com/'
+          scope: '@apify-packages'
 
-            -   name: Build docs
-                run: |
-                    npm ci --force
-                    npm update @apify/openapi
-                    npm run build
-                env:
-                    APIFY_SIGNING_TOKEN: ${{ secrets.APIFY_SIGNING_TOKEN }}
-                    NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-                    SMARTLOOK_PROJECT_KEY: ${{ secrets.SMARTLOOK_PROJECT_KEY }}
+      - name: Build docs
+        run: |
+          npm ci --force
+          npm update @apify/openapi
+          npm run build
+        env:
+          APIFY_SIGNING_TOKEN: ${{ secrets.APIFY_SIGNING_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          SMARTLOOK_PROJECT_KEY: ${{ secrets.SMARTLOOK_PROJECT_KEY }}
 
-            -   uses: lycheeverse/lychee-action@v1.10.0
-                env:
-                    GITHUB_TOKEN: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}
-                with:
-                    fail: true
-                    args: --base https://docs.apify.com --exclude-path 'build/versions.html' --max-retries 6 --verbose --no-progress --accept '100..=103,200..=299,403..=403, 429' './build/**/*.html'
+      - name: Run Lychee Link Checker
+        id: lychee
+        uses: lycheeverse/lychee-action@v1.10.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}
+        with:
+          fail: false  # Changed to false so the workflow doesn't fail on broken links
+          args: >
+            --base https://docs.apify.com
+            --exclude-path 'build/versions.html'
+            --max-retries 6
+            --verbose
+            --no-progress
+            --accept '100..=103,200..=299,403..=403,429'
+            --output ./lychee/out.md
+            --format markdown
+            './build/**/*.html'
+
+      - name: Upload report as artifact
+        uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: Link Checker Report
+          path: ./lychee/out.md
+
+      - name: Add job summary
+        if: always()
+        run: cat ./lychee/out.md >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/lychee.yml
+++ b/.github/workflows/lychee.yml
@@ -2,7 +2,7 @@ name: Periodic Link Checker
 
 on:
   schedule:
-    - cron: '0 0 */3 * *'  # Run every 3 days at midnight UTC
+    - cron: '0 0 * * *'  # Run daily at midnight UTC
   workflow_dispatch:  # Allow manual triggering
 
 jobs:
@@ -37,7 +37,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}
         with:
-          fail: false  # Changed to false so the workflow doesn't fail on broken links
+          fail: false
           args: >
             --base https://docs.apify.com
             --exclude-path 'build/versions.html'
@@ -48,13 +48,7 @@ jobs:
             --output ./lychee/out.md
             --format markdown
             './build/**/*.html'
-
-      - name: Upload report as artifact
-        uses: actions/upload-artifact@v3
-        if: always()
-        with:
-          name: Link Checker Report
-          path: ./lychee/out.md
+        continue-on-error: true
 
       - name: Add job summary
         if: always()


### PR DESCRIPTION
Given the amount of false positives we run into at every time when we are adding a new page to docs, it makes sense to change the link checking job to periodic instead of at every PR.