### PR TITLE
docs: add storages editor to input schema specification

### DIFF
--- a/sources/platform/actors/development/actor_definition/input_schema/specification.md
+++ b/sources/platform/actors/development/actor_definition/input_schema/specification.md
@@ -183,16 +183,16 @@ Rendered input:
 
 Properties:
 
-| Property | Value | Required | Description |
-| --- | --- | --- | --- |
-| `editor` | One of <ul><li>`textfield`</li><li>`textarea`</li><li>`javascript`</li><li>`python`</li><li>`select`</li><li>`datepicker`</li><li>`hidden`</li></ul> | Yes | Visual editor used for <br/>the input field. |
-| `pattern` | String | No | Regular expression that will be <br/>used to validate the input. <br/> If validation fails, <br/>the Actor will not run. |
-| `minLength` | Integer | No | Minimum length of the string. |
-| `maxLength` | Integer | No | Maximum length of the string. |
-| `enum` | [String] | Required if <br/>`editor` <br/>is `select` | Using this field, you can limit values <br/>to the given array of strings. <br/>Input will be displayed as select box. |
-| `enumTitles` | [String] | No | Titles for the `enum` keys described. |
-| `nullable` | Boolean | No | Specifies whether `null` <br/>is an allowed value. |
-| `isSecret` | Boolean | No | Specifies whether the input field<br />will be stored encrypted.<br />Only available <br />with `textfield` and `textarea` editors. |
+| Property     | Value                                                                                                                                                                                                                 | Required                                   | Description                                                                                                                         |
+|--------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------|
+| `editor`     | One of <ul><li>`textfield`</li><li>`textarea`</li><li>`javascript`</li><li>`python`</li><li>`select`</li><li>`datepicker`</li><li>`dataset`</li><li>`keyValueStore`</li><li>`requestQueue`</li><li>`hidden`</li></ul> | Yes                                        | Visual editor used for <br/>the input field.                                                                                        |
+| `pattern`    | String                                                                                                                                                                                                                | No                                         | Regular expression that will be <br/>used to validate the input. <br/> If validation fails, <br/>the Actor will not run.            |
+| `minLength`  | Integer                                                                                                                                                                                                               | No                                         | Minimum length of the string.                                                                                                       |
+| `maxLength`  | Integer                                                                                                                                                                                                               | No                                         | Maximum length of the string.                                                                                                       |
+| `enum`       | [String]                                                                                                                                                                                                              | Required if <br/>`editor` <br/>is `select` | Using this field, you can limit values <br/>to the given array of strings. <br/>Input will be displayed as select box.              |
+| `enumTitles` | [String]                                                                                                                                                                                                              | No                                         | Titles for the `enum` keys described.                                                                                               |
+| `nullable`   | Boolean                                                                                                                                                                                                               | No                                         | Specifies whether `null` <br/>is an allowed value.                                                                                  |
+| `isSecret`   | Boolean                                                                                                                                                                                                               | No                                         | Specifies whether the input field<br />will be stored encrypted.<br />Only available <br />with `textfield` and `textarea` editors. |
 
 :::note Regex escape
 


### PR DESCRIPTION
Add new input schema `editor` values for `string` properties to input schema specification.
This is based on this issue: https://github.com/apify/apify-core/issues/12871 and part of
- Input schema PR: https://github.com/apify/apify-shared-js/pull/476
- (app) Storage input PR: https://github.com/apify/apify-core/issues/12871

This one will be merged as the last one.

<img width="1347" alt="Screenshot 2024-09-12 at 8 47 10" src="https://github.com/user-attachments/assets/04e5086b-770b-4171-a55d-b33d0305849c">
