### PR TITLE
fix: `publish-theme` action uses `secrets.NPM_TOKEN`

### DIFF
--- a/.github/workflows/publish-theme.yaml
+++ b/.github/workflows/publish-theme.yaml
@@ -55,7 +55,7 @@ jobs:
                     echo "access=public" > ~/.npmrc
                     echo "@apify-packages:registry=https://npm.pkg.github.com/" >> ~/.npmrc
                     echo "//registry.npmjs.org/:_authToken=${{ secrets.APIFY_SERVICE_ACCOUNT_NPM_TOKEN }}" >> ~/.npmrc
-                    echo "//npm.pkg.github.com/:_authToken=${{ secrets.NPM_TOKEN }}" >> ~/.npmrc
+                    echo "//npm.pkg.github.com/:_authToken=${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}" >> ~/.npmrc
 
             -   name: Bump the theme version
                 run: |

--- a/.github/workflows/publish-theme.yaml
+++ b/.github/workflows/publish-theme.yaml
@@ -32,7 +32,7 @@ jobs:
 
     publish:
         needs: look_for_change
-        if: needs.look_for_change.outputs.theme_changed == 'true'
+        if: ${{ needs.look_for_change.outputs.theme_changed == 'true' || github.event_name == 'workflow_dispatch' }}
         runs-on: ubuntu-latest
         steps:
             -   uses: actions/checkout@v4

--- a/.github/workflows/publish-theme.yaml
+++ b/.github/workflows/publish-theme.yaml
@@ -48,7 +48,7 @@ jobs:
                     registry-url: 'https://npm.pkg.github.com/'
                     scope: '@apify-packages'
                 env:
-                    NODE_AUTH_TOKEN: ${{ secrets.APIFY_SERVICE_ACCOUNT_NPM_TOKEN }}
+                    NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
             -   name: Setup git user and npm
                 run: |
@@ -56,14 +56,14 @@ jobs:
                     git config --global user.email "noreply@apify.com"
 
                     echo "access=public" > .npmrc
-                    echo "//registry.npmjs.org/:_authToken=${{ secrets.APIFY_SERVICE_ACCOUNT_NPM_TOKEN }}" >> .npmrc
+                    echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" >> .npmrc
 
             -   name: Bump the theme version
                 run: |
                     cd $GITHUB_WORKSPACE/apify-docs-theme
                     npm version patch --legacy-peer-deps
                 env:
-                    NODE_AUTH_TOKEN: ${{ secrets.APIFY_SERVICE_ACCOUNT_NPM_TOKEN }}
+                    NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
             -   name: Deploy theme to npm
                 run: |

--- a/.github/workflows/publish-theme.yaml
+++ b/.github/workflows/publish-theme.yaml
@@ -4,6 +4,7 @@ on:
     push:
         branches:
             - master
+    workflow_dispatch:
 
 jobs:
     look_for_change:
@@ -45,32 +46,27 @@ jobs:
                     cache: 'npm'
                     cache-dependency-path: 'package-lock.json'
                     always-auth: 'true'
-                    registry-url: 'https://npm.pkg.github.com/'
-                    scope: '@apify-packages'
-                env:
-                    NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
             -   name: Setup git user and npm
                 run: |
                     git config --global user.name "Apify Release Bot"
                     git config --global user.email "noreply@apify.com"
 
-                    echo "access=public" > .npmrc
-                    echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" >> .npmrc
+                    echo "access=public" > ~/.npmrc
+                    echo "@apify-packages:registry=https://npm.pkg.github.com/" >> ~/.npmrc
+                    echo "//registry.npmjs.org/:_authToken=${{ secrets.APIFY_SERVICE_ACCOUNT_NPM_TOKEN }}" >> ~/.npmrc
+                    echo "//npm.pkg.github.com/:_authToken=${{ secrets.NPM_TOKEN }}" >> ~/.npmrc
 
             -   name: Bump the theme version
                 run: |
                     cd $GITHUB_WORKSPACE/apify-docs-theme
                     npm version patch --legacy-peer-deps
-                env:
-                    NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
             -   name: Deploy theme to npm
                 run: |
                     cd $GITHUB_WORKSPACE/apify-docs-theme
                     npx -y publish-if-not-exists
                 env:
-                    NPM_TOKEN: ${{ secrets.APIFY_SERVICE_ACCOUNT_NPM_TOKEN }}
                     GIT_USER: "barjin:${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}"
                     GH_TOKEN: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}
 


### PR DESCRIPTION
Wherever applicable, this PR changes the NPM token to `secrets.NPM_TOKEN` to fix the issue with the `ui-packages` [STILL NOT BEING PUBLIC](https://github.com/apify/apify-docs/actions/runs/10681779569/job/29606166939) (I will never stop hating this.)

This does not replace the last occurrence of the token since I believe we need the old token (`APIFY_SERVICE_ACCOUNT_NPM_TOKEN`) to publish packages in the @apify workspace. This might be a question for @fnesveda - are any of the mentioned GH secrets organization-wide (and do you think we can publish packages with `secrets.NPM_TOKEN`?)