### PR TITLE
chore: Add info about omitted user fields

### DIFF
--- a/sources/platform/api_v2/api_v2_reference.apib
+++ b/sources/platform/api_v2/api_v2_reference.apib
@@ -4011,7 +4011,6 @@ This operation requires no authentication token.
 
 Returns information about the current user account, including both public and private information.
 The user account is identified by the provided authentication token.
-
 The fields `plan`, `email` and `profile` are omitted when this endpoint is accessed from Actor run.
 
 + Response 200 (application/json)

--- a/sources/platform/api_v2/api_v2_reference.apib
+++ b/sources/platform/api_v2/api_v2_reference.apib
@@ -4012,6 +4012,8 @@ This operation requires no authentication token.
 Returns information about the current user account, including both public and private information.
 The user account is identified by the provided authentication token.
 
+The fields `plan`, `email` and `profile` are omitted when this endpoint is accessed from Actor run.
+
 + Response 200 (application/json)
 
     + Attributes


### PR DESCRIPTION
We remove these fields when the endpoint is accessed from the actor run. This is done to avoid leaking sensitive fields to public actors. It's not mentioned anywhere.