### PR TITLE
fix: fix content width on pages without much content

### DIFF
--- a/apify-docs-theme/src/theme/custom.css
+++ b/apify-docs-theme/src/theme/custom.css
@@ -447,6 +447,12 @@ html[data-theme="dark"] .DocSearch-Button .DocSearch-Search-Icon {
     margin: auto;
 }
 
+@media (min-width: 1440px) {
+    .main-wrapper > div {
+        width: var(--max-layout-width);
+    }
+}
+
 @media (max-width: 960px) {
     .main-wrapper > div {
         max-width: 100%;

--- a/apify-docs-theme/src/theme/custom.css
+++ b/apify-docs-theme/src/theme/custom.css
@@ -445,12 +445,7 @@ html[data-theme="dark"] .DocSearch-Button .DocSearch-Search-Icon {
 .main-wrapper > div {
     max-width: var(--max-layout-width);
     margin: auto;
-}
-
-@media (min-width: 1440px) {
-    .main-wrapper > div {
-        width: var(--max-layout-width);
-    }
+    width: 100%;
 }
 
 @media (max-width: 960px) {


### PR DESCRIPTION
"Solves" misalignment on some pages with too little content.

Before: 

![obrazek](https://github.com/user-attachments/assets/d226837a-288d-4e9e-bf1d-9db4134d5aba)

After: 

https://github.com/user-attachments/assets/264e22f9-b073-4140-ab12-a9324f46ee70

---

The issue persists on mid-size desktop (laptop) screens—the fixed-width styling can only be applied on large enough displays; otherwise, the content gets obscured on other pages with actual content.

The moving sidebar is caused by not having enough content (vertically).