### PR TITLE
chore: bump search modal version

### DIFF
--- a/apify-docs-theme/package.json
+++ b/apify-docs-theme/package.json
@@ -19,7 +19,7 @@
         "access": "public"
     },
     "dependencies": {
-        "@apify/docs-search-modal": "^1.0.25",
+        "@apify/docs-search-modal": "^1.0.26",
         "@docusaurus/theme-common": "^2.4.1",
         "@stackql/docusaurus-plugin-hubspot": "^1.1.0",
         "axios": "^1.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -68,7 +68,7 @@
             "version": "1.0.127",
             "license": "ISC",
             "dependencies": {
-                "@apify/docs-search-modal": "^1.0.25",
+                "@apify/docs-search-modal": "^1.0.26",
                 "@docusaurus/theme-common": "^2.4.1",
                 "@stackql/docusaurus-plugin-hubspot": "^1.1.0",
                 "axios": "^1.4.0",
@@ -556,9 +556,9 @@
             }
         },
         "node_modules/@apify/docs-search-modal": {
-            "version": "1.0.25",
-            "resolved": "https://registry.npmjs.org/@apify/docs-search-modal/-/docs-search-modal-1.0.25.tgz",
-            "integrity": "sha512-js0hX9sW06x4kvou22my3fpdHloHWJQnNmbojhbp8NVj9ofd7EFWfUWJrczU7GGVntnAeEqzrtiUSguRvKYGWw==",
+            "version": "1.0.26",
+            "resolved": "https://registry.npmjs.org/@apify/docs-search-modal/-/docs-search-modal-1.0.26.tgz",
+            "integrity": "sha512-/G37r+kIBuQALPfT2OA9ENV3Q1MCYwZ7T1Y5w7+J3cgs+ZtIJTT0CqsTC/N/CRKKVqDy1kQbkD46qLX32uDP3A==",
             "dependencies": {
                 "@algolia/autocomplete-js": "^1.10.0",
                 "@algolia/autocomplete-theme-classic": "^1.10.0",


### PR DESCRIPTION
Bumps the `@apify/docs-search-modal` version to include the changes from https://github.com/apify/docs-search-modal/pull/9 .

Completely closes https://github.com/apify/apify-docs/issues/1109