### PR TITLE
docs(platform): update run data retention info

### DIFF
--- a/sources/academy/tutorials/apify_scrapers/getting_started.md
+++ b/sources/academy/tutorials/apify_scrapers/getting_started.md
@@ -73,7 +73,7 @@ In the settings tab, you can set options that are common to all tasks and not di
 
 ### [](#runs) Runs
 
-You can find all the task runs and their detail pages here. Every time you start a task, it will appear here in the list. All of your task's runs and their outcomes will be stored here for the data retention period, [which you can find under your plan](https://apify.com/pricing).
+You can find all the task runs and their detail pages here. Every time you start a task, it will appear here in the list. Apify securely stores your ten most recent runs indefinitely, ensuring your records are always accessible. All of your task's runs and their outcomes, beyond the latest ten, will be stored here for the data retention period, [which you can find under your plan](https://apify.com/pricing).
 
 ### [](#webhooks) Webhooks
 

--- a/sources/platform/actors/running/runs_and_builds.md
+++ b/sources/platform/actors/running/runs_and_builds.md
@@ -123,7 +123,7 @@ You can also adjust timeout and memory or change Actor build before the resurrec
 
 ### Data retention
 
-All **Actor runs** and default storages (Key-value store, Dataset, Request queue) are deleted after the data retention period, based on your [subscription plan](https://apify.com/pricing).
+Apify securely stores your ten most recent runs indefinitely, ensuring your records are always accessible. All **Actor runs** beyond the latest ten are deleted along with their default storages (Key-value store, Dataset, Request queue) after the data retention period based on your [subscription plan](https://apify.com/pricing).
 
 **Actor builds** are deleted only when they are _not tagged_ and have not been used for over 90 days.
 

--- a/sources/platform/storage/usage.md
+++ b/sources/platform/storage/usage.md
@@ -114,7 +114,7 @@ Go to the [API documentation](/api/v2#/introduction/rate-limiting) for details a
 
 ## Data retention {#data-retention}
 
- Apify securely stores your ten most recent runs indefinitely, ensuring your records are always accessible. Unnamed datasets and runs beyond the latest ten will be automatically deleted after 7 days unless otherwise specified. Named datasets are retained indefinitely.
+Apify securely stores your ten most recent runs indefinitely, ensuring your records are always accessible. Unnamed datasets and runs beyond the latest ten will be automatically deleted after 7 days unless otherwise specified. Named datasets are retained indefinitely.
 
 ### Preserving your storages {#preserving-storages}
 

--- a/sources/platform/storage/usage.md
+++ b/sources/platform/storage/usage.md
@@ -114,8 +114,7 @@ Go to the [API documentation](/api/v2#/introduction/rate-limiting) for details a
 
 ## Data retention {#data-retention}
 
-Named datasets are retained indefinitely.
-Unnamed datasets expire after 7 days unless otherwise specified.
+ Apify securely stores your ten most recent runs indefinitely, ensuring your records are always accessible. Unnamed datasets and runs beyond the latest ten will be automatically deleted after 7 days unless otherwise specified. Named datasets are retained indefinitely.
 
 ### Preserving your storages {#preserving-storages}
 


### PR DESCRIPTION
Change Free Retention "microcopy" -> following the update in console (apify-core repo), link to zenhub issue [here](https://app.zenhub.com/workspaces/platform-team-5f6454160d9f82000fa6733f/issues/gh/apify/apify-core/15694)

I have updated 2 places -> platform: runs and builds, and tutorials: tasks. Please, let me know if there is some other page where it suits well, thanks!

Issue:

> Right now we are (supposed to be) preserving the last 10 runs that a free-user made beyond 30 days. This is for reactivation and debugging purposes. We don't explain this to the user at all, so we should do a better job of that.

Updated sections in docs ⬇️ 
<img width="1111" alt="Screenshot 2024-08-22 at 10 46 57" src="https://github.com/user-attachments/assets/f5e1858b-ecdf-4cef-b40a-e19967bbf162">
<img width="924" alt="Screenshot 2024-08-22 at 10 45 13" src="https://github.com/user-attachments/assets/0406e136-9ddf-4ecc-8709-b3fcfdfb4f3d">
