### PR TITLE
feat(UI): make h2 default section heading

### DIFF
--- a/src/components/Section/Section.tsx
+++ b/src/components/Section/Section.tsx
@@ -19,7 +19,7 @@ export default function Section({ heading, description, className, children, hea
     return (
         <section className={clsx(styles.section, className)}>
             {(heading || description) && <div className={styles.sectionHeader}>
-                {heading && <Heading className={headingClassName} type='title2Xl' as={headingAs}>{heading}</Heading>}
+                {heading && <Heading className={headingClassName} type="title2Xl" as={headingAs || 'h2'}>{heading}</Heading>}
                 {description && <Text color={theme.color.neutral.textMuted} size="large">{description}</Text>}
             </div>}
             {children}

--- a/src/pages/api/index.tsx
+++ b/src/pages/api/index.tsx
@@ -173,6 +173,7 @@ curl "https://api.apify.com/v2/datasets/<DATASET_ID>/items?token=<YOUR_API_TOKEN
                             content: (
                                 <SectionWrapper
                                     heading="JavaScript API client"
+                                    headingAs="h3"
                                     description={<div className="Description">
                                     The official library to interact with Apify API from a web browser, Node.js, JavaScript, or Typescript applications.
                                         <GitButton href="https://github.com/apify/apify-client-js" data-size="large" data-show-count="true">Star</GitButton>


### PR DESCRIPTION
All the headings on API page were h1. This PR makes sure default is h2 (Hero component renders h1)
Bug reported [here](https://apify.slack.com/archives/C0L33UM7Z/p1724076669177399)