### PR TITLE
fix: remove output arg from lychee workflow

### DIFF
--- a/.github/workflows/lychee.yml
+++ b/.github/workflows/lychee.yml
@@ -45,7 +45,6 @@ jobs:
                         --verbose
                         --no-progress
                         --accept '100..=103,200..=299,403..=403,429'
-                        --output ./lychee/out.md
                         --format markdown
                         './build/**/*.html'
                 continue-on-error: true


### PR DESCRIPTION
Somehow this gets called twice in the workflow and the action fails, so I want to try & remove it from here and check if this will make it work