### PR TITLE
feat(docs): Hide dateType property

### DIFF
--- a/sources/platform/actors/development/actor_definition/input_schema/specification.md
+++ b/sources/platform/actors/development/actor_definition/input_schema/specification.md
@@ -181,48 +181,6 @@ Rendered input:
 
 ![Apify Actor input schema - country input](./images/input-schema-country.png)
 
-Example of date selection using absolute and relative `datepicker` editor:
-
-```json
-{
-    "absoluteDate": {
-        "title": "Date",
-        "type": "string",
-        "description": "Select absolute date in format YYYY-MM-DD",
-        "editor": "datepicker",
-        "pattern": "^(\\d{4})-(0[1-9]|1[0-2])-(0[1-9]|[12]\\d|3[01])$"
-    },
-    "relativeDate": {
-        "title": "Relative date",
-        "type": "string",
-        "description": "Select relative date in format +/- {number} {unit}",
-        "editor": "datepicker",
-        "dateType": "relative",
-        "pattern": "^([+-])\\s*(\\d+)\\s*(day|week|month|year)s?$"
-    },
-    "anyDate": {
-        "title": "Any date",
-        "type": "string",
-        "description": "Select date in format YYYY-MM-DD or +/- {number} {unit}",
-        "editor": "datepicker",
-        "dateType": "absoluteOrRelative",
-        "pattern": "^(\\d{4})-(0[1-9]|1[0-2])-(0[1-9]|[12]\\d|3[01])$|^([+-])\\s*(\\d+)\\s*(day|week|month|year)s?$"
-    }
-}
-```
-
-The `absoluteDate` property renders a date picker that allows selection of a specific date and returns string value in `YYYY-MM-DD` format. Validation is ensured thanks to `pattern` field. In this case the `dateType` property is omitted, as it defaults to `"absolute"`.
-
-![Apify Actor input schema - country input](./images/input-schema-date-absolute.png)
-
-The `relativeDate` property renders an input field that enables the user to choose the relative date and returns the value in `+/- {number} {unit}` format, for example `"+ 2 days"`. The `dateType` parameter is set to `"relative"` to restrict input to relative dates only.
-
-![Apify Actor input schema - country input](./images/input-schema-date-relative.png)
-
-The `anyDate` property renders a date picker that accepts both absolute and relative dates. The Actor author is responsible for parsing and interpreting the selected date format.
-
-![Apify Actor input schema - country input](./images/input-schema-date-both.png)
-
 Properties:
 
 | Property     | Value                                                                                                                                                | Required                                   | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
@@ -235,7 +193,6 @@ Properties:
 | `enumTitles` | [String]                                                                                                                                             | No                                         | Titles for the `enum` keys described.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
 | `nullable`   | Boolean                                                                                                                                              | No                                         | Specifies whether `null` <br/>is an allowed value.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
 | `isSecret`   | Boolean                                                                                                                                              | No                                         | Specifies whether the input field<br />will be stored encrypted.<br />Only available <br />with `textfield` and `textarea` editors.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
-| `dateType`   | One of <ul><li>`absolute`</li><li>`relative`</li><li>`absoluteOrRelative`</li></ul>                                                                  | No                                         | This property, which is only available with `datepicker` editor, specifies what date format should visual editor accept (The JSON editor accepts any string without validation.).<br/><br/><ul><li>`absolute` value enables date input in `YYYY-MM-DD` format. To parse returned string regex like this can be used: `^(\d{4})-(0[1-9]\|1[0-2])-(0[1-9]\|[12]\d\|3[01])$`.</li><br/><li>`relative` value enables relative date input in <br/>`+/- {number} {unit}` format. <br/>Supported units are: days, weeks, months, years.<br/><br/>The input is passed to the Actor as plain text (e.g., "+3 weeks"). To parse it, regex like this can be used: `^([+-])\s*(\d+)\s*(day\|week\|month\|year)s?$`.</li><br/><li>`absoluteOrRelative` value enables both absolute and relative formats and user can switch between them. It's up to Actor author to parse a determine actual used format - regexes above can be used to check whether the returned string match one of them.</li></ul><br/>Defaults to `absolute`. |
 
 :::note Regex escape
 


### PR DESCRIPTION
Hide datepicker `dateType` property from docs based on: https://apify.slack.com/archives/C010Q0FBYG3/p1731684960993549