### PR TITLE
feat: mention larger allowed input schema size

### DIFF
--- a/sources/platform/actors/development/actor_definition/input_schema/specification.md
+++ b/sources/platform/actors/development/actor_definition/input_schema/specification.md
@@ -24,7 +24,7 @@ You can specify input schema for an Actor in multiple ways:
 - If you omit the `input` field in the `.actor/actor.json` file, the system will look for an `INPUT_SCHEMA.json` file in the `.actor` directory.
 - In the absence of that file, it will search for an `INPUT_SCHEMA.json` file in the Actor's root directory.
 
-The max allowed size for the input schema file is 100 kB. When you provide an input schema, the system will validate the input data passed to the Actor during execution (via the API or the Apify Console) against the specified schema to ensure compliance before starting the Actor.
+The max allowed size for the input schema file is 500 kB. When you provide an input schema, the system will validate the input data passed to the Actor during execution (via the API or the Apify Console) against the specified schema to ensure compliance before starting the Actor.
 
 :::note Validation aid
 

--- a/sources/platform/limits.md
+++ b/sources/platform/limits.md
@@ -97,7 +97,7 @@ The tables below demonstrate the Apify platform's default resource limits. For A
         </tr>
         <tr>
             <td>Maximum size of Actor input schema</td>
-            <td colspan="4">100&nbsp;kB</td>
+            <td colspan="4">500&nbsp;kB</td>
         </tr>
         <tr>
             <td>Maximum number of Actors per user</td>


### PR DESCRIPTION
The size was increased in https://github.com/apify/apify-shared-js/pull/478.