### PR TITLE
chore: copy & paste friendly curl API example

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -73,7 +73,7 @@
         },
         "apify-docs-theme": {
             "name": "@apify/docs-theme",
-            "version": "1.0.161",
+            "version": "1.0.162",
             "license": "ISC",
             "dependencies": {
                 "@apify/docs-search-modal": "^1.2.0",

--- a/src/pages/api/index.tsx
+++ b/src/pages/api/index.tsx
@@ -138,20 +138,18 @@ export default function Api() {
                     <ClientCodeWrapper>
                         <CodeBlock title="cURL" language='bash'>
                             {`# Prepare Actor input
-cat > input.json <<'EOF'
-{
- // Define the input in JSON here
-}
-EOF
+echo '{ "searchStringsArray": ["Apify"] }' > input.json
 
-# Run the Actor
-curl "https://api.apify.com/v2/acts/username~actorname/runs?token=<YOUR_API_TOKEN>" \\
-  -X POST \\
-  -d @input.json \\
-  -H 'Content-Type: application/json'
+# Run the Actor and retreive its default dataset id.
+curl -X POST -d @input.json -H 'Content-Type: application/json' \\
+  -s -o >(tee run.json) \\
+  https://api.apify.com/v2/acts/compass~crawler-google-places/runs?token=<YOUR_API_TOKEN>
 
-# Use the defaultDatasetId from response and pass it instead of <DATASET_ID>
-curl "https://api.apify.com/v2/datasets/<DATASET_ID>/items?token=<YOUR_API_TOKEN>"`
+# Find the defaultDatasetId in the API response 
+cat run.json | jq -r .data.defaultDatasetId
+
+# And pass it instead of <DATASET_ID>
+curl https://api.apify.com/v2/datasets/<DATASET>/items?token=<YOUR_API_TOKEN>`
                             }
                         </CodeBlock>
                     </ClientCodeWrapper>

--- a/src/pages/api/index.tsx
+++ b/src/pages/api/index.tsx
@@ -140,17 +140,12 @@ export default function Api() {
                             {`# Prepare Actor input
 echo '{ "searchStringsArray": ["Apify"] }' > input.json
 
-# Run the Actor and retreive its default dataset id.
-curl -X POST -d @input.json -H 'Content-Type: application/json' \\
-  -s -o >(tee run.json) \\
-  https://api.apify.com/v2/acts/compass~crawler-google-places/runs?token=<YOUR_API_TOKEN>
-
-# Find the defaultDatasetId in the API response 
-cat run.json | jq -r .data.defaultDatasetId
-
-# And pass it instead of <DATASET_ID>
-curl https://api.apify.com/v2/datasets/<DATASET>/items?token=<YOUR_API_TOKEN>`
-                            }
+# Run the Actor and retreive its default dataset content.
+curl -X POST -d @input.json \\
+  -H 'Content-Type: application/json' \\
+  -H 'Authorization: Bearer <YOUR_API_TOKEN>' \\
+  -L 'https://api.apify.com/v2/acts/compass~crawler-google-places/run-sync-get-dataset-items'
+                           `}
                         </CodeBlock>
                     </ClientCodeWrapper>
                 </SectionWrapper>

--- a/src/pages/api/index.tsx
+++ b/src/pages/api/index.tsx
@@ -137,11 +137,9 @@ export default function Api() {
                 >
                     <ClientCodeWrapper>
                         <CodeBlock title="cURL" language='bash'>
-                            {`# Prepare Actor input
-echo '{ "searchStringsArray": ["Apify"] }' > input.json
-
-# Run the Actor and retreive its default dataset content.
-curl -X POST -d @input.json \\
+                            {`# Prepare Actor input and run it synchronously
+echo '{ "searchStringsArray": ["Apify"] }' |
+curl -X POST -d @- \\
   -H 'Content-Type: application/json' \\
   -H 'Authorization: Bearer <YOUR_API_TOKEN>' \\
   -L 'https://api.apify.com/v2/acts/compass~crawler-google-places/run-sync-get-dataset-items'


### PR DESCRIPTION
<img width="623" alt="image" src="https://github.com/user-attachments/assets/f839e94b-a9e8-45ce-a03e-12cf962367b8">

- the commands are restructured in a way that the editable part is always at the end of the snippet (especially annoying in multi-line snippets)
- added the saving of the response of the Run to a `run.json `
- added convenience `jq` command to find the dataset in the Actor run response
- removed (imo) unnecessary quotes
- squished the per command line breaks to save lines

Please, try it yourself before merging:

```
# Prepare Actor input
echo '{ "searchStringsArray": ["Apify"] }' > input.json

# Run the Actor and retreive its default dataset id.
curl -X POST -d @input.json -H 'Content-Type: application/json' \
  -s -o >(tee run.json) \
  https://api.apify.com/v2/acts/compass~crawler-google-places/runs?token=<YOUR_API_TOKEN>

# Find the defaultDatasetId in the API response 
cat run.json | jq -r .data.defaultDatasetId

# And pass it instead of <DATASET_ID>
curl https://api.apify.com/v2/datasets/<DATASET>/items?token=<YOUR_API_TOKEN>
```

