### PR TITLE
docs: remove dead link in langchain docs

### DIFF
--- a/sources/platform/integrations/ai/langchain.md
+++ b/sources/platform/integrations/ai/langchain.md
@@ -128,5 +128,4 @@ LangChain is a standard interface through which you can interact with a variety 
 
 - https://python.langchain.com/docs/get_started/introduction
 - https://python.langchain.com/docs/integrations/providers/apify
-- https://python.langchain.com/docs/integrations/tools/apify
 - https://python.langchain.com/docs/modules/model_io/llms/

--- a/sources/platform/integrations/ai/langchain.md
+++ b/sources/platform/integrations/ai/langchain.md
@@ -127,5 +127,6 @@ LangChain is a standard interface through which you can interact with a variety 
 ## Resources
 
 - https://python.langchain.com/docs/get_started/introduction
+- https://python.langchain.com/docs/integrations/document_loaders/apify_dataset
 - https://python.langchain.com/docs/integrations/providers/apify
 - https://python.langchain.com/docs/modules/model_io/llms/


### PR DESCRIPTION
The link in question was constantly throwing 404's and I cannot find anything similar in langchain docs anymore