### PR TITLE
feat: add standby URL, changes to port unification

### DIFF
--- a/sources/platform/actors/development/programming_interface/actor_standby.md
+++ b/sources/platform/actors/development/programming_interface/actor_standby.md
@@ -25,7 +25,7 @@ If you already have an existing Actor, or you just want to tweak the configurati
 
 Actors using Standby mode must run a HTTP server listening on a specific port. The user requests will then be proxied to the HTTP server. You can use any of the existing [HTTP request methods](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods) like GET, POST, PUT, DELETE, etc. You can pass the input via [HTTP request query string](https://en.wikipedia.org/wiki/Query_string) or via [HTTP request body](https://developer.mozilla.org/en-US/docs/Web/HTTP/Messages#body).
 
-Sometimes, you want the HTTP server to listen on a specific port and cannot change it yourself. You can use `ACTOR_STANDBY_PORT` environment variable to override the port so that Actor Standby will work with your code.
+Sometimes, you want the HTTP server to listen on a specific port and cannot change it yourself. You can use `ACTOR_WEB_SERVER_PORT` environment variable to override the port so that Actor Standby will work with your code.
 
 You can get the port using the Actor configuration available in Apify SDK.
 See example below with a simple Actor using Standby mode.
@@ -44,7 +44,7 @@ const server = http.createServer((req, res) => {
     res.end('Hello from Actor Standby!\n');
 });
 
-server.listen(Actor.config.get('standbyPort'));
+server.listen(Actor.config.get('containerPort'));
 ```
 
 </TabItem>
@@ -62,7 +62,7 @@ class GetHandler(SimpleHTTPRequestHandler):
 
 async def main() -> None:
     async with Actor:
-        with HTTPServer(('', Actor.config.standby_port), GetHandler) as http_server:
+        with HTTPServer(('', Actor.config.web_server_port), GetHandler) as http_server:
             http_server.serve_forever()
 ```
 
@@ -109,6 +109,10 @@ async def main() -> None:
 
 </TabItem>
 </Tabs>
+
+## Getting the URL of the Standby Actor
+
+The URL is exposed as an environment variable `ACTOR_STANDBY_URL`. You can also use `Actor.config`, where the `standbyUrl` option is available.
 
 ## Monetization of Actors with the Standby mode?
 

--- a/sources/platform/actors/development/programming_interface/environment_variables.md
+++ b/sources/platform/actors/development/programming_interface/environment_variables.md
@@ -39,12 +39,12 @@ Here's a table of key system environment variables:
 | `APIFY_PROXY_PASSWORD` | Password for accessing Apify Proxy services. This password enables the Actor to utilize proxy servers on behalf of the user who initiated the Actor run. |
 | `APIFY_PROXY_PORT` | TCP port number to be used for connecting to the Apify Proxy. |
 | `APIFY_PROXY_STATUS_URL` | URL for retrieving proxy status information. Appending `?format=json` to this URL returns the data in JSON format for programmatic processing. |
-| `ACTOR_STANDBY_PORT` | TCP port for the Actor to start an HTTP server to receive messages in the [Actor Standby](/platform/actors/development/programming-interface/standby) mode. |
+| `ACTOR_STANDBY_URL` | URL for accessing web servers of Actor runs in the [Actor Standby](/platform/actors/development/programming-interface/standby) mode. |
 | `ACTOR_STARTED_AT` | Date when the Actor was started. |
 | `ACTOR_TIMEOUT_AT` | Date when the Actor will time out. |
 | `APIFY_TOKEN` | API token of the user who started the Actor. |
 | `APIFY_USER_ID` | ID of the user who started the Actor. May differ from the Actor owner. |
-| `ACTOR_WEB_SERVER_PORT` | TCP port for the Actor to start an HTTP server on. This server can be used to receive external messages or expose monitoring and control interfaces. |
+| `ACTOR_WEB_SERVER_PORT` | TCP port for the Actor to start an HTTP server on. This server can be used to receive external messages or expose monitoring and control interfaces. The server also receives messages from the [Actor Standby](/platform/actors/development/programming-interface/standby) mode. |
 | `ACTOR_WEB_SERVER_URL` | Unique public URL for accessing the Actor run web server from the outside world. |
 | `APIFY_API_PUBLIC_BASE_URL` | Public URL of the Apify API. May be used to interact with the platform programmatically. Typically set to `api.apify.com`. |
 | `APIFY_DEDICATED_CPUS` | Number of CPU cores reserved for the actor, based on allocated memory. |


### PR DESCRIPTION
This PR introduces a new environment variable with Actor standby URL, it also removes the deprecated one for port from the docs and forwards the logic to the web server port env var.