### PR TITLE
fix: update lesson to reflect changes in UI and in number of the repos (upstream branch)

### DIFF
--- a/sources/academy/webscraping/puppeteer_playwright/common_use_cases/paginating_through_results.md
+++ b/sources/academy/webscraping/puppeteer_playwright/common_use_cases/paginating_through_results.md
@@ -58,7 +58,7 @@ const firstPage = await browser.newPage();
 await firstPage.goto(REPOSITORIES_URL);
 
 const lastPageElement = firstPage.locator('a[aria-label*="Page "]:nth-last-child(2)');
-const lastPageLabel = await lastPageElement.getAttribute('aria-label')
+const lastPageLabel = await lastPageElement.getAttribute('aria-label');
 const lastPageNumber = Number(lastPageLabel.replace(/\D/g, ''));
 console.log(lastPageNumber);
 
@@ -81,7 +81,7 @@ await firstPage.goto(REPOSITORIES_URL);
 
 const lastPageLabel = await firstPage.$eval(
     'a[aria-label*="Page "]:nth-last-child(2)',
-    (element) => element.getAttribute('aria-label')
+    (element) => element.getAttribute('aria-label'),
 );
 const lastPageNumber = Number(lastPageLabel.replace(/\D/g, ''));
 console.log(lastPageNumber);
@@ -132,7 +132,7 @@ const firstPage = await browser.newPage();
 await firstPage.goto(REPOSITORIES_URL);
 
 const lastPageElement = firstPage.locator('a[aria-label*="Page "]:nth-last-child(2)');
-const lastPageLabel = await lastPageElement.getAttribute('aria-label')
+const lastPageLabel = await lastPageElement.getAttribute('aria-label');
 const lastPageNumber = Number(lastPageLabel.replace(/\D/g, ''));
 
 // Push all results from the first page to the repositories array
@@ -175,7 +175,7 @@ await firstPage.goto(REPOSITORIES_URL);
 
 const lastPageLabel = await firstPage.$eval(
     'a[aria-label*="Page "]:nth-last-child(2)',
-    (element) => element.getAttribute('aria-label')
+    (element) => element.getAttribute('aria-label'),
 );
 const lastPageNumber = Number(lastPageLabel.replace(/\D/g, ''));
 
@@ -217,14 +217,14 @@ If we click around the pagination links, we can observe that all the URLs follow
 That means we could construct URL for each page if we had an array of numbers with the same range as the pages. If `lastPageNumber` is `4`, the following code creates `[0, 1, 2, 3, 4]`:
 
 ```js
-const array = Array(lastPageNumber + 1)  // getting an array of certain size
-const numbers = [...array.keys()];  // getting the keys (the actual numbers) as another array
+const array = Array(lastPageNumber + 1); // getting an array of certain size
+const numbers = [...array.keys()]; // getting the keys (the actual numbers) as another array
 ```
 
 Page `0` doesn't exist though and we've already scraped page `1`, so we need one more step to remove those:
 
 ```js
-const pageNumbers = numbers.slice(2);  // removes the first two numbers
+const pageNumbers = numbers.slice(2); // removes the first two numbers
 ```
 
 To have our code examples shorter, we'll squash the above to a single line of code:
@@ -237,23 +237,22 @@ Now let's scrape repositories for each of these numbers. We'll create promises f
 
 ```js
 const pageNumbers = [...Array(lastPageNumber + 1).keys()].slice(2);
-const promises = pageNumbers.map((pageNumber) =>
-    (async () => {
-        const paginatedPage = await browser.newPage();
+const promises = pageNumbers.map((pageNumber) => (async () => {
+    const paginatedPage = await browser.newPage();
 
-        // Construct the URL by setting the ?page=... parameter to value of pageNumber
-        const url = new URL(REPOSITORIES_URL);
-        url.searchParams.set('page', pageNumber);
+    // Construct the URL by setting the ?page=... parameter to value of pageNumber
+    const url = new URL(REPOSITORIES_URL);
+    url.searchParams.set('page', pageNumber);
 
-        // Scrape the page
-        await paginatedPage.goto(url.href);
-        const results = await scrapeRepos(paginatedPage)
+    // Scrape the page
+    await paginatedPage.goto(url.href);
+    const results = await scrapeRepos(paginatedPage);
 
-        // Push results to the repositories array
-        repositories.push(...results);
+    // Push results to the repositories array
+    repositories.push(...results);
 
-        await paginatedPage.close();
-    })()
+    await paginatedPage.close();
+})(),
 );
 await Promise.all(promises);
 
@@ -302,7 +301,7 @@ const firstPage = await browser.newPage();
 await firstPage.goto(REPOSITORIES_URL);
 
 const lastPageElement = firstPage.locator('a[aria-label*="Page "]:nth-last-child(2)');
-const lastPageLabel = await lastPageElement.getAttribute('aria-label')
+const lastPageLabel = await lastPageElement.getAttribute('aria-label');
 const lastPageNumber = Number(lastPageLabel.replace(/\D/g, ''));
 
 // Push all results from the first page to the repositories array
@@ -311,23 +310,22 @@ repositories.push(...(await scrapeRepos(firstPage)));
 await firstPage.close();
 
 const pageNumbers = [...Array(lastPageNumber + 1).keys()].slice(2);
-const promises = pageNumbers.map((pageNumber) =>
-    (async () => {
-        const paginatedPage = await browser.newPage();
+const promises = pageNumbers.map((pageNumber) => (async () => {
+    const paginatedPage = await browser.newPage();
 
-        // Construct the URL by setting the ?page=... parameter to value of pageNumber
-        const url = new URL(REPOSITORIES_URL);
-        url.searchParams.set('page', pageNumber);
+    // Construct the URL by setting the ?page=... parameter to value of pageNumber
+    const url = new URL(REPOSITORIES_URL);
+    url.searchParams.set('page', pageNumber);
 
-        // Scrape the page
-        await paginatedPage.goto(url.href);
-        const results = await scrapeRepos(paginatedPage)
+    // Scrape the page
+    await paginatedPage.goto(url.href);
+    const results = await scrapeRepos(paginatedPage);
 
-        // Push results to the repositories array
-        repositories.push(...results);
+    // Push results to the repositories array
+    repositories.push(...results);
 
-        await paginatedPage.close();
-    })()
+    await paginatedPage.close();
+})(),
 );
 await Promise.all(promises);
 
@@ -369,7 +367,7 @@ await firstPage.goto(REPOSITORIES_URL);
 
 const lastPageLabel = await firstPage.$eval(
     'a[aria-label*="Page "]:nth-last-child(2)',
-    (element) => element.getAttribute('aria-label')
+    (element) => element.getAttribute('aria-label'),
 );
 const lastPageNumber = Number(lastPageLabel.replace(/\D/g, ''));
 
@@ -379,23 +377,22 @@ repositories.push(...(await scrapeRepos(page)));
 await firstPage.close();
 
 const pageNumbers = [...Array(lastPageNumber + 1).keys()].slice(2);
-const promises = pageNumbers.map((pageNumber) =>
-    (async () => {
-        const paginatedPage = await browser.newPage();
+const promises = pageNumbers.map((pageNumber) => (async () => {
+    const paginatedPage = await browser.newPage();
 
-        // Construct the URL by setting the ?page=... parameter to value of pageNumber
-        const url = new URL(REPOSITORIES_URL);
-        url.searchParams.set('page', pageNumber);
+    // Construct the URL by setting the ?page=... parameter to value of pageNumber
+    const url = new URL(REPOSITORIES_URL);
+    url.searchParams.set('page', pageNumber);
 
-        // Scrape the page
-        await paginatedPage.goto(url.href);
-        const results = await scrapeRepos(paginatedPage)
+    // Scrape the page
+    await paginatedPage.goto(url.href);
+    const results = await scrapeRepos(paginatedPage);
 
-        // Push results to the repositories array
-        repositories.push(...results);
+    // Push results to the repositories array
+    repositories.push(...results);
 
-        await paginatedPage.close();
-    })()
+    await paginatedPage.close();
+})(),
 );
 await Promise.all(promises);
 

--- a/sources/academy/webscraping/puppeteer_playwright/common_use_cases/paginating_through_results.md
+++ b/sources/academy/webscraping/puppeteer_playwright/common_use_cases/paginating_through_results.md
@@ -10,43 +10,38 @@ import TabItem from '@theme/TabItem';
 
 # Paginating through results {#paginating-through-results}
 
-**Learn how to paginate through results on websites that use either page number-based pagination or dynamic lazy-loading pagination.**
+**Learn how to paginate through results on websites that use either pagination based on page numbers or dynamic lazy loading.**
 
 ---
 
-If you're trying to [collect data](../executing_scripts/extracting_data.md) on a website that has millions, thousands, or even just hundreds of results, it is very likely that they are paginating their results to reduce strain on their back-end as well as on the users loading and rendering the content.
+Websites that list millions, thousands, or even just hundreds of items often use pagination to reduce strain on their servers as well as on visitors' browsers. In this lesson, we'll build a scraper which uses a browser to extract data from each page of such a listing.
 
 ![Amazon pagination](../../advanced_web_scraping/images/pagination.png)
 
-Attempting to scrape thousands to tens of thousands of results using a headless browser on a website that only shows 30 results at a time might be daunting at first, but be rest assured that by the end of this lesson you'll feel confident when faced with this use case.
-
 ## Page number-based pagination {#page-number-based-pagination}
 
-At the time of writing, Facebook has [115 repositories on GitHub](https://github.com/orgs/facebook/repositories). By default, GitHub lists repositories in descending order based on when they were last updated (the most recently updated repos are at the top of the list).
+At the time of writing this lesson, Facebook has [over a hundred repositories on GitHub](https://github.com/orgs/facebook/repositories). By default, GitHub lists repositories in descending order based on when they were last updated (the most recently updated ones are at the top of the list).
 
-We want to scrape all of the titles, links, and descriptions for Facebook's repositories; however, GitHub only displays 30 repos per page. This means we've gotta paginate through all of the results.
-
-Let's first start off by defining some basic variables:
+We want to scrape the titles, links, and descriptions of all of Facebook's repositories; however, GitHub only displays 30 repositories per page. This means we need to paginate through the results. Let's start by defining some variables:
 
 ```js
-// This is where we'll push all of the scraped repos
+// This is where we'll store scraped data
 const repositories = [];
 
+// This will come handy when resolving relative links
 const BASE_URL = 'https://github.com';
 
-// We'll use this URL a couple of times within our code, so we'll
-// store it in a constant variable to prevent typos and so it's
-// easier to tell what it is
+// We'll use this URL a couple of times within our code
 const REPOSITORIES_URL = `${BASE_URL}/orgs/facebook/repositories`;
 ```
 
 ### Finding the last page {#finding-the-last-page}
 
-What we want to do now is grab the last page number, so that we know exactly how many requests we need to send in order to paginate through all of the repositories. Luckily, this information is available right on the page here:
+Going through each page is easier if we know in advance when to stop. The good news is that GitHub's pagination is upfront about the number of the last page, so the total number of pages is available to us:
 
-![Final page number](./images/github-last-page.jpg)
+![Last page number](./images/github-last-page.jpg)
 
-Let's grab this number now with a little bit of code:
+As Facebook adds repositories over time, the number you see in your browser might be different. Let's read the number now with the following code:
 
 <Tabs groupId="main">
 <TabItem value="Playwright" label="Playwright">
@@ -55,20 +50,17 @@ Let's grab this number now with a little bit of code:
 import { chromium } from 'playwright';
 
 const repositories = [];
-
 const BASE_URL = 'https://github.com';
 const REPOSITORIES_URL = `${BASE_URL}/orgs/facebook/repositories`;
 
 const browser = await chromium.launch({ headless: false });
-const page = await browser.newPage();
+const firstPage = await browser.newPage();
+await firstPage.goto(REPOSITORIES_URL);
 
-await page.goto(REPOSITORIES_URL);
-
-const lastPageElement = page.locator('a[aria-label*="Page "]:nth-last-child(2)');
-// This will output 4
-const lastPage = +(await lastPageElement.getAttribute('aria-label')).replace(/\D/g, '');
-
-console.log(lastPage);
+const lastPageElement = firstPage.locator('a[aria-label*="Page "]:nth-last-child(2)');
+const lastPageLabel = await lastPageElement.getAttribute('aria-label')
+const lastPageNumber = Number(lastPageLabel.replace(/\D/g, ''));
+console.log(lastPageNumber);
 
 await browser.close();
 ```
@@ -80,20 +72,19 @@ await browser.close();
 import puppeteer from 'puppeteer';
 
 const repositories = [];
-
 const BASE_URL = 'https://github.com';
 const REPOSITORIES_URL = `${BASE_URL}/orgs/facebook/repositories`;
 
 const browser = await puppeteer.launch({ headless: false });
-const page = await browser.newPage();
+const firstPage = await browser.newPage();
+await firstPage.goto(REPOSITORIES_URL);
 
-await page.goto(REPOSITORIES_URL);
-
-const lastPageLabel = await page.$eval('a[aria-label*="Page "]:nth-last-child(2)', (elem) => elem.getAttribute('aria-label'));
-// This will output 4
-const lastPage = +lastPageLabel.replace(/\D/g, '');
-
-console.log(lastPage);
+const lastPageLabel = await firstPage.$eval(
+    'a[aria-label*="Page "]:nth-last-child(2)',
+    (element) => element.getAttribute('aria-label')
+);
+const lastPageNumber = Number(lastPageLabel.replace(/\D/g, ''));
+console.log(lastPageNumber);
 
 await browser.close();
 ```
@@ -101,157 +92,184 @@ await browser.close();
 </TabItem>
 </Tabs>
 
-> [Learn more](https://developer.mozilla.org/en-US/docs/Web/CSS/:nth-last-child) about the `:nth-last-child` pseudo-class. It works similar to `:nth-child`, but starts from the bottom of the parent element's children instead of from the top.
+:::tip :nth-last-child
 
-When we run this code, here's what we see:
+[Learn more](https://developer.mozilla.org/en-US/docs/Web/CSS/:nth-last-child) about the `:nth-last-child` pseudo-class. It works like `:nth-child`, but starts from the bottom of the parent element's children instead of from the top.
+
+:::
+
+When we run the code, it prints the total number of pages, which is `4` at the time of writing this lesson. Now let's scrape repositories from all the pages.
+
+First, we'll add a function that can handle the data extraction for a single page and return an array of results. Then, to start, we'll run this function just for the first page:
+
+<Tabs groupId="main">
+<TabItem value="Playwright" label="Playwright">
+
+```js
+import { chromium } from 'playwright';
+import * as cheerio from 'cheerio';
+
+const repositories = [];
+const BASE_URL = 'https://github.com';
+const REPOSITORIES_URL = `${BASE_URL}/orgs/facebook/repositories`;
+
+// Scrapes all repositories from a single page
+const scrapeRepos = async (page) => {
+    const $ = cheerio.load(await page.content());
+
+    return [...$('.list-view-item')].map((item) => {
+        const repoElement = $(item);
+        return {
+            title: repoElement.find('h4').text().trim(),
+            description: repoElement.find('.repos-list-description').text().trim(),
+            link: new URL(repoElement.find('h4 a').attr('href'), BASE_URL).href,
+        };
+    });
+};
+
+const browser = await chromium.launch({ headless: false });
+const firstPage = await browser.newPage();
+await firstPage.goto(REPOSITORIES_URL);
+
+const lastPageElement = firstPage.locator('a[aria-label*="Page "]:nth-last-child(2)');
+const lastPageLabel = await lastPageElement.getAttribute('aria-label')
+const lastPageNumber = Number(lastPageLabel.replace(/\D/g, ''));
+
+// Push all results from the first page to the repositories array
+repositories.push(...(await scrapeRepos(firstPage)));
+
+// Log the 30 repositories scraped from the first page
+console.log(repositories);
+
+await browser.close();
+```
+
+</TabItem>
+<TabItem value="Puppeteer" label="Puppeteer">
+
+```js
+import puppeteer from 'puppeteer';
+import * as cheerio from 'cheerio';
+
+const repositories = [];
+const BASE_URL = 'https://github.com';
+const REPOSITORIES_URL = `${BASE_URL}/orgs/facebook/repositories`;
+
+// Scrapes all repositories from a single page
+const scrapeRepos = async (page) => {
+    const $ = cheerio.load(await page.content());
+
+    return [...$('.list-view-item')].map((item) => {
+        const repoElement = $(item);
+        return {
+            title: repoElement.find('h4').text().trim(),
+            description: repoElement.find('.repos-list-description').text().trim(),
+            link: new URL(repoElement.find('h4 a').attr('href'), BASE_URL).href,
+        };
+    });
+};
+
+const browser = await puppeteer.launch({ headless: false });
+const firstPage = await browser.newPage();
+await firstPage.goto(REPOSITORIES_URL);
+
+const lastPageLabel = await firstPage.$eval(
+    'a[aria-label*="Page "]:nth-last-child(2)',
+    (element) => element.getAttribute('aria-label')
+);
+const lastPageNumber = Number(lastPageLabel.replace(/\D/g, ''));
+
+// Push all results from the first page to the repositories array
+repositories.push(...(await scrapeRepos(firstPage)));
+
+// Log the 30 repositories scraped from the first page
+console.log(repositories);
+
+await browser.close();
+```
+
+</TabItem>
+</Tabs>
+
+If we run the code above, it outputs data about the first 30 repositories listed:
 
 ```text
-4
+$ node index.js
+[
+  {
+    title: 'react-native',
+    description: 'A framework for building native applications using React',
+    link: 'https://github.com/facebook/react-native'
+  },
+  {
+    title: 'fboss',
+    description: 'Facebook Open Switching System Software for controlling network switches.',
+    link: 'https://github.com/facebook/fboss'
+  },
+  ...
+]
 ```
-
-And since we're already on the first page, we'll go ahead and scrape the repos from it. However, since we are going to reuse this logic on the other pages as well, let's create a function that will handle the data extraction and reliably return a nice array of results:
-
-<Tabs groupId="main">
-<TabItem value="Playwright" label="Playwright">
-
-```js
-import { chromium } from 'playwright';
-import * as cheerio from 'cheerio';
-
-const repositories = [];
-
-const BASE_URL = 'https://github.com';
-const REPOSITORIES_URL = `${BASE_URL}/orgs/facebook/repositories`;
-
-// Create a function which grabs all repos from a page
-const scrapeRepos = async (page) => {
-    const $ = cheerio.load(await page.content());
-
-    return [...$('li.Box-row')].map((item) => {
-        const elem = $(item);
-        const titleElement = elem.find('a[itemprop*="name"]');
-
-        return {
-            title: titleElement.text().trim(),
-            description: elem.find('p[itemprop="description"]').text().trim(),
-            link: new URL(titleElement.attr('href'), BASE_URL).href,
-        };
-    });
-};
-
-const browser = await chromium.launch({ headless: false });
-const page = await browser.newPage();
-
-await page.goto(REPOSITORIES_URL);
-
-const lastPageElement = page.locator('a[aria-label*="Page "]:nth-last-child(2)');
-const lastPage = +(await lastPageElement.getAttribute('aria-label')).replace(/\D/g, '');
-
-// Push all results from the first page to results array
-repositories.push(...(await scrapeRepos(page)));
-
-// Log the 30 repositories scraped from the first page
-console.log(repositories);
-
-await browser.close();
-```
-
-</TabItem>
-<TabItem value="Puppeteer" label="Puppeteer">
-
-```js
-import puppeteer from 'puppeteer';
-import * as cheerio from 'cheerio';
-
-const repositories = [];
-
-const BASE_URL = 'https://github.com';
-const REPOSITORIES_URL = `${BASE_URL}/orgs/facebook/repositories`;
-
-// Create a function which grabs all repos from a page
-const scrapeRepos = async (page) => {
-    const $ = cheerio.load(await page.content());
-
-    return [...$('li.Box-row')].map((item) => {
-        const elem = $(item);
-        const titleElement = elem.find('a[itemprop*="name"]');
-
-        return {
-            title: titleElement.text().trim(),
-            description: elem.find('p[itemprop="description"]').text().trim(),
-            link: new URL(titleElement.attr('href'), BASE_URL).href,
-        };
-    });
-};
-
-const browser = await puppeteer.launch({ headless: false });
-const page = await browser.newPage();
-
-await page.goto(REPOSITORIES_URL);
-
-const lastPageLabel = await page.$eval('a[aria-label*="Page "]:nth-last-child(2)', (elem) => elem.getAttribute('aria-label'));
-const lastPage = +lastPageLabel.replace(/\D/g, '');
-
-// Push all results from the first page to results array
-repositories.push(...(await scrapeRepos(page)));
-
-// Log the 30 repositories scraped from the first page
-console.log(repositories);
-
-await browser.close();
-```
-
-</TabItem>
-</Tabs>
 
 ### Making a request for each results page {#making-a-request-for-each-results-page}
 
-Cool, so now we have all the tools we need to write concise logic that will be run for every single page. First, we'll create an array of numbers from 0–4:
+If we click around the pagination links, we can observe that all the URLs follow certain format. For example, we can find page number 2 at `https://github.com/orgs/facebook/repositories?page=2`.
+
+That means we could construct URL for each page if we had an array of numbers with the same range as the pages. If `lastPageNumber` is `4`, the following code creates `[0, 1, 2, 3, 4]`:
 
 ```js
-// We must add 1 to the lastPage, since the array starts at 0 and we
-// are creating an array from its index values
-Array(lastPage + 1).keys(); // -> [0, 1, 2, 3, 4]
+const array = Array(lastPageNumber + 1)  // getting an array of certain size
+const numbers = [...array.keys()];  // getting the keys (the actual numbers) as another array
 ```
 
-Then, we'll slice the first two values from that array so that it starts from 2 and ends at 4:
+Page `0` doesn't exist though and we've already scraped page `1`, so we need one more step to remove those:
 
 ```js
-[...Array(lastPage + 1).keys()].slice(2); // -> [2, 3, 4]
+const pageNumbers = numbers.slice(2);  // removes the first two numbers
 ```
 
-This array now accurately represents the pages we need to go through. We'll map through it and create an array of promises, all of which make a request to each page, scrape its data, then push it to the **repositories** array:
+To have our code examples shorter, we'll squash the above to a single line of code:
 
 ```js
-// Map through the range. The value from the array is the page number
-// to make a request for
-const promises = [...Array(lastPage + 1).keys()].slice(2).map((pageNumber) => (async () => {
-    const page2 = await browser.newPage();
+const pageNumbers = [...Array(lastPageNumber + 1).keys()].slice(2);
+```
 
-    // Prepare the URL before making the request by setting the "page"
-    // parameter to whatever the pageNumber is currently
-    const url = new URL(REPOSITORIES_URL);
-    url.searchParams.set('page', pageNumber);
+Now let's scrape repositories for each of these numbers. We'll create promises for each request and collect results to a single `repositories` array:
 
-    await page2.goto(url.href);
+```js
+const pageNumbers = [...Array(lastPageNumber + 1).keys()].slice(2);
+const promises = pageNumbers.map((pageNumber) =>
+    (async () => {
+        const paginatedPage = await browser.newPage();
 
-    // Scrape the data and push it to the "repositories" array
-    repositories.push(...(await scrapeRepos(page2)));
+        // Construct the URL by setting the ?page=... parameter to value of pageNumber
+        const url = new URL(REPOSITORIES_URL);
+        url.searchParams.set('page', pageNumber);
 
-    await page2.close();
-})(),
+        // Scrape the page
+        await paginatedPage.goto(url.href);
+        const results = await scrapeRepos(paginatedPage)
+
+        // Push results to the repositories array
+        repositories.push(...results);
+
+        await paginatedPage.close();
+    })()
 );
-
 await Promise.all(promises);
 
+// For brievity logging just the count of repositories scraped
 console.log(repositories.length);
 ```
 
-> **IMPORTANT!** Usually, within the map function's callback you'd want to add the requests to a request queue, especially when paginating through hundreds (or even thousands) of pages. But since we know that we have 4 pages and only 3 left to go through, it is totally safe to use `Promise.all()` for this specific use-case.
+:::caution Scaling to hundreds of requests
+
+Using `Promise.all()` is okay for up to ten or maybe tens of requests, but won't work well for large numbers. When scraping hundreds or even thousands of pages, it's necessary to have more robust infrastructure in place, such as a request queue.
+
+:::
 
 ### Final code {#final-pagination-code}
 
-After all is said and done, here's what our final code looks like:
+The code below puts all the bits together:
 
 <Tabs groupId="main">
 <TabItem value="Playwright" label="Playwright">
@@ -261,54 +279,59 @@ import { chromium } from 'playwright';
 import * as cheerio from 'cheerio';
 
 const repositories = [];
-
 const BASE_URL = 'https://github.com';
 const REPOSITORIES_URL = `${BASE_URL}/orgs/facebook/repositories`;
 
+// Scrapes all repositories from a single page
 const scrapeRepos = async (page) => {
     const $ = cheerio.load(await page.content());
 
-    return [...$('li.Box-row')].map((item) => {
-        const elem = $(item);
-        const titleElement = elem.find('a[itemprop*="name"]');
-
+    return [...$('.list-view-item')].map((item) => {
+        const repoElement = $(item);
         return {
-            title: titleElement.text().trim(),
-            description: elem.find('p[itemprop="description"]').text().trim(),
-            link: new URL(titleElement.attr('href'), BASE_URL).href,
+            title: repoElement.find('h4').text().trim(),
+            description: repoElement.find('.repos-list-description').text().trim(),
+            link: new URL(repoElement.find('h4 a').attr('href'), BASE_URL).href,
         };
     });
 };
 
 const browser = await chromium.launch({ headless: false });
-const page = await browser.newPage();
+const firstPage = await browser.newPage();
 
-await page.goto(REPOSITORIES_URL);
+await firstPage.goto(REPOSITORIES_URL);
 
-const lastPageElement = page.locator('a[aria-label*="Page "]:nth-last-child(2)');
-const lastPage = +(await lastPageElement.getAttribute('aria-label')).replace(/\D/g, '');
+const lastPageElement = firstPage.locator('a[aria-label*="Page "]:nth-last-child(2)');
+const lastPageLabel = await lastPageElement.getAttribute('aria-label')
+const lastPageNumber = Number(lastPageLabel.replace(/\D/g, ''));
 
-repositories.push(...(await scrapeRepos(page)));
+// Push all results from the first page to the repositories array
+repositories.push(...(await scrapeRepos(firstPage)));
 
-await page.close();
+await firstPage.close();
 
-const promises = [...Array(lastPage + 1).keys()].slice(2).map((pageNumber) => (async () => {
-    const page2 = await browser.newPage();
+const pageNumbers = [...Array(lastPageNumber + 1).keys()].slice(2);
+const promises = pageNumbers.map((pageNumber) =>
+    (async () => {
+        const paginatedPage = await browser.newPage();
 
-    const url = new URL(REPOSITORIES_URL);
-    url.searchParams.set('page', pageNumber);
+        // Construct the URL by setting the ?page=... parameter to value of pageNumber
+        const url = new URL(REPOSITORIES_URL);
+        url.searchParams.set('page', pageNumber);
 
-    await page2.goto(url.href);
+        // Scrape the page
+        await paginatedPage.goto(url.href);
+        const results = await scrapeRepos(paginatedPage)
 
-    repositories.push(...(await scrapeRepos(page2)));
+        // Push results to the repositories array
+        repositories.push(...results);
 
-    await page2.close();
-})(),
+        await paginatedPage.close();
+    })()
 );
-
 await Promise.all(promises);
 
-// Log the final length of the "repositories" array
+// For brievity logging just the count of repositories scraped
 console.log(repositories.length);
 
 await browser.close();
@@ -322,55 +345,61 @@ import puppeteer from 'puppeteer';
 import * as cheerio from 'cheerio';
 
 const repositories = [];
-
 const BASE_URL = 'https://github.com';
 const REPOSITORIES_URL = `${BASE_URL}/orgs/facebook/repositories`;
 
-// Create a function which grabs all repos from a page
+// Scrapes all repositories from a single page
 const scrapeRepos = async (page) => {
     const $ = cheerio.load(await page.content());
 
-    return [...$('li.Box-row')].map((item) => {
-        const elem = $(item);
-        const titleElement = elem.find('a[itemprop*="name"]');
-
+    return [...$('.list-view-item')].map((item) => {
+        const repoElement = $(item);
         return {
-            title: titleElement.text().trim(),
-            description: elem.find('p[itemprop="description"]').text().trim(),
-            link: new URL(titleElement.attr('href'), BASE_URL).href,
+            title: repoElement.find('h4').text().trim(),
+            description: repoElement.find('.repos-list-description').text().trim(),
+            link: new URL(repoElement.find('h4 a').attr('href'), BASE_URL).href,
         };
     });
 };
 
 const browser = await puppeteer.launch({ headless: false });
-const page = await browser.newPage();
+const firstPage = await browser.newPage();
 
-await page.goto(REPOSITORIES_URL);
+await firstPage.goto(REPOSITORIES_URL);
 
-const lastPageLabel = await page.$eval('a[aria-label*="Page "]:nth-last-child(2)', (elem) => elem.getAttribute('aria-label'));
-const lastPage = +lastPageLabel.replace(/\D/g, '');
+const lastPageLabel = await firstPage.$eval(
+    'a[aria-label*="Page "]:nth-last-child(2)',
+    (element) => element.getAttribute('aria-label')
+);
+const lastPageNumber = Number(lastPageLabel.replace(/\D/g, ''));
 
+// Push all results from the first page to the repositories array
 repositories.push(...(await scrapeRepos(page)));
 
-await page.close();
+await firstPage.close();
 
-const promises = [...Array(lastPage + 1).keys()].slice(2).map((pageNumber) => (async () => {
-    const page2 = await browser.newPage();
+const pageNumbers = [...Array(lastPageNumber + 1).keys()].slice(2);
+const promises = pageNumbers.map((pageNumber) =>
+    (async () => {
+        const paginatedPage = await browser.newPage();
 
-    const url = new URL(REPOSITORIES_URL);
-    url.searchParams.set('page', pageNumber);
+        // Construct the URL by setting the ?page=... parameter to value of pageNumber
+        const url = new URL(REPOSITORIES_URL);
+        url.searchParams.set('page', pageNumber);
 
-    await page2.goto(url.href);
+        // Scrape the page
+        await paginatedPage.goto(url.href);
+        const results = await scrapeRepos(paginatedPage)
 
-    repositories.push(...(await scrapeRepos(page2)));
+        // Push results to the repositories array
+        repositories.push(...results);
 
-    await page2.close();
-})(),
+        await paginatedPage.close();
+    })()
 );
-
 await Promise.all(promises);
 
-// Log the final length of the "repositories" array
+// For brievity logging just the count of repositories scraped
 console.log(repositories.length);
 
 await browser.close();
@@ -379,9 +408,10 @@ await browser.close();
 </TabItem>
 </Tabs>
 
-If we remember correctly, Facebook has 115 GitHub repositories (at the time of writing this lesson), so the final output should be:
+At the time of writing this lesson, a summary at the top of the [listing page](https://github.com/orgs/facebook/repositories) claims that Facebook has 115 repositories. Whatever is the number you are seeing, it should be equal to the number you get if you run the program:
 
 ```text
+$ node index.js
 115
 ```
 


### PR DESCRIPTION
Closes https://github.com/apify/apify-docs/pull/1108. It's the same PR, but from an upstream branch, not from my fork. As discussed on Slack, this works around unauthorized npm token on CI.