### PR TITLE
chore: remove patching

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -58,7 +58,6 @@
                 "globby": "^14.0.0",
                 "markdownlint": "^0.35.0",
                 "markdownlint-cli": "^0.41.0",
-                "patch-package": "^8.0.0",
                 "path-browserify": "^1.0.1",
                 "rimraf": "^6.0.0",
                 "typescript": "^5.1.3"
@@ -15511,11 +15510,6 @@
             "version": "4.2.2",
             "license": "Apache-2.0"
         },
-        "node_modules/@yarnpkg/lockfile": {
-            "version": "1.1.0",
-            "dev": true,
-            "license": "BSD-2-Clause"
-        },
         "node_modules/abort-controller": {
             "version": "3.0.0",
             "license": "MIT",
@@ -19467,14 +19461,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/find-yarn-workspace-root": {
-            "version": "2.0.0",
-            "dev": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "micromatch": "^4.0.2"
-            }
-        },
         "node_modules/flat": {
             "version": "5.0.2",
             "license": "BSD-3-Clause",
@@ -21579,23 +21565,6 @@
             "version": "1.0.0",
             "license": "MIT"
         },
-        "node_modules/json-stable-stringify": {
-            "version": "1.1.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "call-bind": "^1.0.5",
-                "isarray": "^2.0.5",
-                "jsonify": "^0.0.1",
-                "object-keys": "^1.1.1"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/json-stable-stringify-without-jsonify": {
             "version": "1.0.1",
             "dev": true,
@@ -21624,14 +21593,6 @@
             },
             "optionalDependencies": {
                 "graceful-fs": "^4.1.6"
-            }
-        },
-        "node_modules/jsonify": {
-            "version": "0.0.1",
-            "dev": true,
-            "license": "Public Domain",
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/jsonpointer": {
@@ -21693,14 +21654,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
-            }
-        },
-        "node_modules/klaw-sync": {
-            "version": "6.0.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "graceful-fs": "^4.1.11"
             }
         },
         "node_modules/kleur": {
@@ -28126,21 +28079,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/open": {
-            "version": "7.4.2",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "is-docker": "^2.0.0",
-                "is-wsl": "^2.1.1"
-            },
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/openapi-sampler": {
             "version": "1.5.1",
             "license": "MIT",
@@ -28170,14 +28108,6 @@
             },
             "engines": {
                 "node": ">= 0.8.0"
-            }
-        },
-        "node_modules/os-tmpdir": {
-            "version": "1.0.2",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10.0"
             }
         },
         "node_modules/p-cancelable": {
@@ -28355,115 +28285,6 @@
             "dependencies": {
                 "no-case": "^3.0.4",
                 "tslib": "^2.0.3"
-            }
-        },
-        "node_modules/patch-package": {
-            "version": "8.0.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@yarnpkg/lockfile": "^1.1.0",
-                "chalk": "^4.1.2",
-                "ci-info": "^3.7.0",
-                "cross-spawn": "^7.0.3",
-                "find-yarn-workspace-root": "^2.0.0",
-                "fs-extra": "^9.0.0",
-                "json-stable-stringify": "^1.0.2",
-                "klaw-sync": "^6.0.0",
-                "minimist": "^1.2.6",
-                "open": "^7.4.2",
-                "rimraf": "^2.6.3",
-                "semver": "^7.5.3",
-                "slash": "^2.0.0",
-                "tmp": "^0.0.33",
-                "yaml": "^2.2.2"
-            },
-            "bin": {
-                "patch-package": "index.js"
-            },
-            "engines": {
-                "node": ">=14",
-                "npm": ">5"
-            }
-        },
-        "node_modules/patch-package/node_modules/brace-expansion": {
-            "version": "1.1.11",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "balanced-match": "^1.0.0",
-                "concat-map": "0.0.1"
-            }
-        },
-        "node_modules/patch-package/node_modules/fs-extra": {
-            "version": "9.1.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "at-least-node": "^1.0.0",
-                "graceful-fs": "^4.2.0",
-                "jsonfile": "^6.0.1",
-                "universalify": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/patch-package/node_modules/glob": {
-            "version": "7.2.3",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^3.1.1",
-                "once": "^1.3.0",
-                "path-is-absolute": "^1.0.0"
-            },
-            "engines": {
-                "node": "*"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
-        "node_modules/patch-package/node_modules/minimatch": {
-            "version": "3.1.2",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "brace-expansion": "^1.1.7"
-            },
-            "engines": {
-                "node": "*"
-            }
-        },
-        "node_modules/patch-package/node_modules/rimraf": {
-            "version": "2.7.1",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "glob": "^7.1.3"
-            },
-            "bin": {
-                "rimraf": "bin.js"
-            }
-        },
-        "node_modules/patch-package/node_modules/slash": {
-            "version": "2.0.0",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=6"
-            }
-        },
-        "node_modules/patch-package/node_modules/yaml": {
-            "version": "2.3.4",
-            "dev": true,
-            "license": "ISC",
-            "engines": {
-                "node": ">= 14"
             }
         },
         "node_modules/path-browserify": {
@@ -33588,17 +33409,6 @@
         "node_modules/tiny-warning": {
             "version": "1.0.3",
             "license": "MIT"
-        },
-        "node_modules/tmp": {
-            "version": "0.0.33",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "os-tmpdir": "~1.0.2"
-            },
-            "engines": {
-                "node": ">=0.6.0"
-            }
         },
         "node_modules/to-fast-properties": {
             "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
         "swizzle": "docusaurus swizzle",
         "deploy": "rimraf .docusaurus && docusaurus deploy",
         "docusaurus": "docusaurus",
-        "postinstall": "patch-package",
         "lint": "npm run lint:md && npm run lint:code",
         "lint:fix": "npm run lint:md:fix && npm run lint:code:fix",
         "lint:md": "markdownlint '**/*.md'",
@@ -51,7 +50,6 @@
         "globby": "^14.0.0",
         "markdownlint": "^0.35.0",
         "markdownlint-cli": "^0.41.0",
-        "patch-package": "^8.0.0",
         "path-browserify": "^1.0.1",
         "rimraf": "^6.0.0",
         "typescript": "^5.1.3"


### PR DESCRIPTION
Previously there has been a patch to modify front matter in Docusaurus v2, but with migration to Docusaurus v3, this has been moved to a config file and patching is not necessary anymore. The patch itself has been removed from the codebase, but I noticed there are leftovers in form of a dependency and a postinstall script.

Not sure who can review this, so I'm sorry if I asked the wrong people 🙏 