### PR TITLE
fix: disable `@docusaurus/faster` for now

### DIFF
--- a/apify-docs-theme/src/theme/custom.css
+++ b/apify-docs-theme/src/theme/custom.css
@@ -1779,3 +1779,10 @@ iframe[src*="youtube"] {
         margin-left: 5px;
     }
 }
+
+@media (max-width: 768px) {
+    .DocSearch-Button-Keys,
+    .DocSearch-Button-Placeholder {
+        display: none !important;
+    }
+}

--- a/apify-docs-theme/src/theme/custom.css
+++ b/apify-docs-theme/src/theme/custom.css
@@ -1769,3 +1769,13 @@ iframe[src*="youtube"] {
     font-size: var(--ifm-h1-font-size);
     margin-bottom: calc(var(--ifm-h1-vertical-rhythm-bottom)* var(--ifm-leading)) !important;
 }
+
+@media (max-width: 996px) {
+    div[class^="navbarSearchContainer"] {
+        position: static;
+    }
+
+    div[class^="navbarSearchContainer"] button {
+        margin-left: 5px;
+    }
+}

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -16,9 +16,9 @@ module.exports = {
     organizationName: 'apify',
     projectName: 'apify-docs',
     scripts: ['/js/custom.js'],
-    future: {
-        experimental_faster: true,
-    },
+    // future: {
+    //     experimental_faster: true,
+    // },
     headTags: [
         {
             tagName: 'link',

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,6 +47,7 @@
             "devDependencies": {
                 "@apify/eslint-config-ts": "^0.4.1",
                 "@apify/tsconfig": "^0.1.0",
+                "@rsbuild/plugin-styled-components": "^1.1.0",
                 "@types/react": "^18.2.8",
                 "@typescript-eslint/eslint-plugin": "^7.0.0",
                 "@typescript-eslint/parser": "^7.0.0",
@@ -628,28 +629,6 @@
             },
             "engines": {
                 "node": ">=6.0.0"
-            }
-        },
-        "node_modules/@antfu/install-pkg": {
-            "version": "0.4.1",
-            "resolved": "https://registry.npmjs.org/@antfu/install-pkg/-/install-pkg-0.4.1.tgz",
-            "integrity": "sha512-T7yB5QNG29afhWVkVq7XeIMBa5U/vs9mX69YqayXypPRmYzUmzwnYltplHmPtZ4HPCn+sQKeXW8I47wCbuBOjw==",
-            "license": "MIT",
-            "dependencies": {
-                "package-manager-detector": "^0.2.0",
-                "tinyexec": "^0.3.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/antfu"
-            }
-        },
-        "node_modules/@antfu/utils": {
-            "version": "0.7.10",
-            "resolved": "https://registry.npmjs.org/@antfu/utils/-/utils-0.7.10.tgz",
-            "integrity": "sha512-+562v9k4aI80m1+VuMHehNJWLOFjBnXn3tdOitzD0il5b7smkSBal4+a3oKiQTbrwMmN/TBUMDvbdoWDehgOww==",
-            "license": "MIT",
-            "funding": {
-                "url": "https://github.com/sponsors/antfu"
             }
         },
         "node_modules/@apidevtools/json-schema-ref-parser": {
@@ -2528,9 +2507,9 @@
             }
         },
         "node_modules/@braintree/sanitize-url": {
-            "version": "7.1.0",
-            "resolved": "https://registry.npmjs.org/@braintree/sanitize-url/-/sanitize-url-7.1.0.tgz",
-            "integrity": "sha512-o+UlMLt49RvtCASlOMW0AkHnabN9wR9rwCCherxO0yG4Npy34GkvrAqdXQvrhNs+jh+gkK8gB8Lf05qL/O7KWg==",
+            "version": "6.0.4",
+            "resolved": "https://registry.npmjs.org/@braintree/sanitize-url/-/sanitize-url-6.0.4.tgz",
+            "integrity": "sha512-s3jaWicZd0pkP0jf5ysyHUI/RE7MHos6qlToFcGWXVp+ykHOy77OUMrfbgJ9it2C5bow7OIQwYYaHjk9XlBQ2A==",
             "license": "MIT"
         },
         "node_modules/@cfaester/enzyme-adapter-react-18": {
@@ -2556,45 +2535,6 @@
             "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
             "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
             "license": "MIT"
-        },
-        "node_modules/@chevrotain/cst-dts-gen": {
-            "version": "11.0.3",
-            "resolved": "https://registry.npmjs.org/@chevrotain/cst-dts-gen/-/cst-dts-gen-11.0.3.tgz",
-            "integrity": "sha512-BvIKpRLeS/8UbfxXxgC33xOumsacaeCKAjAeLyOn7Pcp95HiRbrpl14S+9vaZLolnbssPIUuiUd8IvgkRyt6NQ==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@chevrotain/gast": "11.0.3",
-                "@chevrotain/types": "11.0.3",
-                "lodash-es": "4.17.21"
-            }
-        },
-        "node_modules/@chevrotain/gast": {
-            "version": "11.0.3",
-            "resolved": "https://registry.npmjs.org/@chevrotain/gast/-/gast-11.0.3.tgz",
-            "integrity": "sha512-+qNfcoNk70PyS/uxmj3li5NiECO+2YKZZQMbmjTqRI3Qchu8Hig/Q9vgkHpI3alNjr7M+a2St5pw5w5F6NL5/Q==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@chevrotain/types": "11.0.3",
-                "lodash-es": "4.17.21"
-            }
-        },
-        "node_modules/@chevrotain/regexp-to-ast": {
-            "version": "11.0.3",
-            "resolved": "https://registry.npmjs.org/@chevrotain/regexp-to-ast/-/regexp-to-ast-11.0.3.tgz",
-            "integrity": "sha512-1fMHaBZxLFvWI067AVbGJav1eRY7N8DDvYCTwGBiE/ytKBgP8azTdgyrKyWZ9Mfh09eHWb5PgTSO8wi7U824RA==",
-            "license": "Apache-2.0"
-        },
-        "node_modules/@chevrotain/types": {
-            "version": "11.0.3",
-            "resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-11.0.3.tgz",
-            "integrity": "sha512-gsiM3G8b58kZC2HaWR50gu6Y1440cHiJ+i3JUvcp/35JchYejb2+5MVeJK0iKThYpAa/P2PYFV4hoi44HD+aHQ==",
-            "license": "Apache-2.0"
-        },
-        "node_modules/@chevrotain/utils": {
-            "version": "11.0.3",
-            "resolved": "https://registry.npmjs.org/@chevrotain/utils/-/utils-11.0.3.tgz",
-            "integrity": "sha512-YslZMgtJUyuMbZ+aKvfF3x1f5liK4mWNxghFRv7jqRR9C3R3fAOGTTKvxXDa2Y1s9zSbcpuO0cAxDYsc9SrXoQ==",
-            "license": "Apache-2.0"
         },
         "node_modules/@colors/colors": {
             "version": "1.5.0",
@@ -5869,6 +5809,20 @@
                 "react-dom": "^18.0.0"
             }
         },
+        "node_modules/@docusaurus/core/node_modules/webpack-merge": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-6.0.1.tgz",
+            "integrity": "sha512-hXXvrjtx2PLYx4qruKl+kyRSLc52V+cCvMxRjmKwoA+CBbbF5GfIBtR6kCvl0fYGqTUPKB+1ktVmTHqMOzgCBg==",
+            "license": "MIT",
+            "dependencies": {
+                "clone-deep": "^4.0.1",
+                "flat": "^5.0.2",
+                "wildcard": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
         "node_modules/@docusaurus/cssnano-preset": {
             "version": "3.6.3",
             "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-3.6.3.tgz",
@@ -7142,20 +7096,6 @@
                 "react-dom": "^18.0.0"
             }
         },
-        "node_modules/@docusaurus/types/node_modules/webpack-merge": {
-            "version": "5.10.0",
-            "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
-            "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
-            "license": "MIT",
-            "dependencies": {
-                "clone-deep": "^4.0.1",
-                "flat": "^5.0.2",
-                "wildcard": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=10.0.0"
-            }
-        },
         "node_modules/@docusaurus/utils": {
             "version": "3.6.3",
             "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-3.6.3.tgz",
@@ -7567,27 +7507,6 @@
             "dev": true,
             "license": "BSD-3-Clause"
         },
-        "node_modules/@iconify/types": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/@iconify/types/-/types-2.0.0.tgz",
-            "integrity": "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==",
-            "license": "MIT"
-        },
-        "node_modules/@iconify/utils": {
-            "version": "2.1.33",
-            "resolved": "https://registry.npmjs.org/@iconify/utils/-/utils-2.1.33.tgz",
-            "integrity": "sha512-jP9h6v/g0BIZx0p7XGJJVtkVnydtbgTgt9mVNcGDYwaa7UhdHdI9dvoq+gKj9sijMSJKxUPEG2JyjsgXjxL7Kw==",
-            "license": "MIT",
-            "dependencies": {
-                "@antfu/install-pkg": "^0.4.0",
-                "@antfu/utils": "^0.7.10",
-                "@iconify/types": "^2.0.0",
-                "debug": "^4.3.6",
-                "kolorist": "^1.8.0",
-                "local-pkg": "^0.5.0",
-                "mlly": "^1.7.1"
-            }
-        },
         "node_modules/@isaacs/cliui": {
             "version": "8.0.2",
             "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
@@ -7797,15 +7716,6 @@
             "peerDependencies": {
                 "@types/react": ">=16",
                 "react": ">=16"
-            }
-        },
-        "node_modules/@mermaid-js/parser": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/@mermaid-js/parser/-/parser-0.3.0.tgz",
-            "integrity": "sha512-HsvL6zgE5sUPGgkIDlmAWR1HTNHz2Iy11BAWPTa4Jjabkpguy4Ze2gzfLrg6pdRuBvFwgUYyxiaNqZwrEEXepA==",
-            "license": "MIT",
-            "dependencies": {
-                "langium": "3.0.0"
             }
         },
         "node_modules/@module-federation/runtime": {
@@ -8341,6 +8251,25 @@
                     "optional": true
                 },
                 "react-redux": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@rsbuild/plugin-styled-components": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@rsbuild/plugin-styled-components/-/plugin-styled-components-1.1.0.tgz",
+            "integrity": "sha512-KeFJOpb1dTV98zOHWOM6Dc8V/Eo9evL1NNuFarTfm+ESOBdeXSX0uE/CreVQKmRqS0JTFk7pJwHCpssxcPaA+g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@swc/plugin-styled-components": "5.0.0",
+                "reduce-configs": "^1.0.0"
+            },
+            "peerDependencies": {
+                "@rsbuild/core": "1.x"
+            },
+            "peerDependenciesMeta": {
+                "@rsbuild/core": {
                     "optional": true
                 }
             }
@@ -9232,6 +9161,16 @@
                 "node": ">=10"
             }
         },
+        "node_modules/@swc/plugin-styled-components": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/@swc/plugin-styled-components/-/plugin-styled-components-5.0.0.tgz",
+            "integrity": "sha512-c9WCV2hU4OxfczzeABNFwkLftAovP7IeHPX0nxqu1HMn4x/T6MjWoJ22hspBv32NpUwGlvIgRG3SyHRHE80enw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@swc/counter": "^0.1.3"
+            }
+        },
         "node_modules/@swc/types": {
             "version": "0.1.17",
             "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.17.tgz",
@@ -9309,192 +9248,6 @@
                 "@types/node": "*"
             }
         },
-        "node_modules/@types/d3": {
-            "version": "7.4.3",
-            "resolved": "https://registry.npmjs.org/@types/d3/-/d3-7.4.3.tgz",
-            "integrity": "sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww==",
-            "license": "MIT",
-            "dependencies": {
-                "@types/d3-array": "*",
-                "@types/d3-axis": "*",
-                "@types/d3-brush": "*",
-                "@types/d3-chord": "*",
-                "@types/d3-color": "*",
-                "@types/d3-contour": "*",
-                "@types/d3-delaunay": "*",
-                "@types/d3-dispatch": "*",
-                "@types/d3-drag": "*",
-                "@types/d3-dsv": "*",
-                "@types/d3-ease": "*",
-                "@types/d3-fetch": "*",
-                "@types/d3-force": "*",
-                "@types/d3-format": "*",
-                "@types/d3-geo": "*",
-                "@types/d3-hierarchy": "*",
-                "@types/d3-interpolate": "*",
-                "@types/d3-path": "*",
-                "@types/d3-polygon": "*",
-                "@types/d3-quadtree": "*",
-                "@types/d3-random": "*",
-                "@types/d3-scale": "*",
-                "@types/d3-scale-chromatic": "*",
-                "@types/d3-selection": "*",
-                "@types/d3-shape": "*",
-                "@types/d3-time": "*",
-                "@types/d3-time-format": "*",
-                "@types/d3-timer": "*",
-                "@types/d3-transition": "*",
-                "@types/d3-zoom": "*"
-            }
-        },
-        "node_modules/@types/d3-array": {
-            "version": "3.2.1",
-            "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.1.tgz",
-            "integrity": "sha512-Y2Jn2idRrLzUfAKV2LyRImR+y4oa2AntrgID95SHJxuMUrkNXmanDSed71sRNZysveJVt1hLLemQZIady0FpEg==",
-            "license": "MIT"
-        },
-        "node_modules/@types/d3-axis": {
-            "version": "3.0.6",
-            "resolved": "https://registry.npmjs.org/@types/d3-axis/-/d3-axis-3.0.6.tgz",
-            "integrity": "sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw==",
-            "license": "MIT",
-            "dependencies": {
-                "@types/d3-selection": "*"
-            }
-        },
-        "node_modules/@types/d3-brush": {
-            "version": "3.0.6",
-            "resolved": "https://registry.npmjs.org/@types/d3-brush/-/d3-brush-3.0.6.tgz",
-            "integrity": "sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A==",
-            "license": "MIT",
-            "dependencies": {
-                "@types/d3-selection": "*"
-            }
-        },
-        "node_modules/@types/d3-chord": {
-            "version": "3.0.6",
-            "resolved": "https://registry.npmjs.org/@types/d3-chord/-/d3-chord-3.0.6.tgz",
-            "integrity": "sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg==",
-            "license": "MIT"
-        },
-        "node_modules/@types/d3-color": {
-            "version": "3.1.3",
-            "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
-            "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
-            "license": "MIT"
-        },
-        "node_modules/@types/d3-contour": {
-            "version": "3.0.6",
-            "resolved": "https://registry.npmjs.org/@types/d3-contour/-/d3-contour-3.0.6.tgz",
-            "integrity": "sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg==",
-            "license": "MIT",
-            "dependencies": {
-                "@types/d3-array": "*",
-                "@types/geojson": "*"
-            }
-        },
-        "node_modules/@types/d3-delaunay": {
-            "version": "6.0.4",
-            "resolved": "https://registry.npmjs.org/@types/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
-            "integrity": "sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw==",
-            "license": "MIT"
-        },
-        "node_modules/@types/d3-dispatch": {
-            "version": "3.0.6",
-            "resolved": "https://registry.npmjs.org/@types/d3-dispatch/-/d3-dispatch-3.0.6.tgz",
-            "integrity": "sha512-4fvZhzMeeuBJYZXRXrRIQnvUYfyXwYmLsdiN7XXmVNQKKw1cM8a5WdID0g1hVFZDqT9ZqZEY5pD44p24VS7iZQ==",
-            "license": "MIT"
-        },
-        "node_modules/@types/d3-drag": {
-            "version": "3.0.7",
-            "resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-3.0.7.tgz",
-            "integrity": "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==",
-            "license": "MIT",
-            "dependencies": {
-                "@types/d3-selection": "*"
-            }
-        },
-        "node_modules/@types/d3-dsv": {
-            "version": "3.0.7",
-            "resolved": "https://registry.npmjs.org/@types/d3-dsv/-/d3-dsv-3.0.7.tgz",
-            "integrity": "sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g==",
-            "license": "MIT"
-        },
-        "node_modules/@types/d3-ease": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
-            "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
-            "license": "MIT"
-        },
-        "node_modules/@types/d3-fetch": {
-            "version": "3.0.7",
-            "resolved": "https://registry.npmjs.org/@types/d3-fetch/-/d3-fetch-3.0.7.tgz",
-            "integrity": "sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA==",
-            "license": "MIT",
-            "dependencies": {
-                "@types/d3-dsv": "*"
-            }
-        },
-        "node_modules/@types/d3-force": {
-            "version": "3.0.10",
-            "resolved": "https://registry.npmjs.org/@types/d3-force/-/d3-force-3.0.10.tgz",
-            "integrity": "sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw==",
-            "license": "MIT"
-        },
-        "node_modules/@types/d3-format": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/@types/d3-format/-/d3-format-3.0.4.tgz",
-            "integrity": "sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g==",
-            "license": "MIT"
-        },
-        "node_modules/@types/d3-geo": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/@types/d3-geo/-/d3-geo-3.1.0.tgz",
-            "integrity": "sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ==",
-            "license": "MIT",
-            "dependencies": {
-                "@types/geojson": "*"
-            }
-        },
-        "node_modules/@types/d3-hierarchy": {
-            "version": "3.1.7",
-            "resolved": "https://registry.npmjs.org/@types/d3-hierarchy/-/d3-hierarchy-3.1.7.tgz",
-            "integrity": "sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg==",
-            "license": "MIT"
-        },
-        "node_modules/@types/d3-interpolate": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
-            "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
-            "license": "MIT",
-            "dependencies": {
-                "@types/d3-color": "*"
-            }
-        },
-        "node_modules/@types/d3-path": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.0.tgz",
-            "integrity": "sha512-P2dlU/q51fkOc/Gfl3Ul9kicV7l+ra934qBFXCFhrZMOL6du1TM0pm1ThYvENukyOn5h9v+yMJ9Fn5JK4QozrQ==",
-            "license": "MIT"
-        },
-        "node_modules/@types/d3-polygon": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/@types/d3-polygon/-/d3-polygon-3.0.2.tgz",
-            "integrity": "sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA==",
-            "license": "MIT"
-        },
-        "node_modules/@types/d3-quadtree": {
-            "version": "3.0.6",
-            "resolved": "https://registry.npmjs.org/@types/d3-quadtree/-/d3-quadtree-3.0.6.tgz",
-            "integrity": "sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg==",
-            "license": "MIT"
-        },
-        "node_modules/@types/d3-random": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/@types/d3-random/-/d3-random-3.0.3.tgz",
-            "integrity": "sha512-Imagg1vJ3y76Y2ea0871wpabqp613+8/r0mCLEBfdtqC7xMSfj9idOnmBYyMoULfHePJyxMAw3nWhJxzc+LFwQ==",
-            "license": "MIT"
-        },
         "node_modules/@types/d3-scale": {
             "version": "4.0.8",
             "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.8.tgz",
@@ -9505,62 +9258,16 @@
             }
         },
         "node_modules/@types/d3-scale-chromatic": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/@types/d3-scale-chromatic/-/d3-scale-chromatic-3.0.3.tgz",
-            "integrity": "sha512-laXM4+1o5ImZv3RpFAsTRn3TEkzqkytiOY0Dz0sq5cnd1dtNlk6sHLon4OvqaiJb28T0S/TdsBI3Sjsy+keJrw==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/@types/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+            "integrity": "sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ==",
             "license": "MIT"
-        },
-        "node_modules/@types/d3-selection": {
-            "version": "3.0.11",
-            "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-3.0.11.tgz",
-            "integrity": "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==",
-            "license": "MIT"
-        },
-        "node_modules/@types/d3-shape": {
-            "version": "3.1.6",
-            "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.6.tgz",
-            "integrity": "sha512-5KKk5aKGu2I+O6SONMYSNflgiP0WfZIQvVUMan50wHsLG1G94JlxEVnCpQARfTtzytuY0p/9PXXZb3I7giofIA==",
-            "license": "MIT",
-            "dependencies": {
-                "@types/d3-path": "*"
-            }
         },
         "node_modules/@types/d3-time": {
             "version": "3.0.4",
             "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
             "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
             "license": "MIT"
-        },
-        "node_modules/@types/d3-time-format": {
-            "version": "4.0.3",
-            "resolved": "https://registry.npmjs.org/@types/d3-time-format/-/d3-time-format-4.0.3.tgz",
-            "integrity": "sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg==",
-            "license": "MIT"
-        },
-        "node_modules/@types/d3-timer": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
-            "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
-            "license": "MIT"
-        },
-        "node_modules/@types/d3-transition": {
-            "version": "3.0.9",
-            "resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-3.0.9.tgz",
-            "integrity": "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==",
-            "license": "MIT",
-            "dependencies": {
-                "@types/d3-selection": "*"
-            }
-        },
-        "node_modules/@types/d3-zoom": {
-            "version": "3.0.8",
-            "resolved": "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-3.0.8.tgz",
-            "integrity": "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==",
-            "license": "MIT",
-            "dependencies": {
-                "@types/d3-interpolate": "*",
-                "@types/d3-selection": "*"
-            }
         },
         "node_modules/@types/debug": {
             "version": "4.1.12",
@@ -9569,15 +9276,6 @@
             "license": "MIT",
             "dependencies": {
                 "@types/ms": "*"
-            }
-        },
-        "node_modules/@types/dompurify": {
-            "version": "3.0.5",
-            "resolved": "https://registry.npmjs.org/@types/dompurify/-/dompurify-3.0.5.tgz",
-            "integrity": "sha512-1Wg0g3BtQF7sSb27fJQAKck1HECM6zV1EB66j8JH9i3LCjYabJa0FSdiSgsD5K/RbrsR0SiraKacLB+T8ZVYAg==",
-            "license": "MIT",
-            "dependencies": {
-                "@types/trusted-types": "*"
             }
         },
         "node_modules/@types/eslint": {
@@ -9655,12 +9353,6 @@
             "version": "3.0.4",
             "resolved": "https://registry.npmjs.org/@types/extend/-/extend-3.0.4.tgz",
             "integrity": "sha512-ArMouDUTJEz1SQRpFsT2rIw7DeqICFv5aaVzLSIYMYQSLcwcGOfT3VyglQs/p7K3F7fT4zxr0NWxYZIdifD6dA==",
-            "license": "MIT"
-        },
-        "node_modules/@types/geojson": {
-            "version": "7946.0.14",
-            "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.14.tgz",
-            "integrity": "sha512-WCfD5Ht3ZesJUsONdhvm84dmzWOiOzOAqOncN0++w0lBw1o8OuDNJF2McvvCef/yBqb/HYRahp1BYtODFQ8bRg==",
             "license": "MIT"
         },
         "node_modules/@types/gtag.js": {
@@ -11799,32 +11491,6 @@
                 "url": "https://github.com/sponsors/fb55"
             }
         },
-        "node_modules/chevrotain": {
-            "version": "11.0.3",
-            "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-11.0.3.tgz",
-            "integrity": "sha512-ci2iJH6LeIkvP9eJW6gpueU8cnZhv85ELY8w8WiFtNjMHA5ad6pQLaJo9mEly/9qUyCpvqX8/POVUTf18/HFdw==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@chevrotain/cst-dts-gen": "11.0.3",
-                "@chevrotain/gast": "11.0.3",
-                "@chevrotain/regexp-to-ast": "11.0.3",
-                "@chevrotain/types": "11.0.3",
-                "@chevrotain/utils": "11.0.3",
-                "lodash-es": "4.17.21"
-            }
-        },
-        "node_modules/chevrotain-allstar": {
-            "version": "0.3.1",
-            "resolved": "https://registry.npmjs.org/chevrotain-allstar/-/chevrotain-allstar-0.3.1.tgz",
-            "integrity": "sha512-b7g+y9A0v4mxCW1qUhf3BSVPg+/NvGErk/dOkrDaHA0nQIQGAtrOjlX//9OQtRlSCy+x9rfB5N8yC71lH1nvMw==",
-            "license": "MIT",
-            "dependencies": {
-                "lodash-es": "^4.17.21"
-            },
-            "peerDependencies": {
-                "chevrotain": "^11.0.0"
-            }
-        },
         "node_modules/chokidar": {
             "version": "3.6.0",
             "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
@@ -11874,9 +11540,9 @@
             }
         },
         "node_modules/cipher-base": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.5.tgz",
-            "integrity": "sha512-xq7ICKB4TMHUx7Tz1L9O2SGKOhYMOTR32oir45Bq28/AQTpHogKgHcoYFSdRbMtddl+ozNXfXY9jWcgYKmde0w==",
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.6.tgz",
+            "integrity": "sha512-3Ek9H3X6pj5TgenXYtNWdaBon1tgYCaebd+XPg0keyjEbEfkD4KkmAxkQ/i1vYvxdcT5nscLBfq9VJRmCBcFSw==",
             "license": "MIT",
             "dependencies": {
                 "inherits": "^2.0.4",
@@ -12205,12 +11871,6 @@
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
             "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-            "license": "MIT"
-        },
-        "node_modules/confbox": {
-            "version": "0.1.8",
-            "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
-            "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
             "license": "MIT"
         },
         "node_modules/config-chain": {
@@ -13018,33 +12678,6 @@
                 "cytoscape": "^3.2.0"
             }
         },
-        "node_modules/cytoscape-fcose": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/cytoscape-fcose/-/cytoscape-fcose-2.2.0.tgz",
-            "integrity": "sha512-ki1/VuRIHFCzxWNrsshHYPs6L7TvLu3DL+TyIGEsRcvVERmxokbf5Gdk7mFxZnTdiGtnA4cfSmjZJMviqSuZrQ==",
-            "license": "MIT",
-            "dependencies": {
-                "cose-base": "^2.2.0"
-            },
-            "peerDependencies": {
-                "cytoscape": "^3.2.0"
-            }
-        },
-        "node_modules/cytoscape-fcose/node_modules/cose-base": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/cose-base/-/cose-base-2.2.0.tgz",
-            "integrity": "sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g==",
-            "license": "MIT",
-            "dependencies": {
-                "layout-base": "^2.0.0"
-            }
-        },
-        "node_modules/cytoscape-fcose/node_modules/layout-base": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/layout-base/-/layout-base-2.0.1.tgz",
-            "integrity": "sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg==",
-            "license": "MIT"
-        },
         "node_modules/d3": {
             "version": "7.9.0",
             "resolved": "https://registry.npmjs.org/d3/-/d3-7.9.0.tgz",
@@ -13496,12 +13129,12 @@
             }
         },
         "node_modules/dagre-d3-es": {
-            "version": "7.0.11",
-            "resolved": "https://registry.npmjs.org/dagre-d3-es/-/dagre-d3-es-7.0.11.tgz",
-            "integrity": "sha512-tvlJLyQf834SylNKax8Wkzco/1ias1OPw8DcUMDE7oUIoSEW25riQVuiu/0OWEFqT0cxHT3Pa9/D82Jr47IONw==",
+            "version": "7.0.10",
+            "resolved": "https://registry.npmjs.org/dagre-d3-es/-/dagre-d3-es-7.0.10.tgz",
+            "integrity": "sha512-qTCQmEhcynucuaZgY5/+ti3X/rnszKZhEQH/ZdWdtP1tA/y3VoHJzcVrO9pjjJCNpigfscAtoUB5ONcd2wNn0A==",
             "license": "MIT",
             "dependencies": {
-                "d3": "^7.9.0",
+                "d3": "^7.8.2",
                 "lodash-es": "^4.17.21"
             }
         },
@@ -14111,18 +13744,6 @@
                 "npm": ">=7.0.0"
             }
         },
-        "node_modules/docusaurus-plugin-redoc/node_modules/marked": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
-            "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
-            "license": "MIT",
-            "bin": {
-                "marked": "bin/marked.js"
-            },
-            "engines": {
-                "node": ">= 12"
-            }
-        },
         "node_modules/docusaurus-plugin-redoc/node_modules/redoc": {
             "version": "2.1.5",
             "resolved": "https://registry.npmjs.org/redoc/-/redoc-2.1.5.tgz",
@@ -14226,17 +13847,15 @@
             }
         },
         "node_modules/docusaurus-theme-redoc": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/docusaurus-theme-redoc/-/docusaurus-theme-redoc-2.2.0.tgz",
-            "integrity": "sha512-oeREQZ7xf3qbkHSAvPVciGlssSb80zx+1GkiymM0sZwuZbD6FbTc6g1Dz81j8oCv0asSiRbsGo62KnpAatjnOg==",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/docusaurus-theme-redoc/-/docusaurus-theme-redoc-2.1.1.tgz",
+            "integrity": "sha512-a9yuYyGVhj7NgBYiqJyjLEkJg/yTdsqg9Rn/cG8YXMIFwxIpn4tanIplUqwisK2PS81ZxOv7SfSgvGm/FSi/wA==",
             "license": "MIT",
             "dependencies": {
                 "@redocly/openapi-core": "1.16.0",
                 "clsx": "^1.2.1",
                 "lodash": "^4.17.21",
                 "mobx": "^6.12.4",
-                "postcss": "^8.4.45",
-                "postcss-prefix-selector": "^1.16.1",
                 "redoc": "2.1.5",
                 "styled-components": "^6.1.11"
             },
@@ -14284,18 +13903,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">=6"
-            }
-        },
-        "node_modules/docusaurus-theme-redoc/node_modules/marked": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
-            "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
-            "license": "MIT",
-            "bin": {
-                "marked": "bin/marked.js"
-            },
-            "engines": {
-                "node": ">= 12"
             }
         },
         "node_modules/docusaurus-theme-redoc/node_modules/redoc": {
@@ -14487,6 +14094,12 @@
             "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.64.tgz",
             "integrity": "sha512-IXEuxU+5ClW2IGEYFC2T7szbyVgehupCWQe5GNh+H065CD6U6IFN0s4KeAMFGNmQolRU4IV7zGBWSYMmZ8uuqQ==",
             "license": "ISC"
+        },
+        "node_modules/elkjs": {
+            "version": "0.9.3",
+            "resolved": "https://registry.npmjs.org/elkjs/-/elkjs-0.9.3.tgz",
+            "integrity": "sha512-f/ZeWvW/BCXbhGEf1Ujp29EASo/lk1FDnETgNKwJrsVvGZhUWCZyg3xLJjAsxfOmt8KjswHmI5EwCQcPMpOYhQ==",
+            "license": "EPL-2.0"
         },
         "node_modules/elliptic": {
             "version": "6.6.1",
@@ -16982,12 +16595,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/hachure-fill": {
-            "version": "0.5.2",
-            "resolved": "https://registry.npmjs.org/hachure-fill/-/hachure-fill-0.5.2.tgz",
-            "integrity": "sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==",
-            "license": "MIT"
-        },
         "node_modules/handle-thing": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-2.0.1.tgz",
@@ -19202,28 +18809,6 @@
                 "node": ">=6"
             }
         },
-        "node_modules/kolorist": {
-            "version": "1.8.0",
-            "resolved": "https://registry.npmjs.org/kolorist/-/kolorist-1.8.0.tgz",
-            "integrity": "sha512-Y+60/zizpJ3HRH8DCss+q95yr6145JXZo46OTpFvDZWLfRCE4qChOyk1b26nMaNpfHHgxagk9dXT5OP0Tfe+dQ==",
-            "license": "MIT"
-        },
-        "node_modules/langium": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/langium/-/langium-3.0.0.tgz",
-            "integrity": "sha512-+Ez9EoiByeoTu/2BXmEaZ06iPNXM6thWJp02KfBO/raSMyCJ4jw7AkWWa+zBCTm0+Tw1Fj9FOxdqSskyN5nAwg==",
-            "license": "MIT",
-            "dependencies": {
-                "chevrotain": "~11.0.3",
-                "chevrotain-allstar": "~0.3.0",
-                "vscode-languageserver": "~9.0.1",
-                "vscode-languageserver-textdocument": "~1.0.11",
-                "vscode-uri": "~3.0.8"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
         "node_modules/language-subtag-registry": {
             "version": "0.3.23",
             "resolved": "https://registry.npmjs.org/language-subtag-registry/-/language-subtag-registry-0.3.23.tgz",
@@ -19617,22 +19202,6 @@
                 "node": ">=8.9.0"
             }
         },
-        "node_modules/local-pkg": {
-            "version": "0.5.1",
-            "resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-0.5.1.tgz",
-            "integrity": "sha512-9rrA30MRRP3gBD3HTGnC6cDFpaE1kVDWxWgqWJUN0RvDNAo+Nz/9GxB+nHOH0ifbVFy0hSA1V6vFDvnx54lTEQ==",
-            "license": "MIT",
-            "dependencies": {
-                "mlly": "^1.7.3",
-                "pkg-types": "^1.2.1"
-            },
-            "engines": {
-                "node": ">=14"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/antfu"
-            }
-        },
         "node_modules/locate-path": {
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -19925,15 +19494,15 @@
             }
         },
         "node_modules/marked": {
-            "version": "13.0.3",
-            "resolved": "https://registry.npmjs.org/marked/-/marked-13.0.3.tgz",
-            "integrity": "sha512-rqRix3/TWzE9rIoFGIn8JmsVfhiuC8VIQ8IdX5TfzmeBucdY05/0UlzKaw0eVtpcN/OdVFpBk7CjKGo9iHJ/zA==",
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
+            "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
             "license": "MIT",
             "bin": {
                 "marked": "bin/marked.js"
             },
             "engines": {
-                "node": ">= 18"
+                "node": ">= 12"
             }
         },
         "node_modules/md5.js": {
@@ -24068,39 +23637,164 @@
             }
         },
         "node_modules/mermaid": {
-            "version": "11.4.0",
-            "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.4.0.tgz",
-            "integrity": "sha512-mxCfEYvADJqOiHfGpJXLs4/fAjHz448rH0pfY5fAoxiz70rQiDSzUUy4dNET2T08i46IVpjohPd6WWbzmRHiPA==",
+            "version": "10.9.3",
+            "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-10.9.3.tgz",
+            "integrity": "sha512-V80X1isSEvAewIL3xhmz/rVmc27CVljcsbWxkxlWJWY/1kQa4XOABqpDl2qQLGKzpKm6WbTfUEKImBlUfFYArw==",
             "license": "MIT",
             "dependencies": {
-                "@braintree/sanitize-url": "^7.0.1",
-                "@iconify/utils": "^2.1.32",
-                "@mermaid-js/parser": "^0.3.0",
-                "@types/d3": "^7.4.3",
-                "@types/dompurify": "^3.0.5",
-                "cytoscape": "^3.29.2",
+                "@braintree/sanitize-url": "^6.0.1",
+                "@types/d3-scale": "^4.0.3",
+                "@types/d3-scale-chromatic": "^3.0.0",
+                "cytoscape": "^3.28.1",
                 "cytoscape-cose-bilkent": "^4.1.0",
-                "cytoscape-fcose": "^2.2.0",
-                "d3": "^7.9.0",
+                "d3": "^7.4.0",
                 "d3-sankey": "^0.12.3",
-                "dagre-d3-es": "7.0.11",
-                "dayjs": "^1.11.10",
-                "dompurify": "^3.0.11 <3.1.7",
+                "dagre-d3-es": "7.0.10",
+                "dayjs": "^1.11.7",
+                "dompurify": "^3.0.5 <3.1.7",
+                "elkjs": "^0.9.0",
                 "katex": "^0.16.9",
-                "khroma": "^2.1.0",
+                "khroma": "^2.0.0",
                 "lodash-es": "^4.17.21",
-                "marked": "^13.0.2",
-                "roughjs": "^4.6.6",
-                "stylis": "^4.3.1",
+                "mdast-util-from-markdown": "^1.3.0",
+                "non-layered-tidy-tree-layout": "^2.0.2",
+                "stylis": "^4.1.3",
                 "ts-dedent": "^2.2.0",
-                "uuid": "^9.0.1"
+                "uuid": "^9.0.0",
+                "web-worker": "^1.2.0"
             }
         },
-        "node_modules/mermaid/node_modules/dayjs": {
-            "version": "1.11.13",
-            "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.13.tgz",
-            "integrity": "sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg==",
+        "node_modules/mermaid/node_modules/@types/unist": {
+            "version": "2.0.11",
+            "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
+            "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
             "license": "MIT"
+        },
+        "node_modules/mermaid/node_modules/mdast-util-from-markdown": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-1.3.1.tgz",
+            "integrity": "sha512-4xTO/M8c82qBcnQc1tgpNtubGUW/Y1tBQ1B0i5CtSoelOLKFYlElIr3bvgREYYO5iRqbMY1YuqZng0GVOI8Qww==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/mdast": "^3.0.0",
+                "@types/unist": "^2.0.0",
+                "decode-named-character-reference": "^1.0.0",
+                "mdast-util-to-string": "^3.1.0",
+                "micromark": "^3.0.0",
+                "micromark-util-decode-numeric-character-reference": "^1.0.0",
+                "micromark-util-decode-string": "^1.0.0",
+                "micromark-util-normalize-identifier": "^1.0.0",
+                "micromark-util-symbol": "^1.0.0",
+                "micromark-util-types": "^1.0.0",
+                "unist-util-stringify-position": "^3.0.0",
+                "uvu": "^0.5.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/mermaid/node_modules/mdast-util-to-string": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-3.2.0.tgz",
+            "integrity": "sha512-V4Zn/ncyN1QNSqSBxTrMOLpjr+IKdHl2v3KVLoWmDPscP4r9GcCi71gjgvUV1SFSKh92AjAG4peFuBl2/YgCJg==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/mdast": "^3.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/mermaid/node_modules/micromark": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/micromark/-/micromark-3.2.0.tgz",
+            "integrity": "sha512-uD66tJj54JLYq0De10AhWycZWGQNUvDI55xPgk2sQM5kn1JYlhbCMTtEeT27+vAhW2FBQxLlOmS3pmA7/2z4aA==",
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "@types/debug": "^4.0.0",
+                "debug": "^4.0.0",
+                "decode-named-character-reference": "^1.0.0",
+                "micromark-core-commonmark": "^1.0.1",
+                "micromark-factory-space": "^1.0.0",
+                "micromark-util-character": "^1.0.0",
+                "micromark-util-chunked": "^1.0.0",
+                "micromark-util-combine-extensions": "^1.0.0",
+                "micromark-util-decode-numeric-character-reference": "^1.0.0",
+                "micromark-util-encode": "^1.0.0",
+                "micromark-util-normalize-identifier": "^1.0.0",
+                "micromark-util-resolve-all": "^1.0.0",
+                "micromark-util-sanitize-uri": "^1.0.0",
+                "micromark-util-subtokenize": "^1.0.0",
+                "micromark-util-symbol": "^1.0.0",
+                "micromark-util-types": "^1.0.1",
+                "uvu": "^0.5.0"
+            }
+        },
+        "node_modules/mermaid/node_modules/micromark-util-decode-numeric-character-reference": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-1.1.0.tgz",
+            "integrity": "sha512-m9V0ExGv0jB1OT21mrWcuf4QhP46pH1KkfWy9ZEezqHKAxkj4mPCy3nIH1rkbdMlChLHX531eOrymlwyZIf2iw==",
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "micromark-util-symbol": "^1.0.0"
+            }
+        },
+        "node_modules/mermaid/node_modules/micromark-util-decode-string": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-1.1.0.tgz",
+            "integrity": "sha512-YphLGCK8gM1tG1bd54azwyrQRjCFcmgj2S2GoJDNnh4vYtnL38JS8M4gpxzOPNyHdNEpheyWXCTnnTDY3N+NVQ==",
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "decode-named-character-reference": "^1.0.0",
+                "micromark-util-character": "^1.0.0",
+                "micromark-util-decode-numeric-character-reference": "^1.0.0",
+                "micromark-util-symbol": "^1.0.0"
+            }
+        },
+        "node_modules/mermaid/node_modules/unist-util-stringify-position": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-3.0.3.tgz",
+            "integrity": "sha512-k5GzIBZ/QatR8N5X2y+drfpWG8IDBzdnVj6OInRNWm1oXrzydiaAT2OQiA8DPRRZyAKb9b6I2a6PxYklZD0gKg==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/unist": "^2.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
         },
         "node_modules/methods": {
             "version": "1.1.2",
@@ -26092,18 +25786,6 @@
                 "node": ">=16 || 14 >=14.17"
             }
         },
-        "node_modules/mlly": {
-            "version": "1.7.3",
-            "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.7.3.tgz",
-            "integrity": "sha512-xUsx5n/mN0uQf4V548PKQ+YShA4/IW0KI1dZhrNrPCLG+xizETbHTkOa1f8/xut9JRPp8kQuMnz0oqwkTiLo/A==",
-            "license": "MIT",
-            "dependencies": {
-                "acorn": "^8.14.0",
-                "pathe": "^1.1.2",
-                "pkg-types": "^1.2.1",
-                "ufo": "^1.5.4"
-            }
-        },
         "node_modules/mobx": {
             "version": "6.13.5",
             "resolved": "https://registry.npmjs.org/mobx/-/mobx-6.13.5.tgz",
@@ -26382,9 +26064,9 @@
             }
         },
         "node_modules/node-polyfill-webpack-plugin/node_modules/type-fest": {
-            "version": "4.28.1",
-            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.28.1.tgz",
-            "integrity": "sha512-LO/+yb3mf46YqfUC7QkkoAlpa7CTYh//V1Xy9+NQ+pKqDqXIq0NTfPfQRwFfCt+if4Qkwb9gzZfsl6E5TkXZGw==",
+            "version": "4.29.0",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.29.0.tgz",
+            "integrity": "sha512-RPYt6dKyemXJe7I6oNstcH24myUGSReicxcHTvCLgzm4e0n8y05dGvcGB15/SoPRBmhlMthWQ9pvKyL81ko8nQ==",
             "license": "(MIT OR CC0-1.0)",
             "engines": {
                 "node": ">=16"
@@ -26406,6 +26088,12 @@
             "version": "2.0.18",
             "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.18.tgz",
             "integrity": "sha512-d9VeXT4SJ7ZeOqGX6R5EM022wpL+eWPooLI+5UpWn2jCT1aosUQEhQP214x33Wkwx3JQMvIm+tIoVOdodFS40g==",
+            "license": "MIT"
+        },
+        "node_modules/non-layered-tidy-tree-layout": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/non-layered-tidy-tree-layout/-/non-layered-tidy-tree-layout-2.0.2.tgz",
+            "integrity": "sha512-gkXMxRzUH+PB0ax9dUN0yYF0S25BqeAYqhgMaLUFmpXLEk7Fcu8f4emJuOAY0V8kjDICxROIKsTAKsV/v355xw==",
             "license": "MIT"
         },
         "node_modules/normalize-path": {
@@ -27032,12 +26720,6 @@
             "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
             "license": "BlueOak-1.0.0"
         },
-        "node_modules/package-manager-detector": {
-            "version": "0.2.5",
-            "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-0.2.5.tgz",
-            "integrity": "sha512-3dS7y28uua+UDbRCLBqltMBrbI+A5U2mI9YuxHRxIWYmLj3DwntEBmERYzIAQ4DMeuCUOBSak7dBHHoXKpOTYQ==",
-            "license": "MIT"
-        },
         "node_modules/pako": {
             "version": "1.0.11",
             "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
@@ -27195,12 +26877,6 @@
             "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
             "license": "MIT"
         },
-        "node_modules/path-data-parser": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/path-data-parser/-/path-data-parser-0.1.0.tgz",
-            "integrity": "sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w==",
-            "license": "MIT"
-        },
         "node_modules/path-exists": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -27299,12 +26975,6 @@
             "dependencies": {
                 "inherits": "2.0.3"
             }
-        },
-        "node_modules/pathe": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
-            "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
-            "license": "MIT"
         },
         "node_modules/pbkdf2": {
             "version": "3.1.2",
@@ -27452,17 +27122,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/pkg-types": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.2.1.tgz",
-            "integrity": "sha512-sQoqa8alT3nHjGuTjuKgOnvjo4cljkufdtLMnO2LBP/wRwuDlo1tkaEdMxCRhyGRPacv/ztlZgDPm2b7FAmEvw==",
-            "license": "MIT",
-            "dependencies": {
-                "confbox": "^0.1.8",
-                "mlly": "^1.7.2",
-                "pathe": "^1.1.2"
-            }
-        },
         "node_modules/pkg-up": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-3.1.0.tgz",
@@ -27543,22 +27202,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">=4"
-            }
-        },
-        "node_modules/points-on-curve": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/points-on-curve/-/points-on-curve-0.2.0.tgz",
-            "integrity": "sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A==",
-            "license": "MIT"
-        },
-        "node_modules/points-on-path": {
-            "version": "0.2.1",
-            "resolved": "https://registry.npmjs.org/points-on-path/-/points-on-path-0.2.1.tgz",
-            "integrity": "sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g==",
-            "license": "MIT",
-            "dependencies": {
-                "path-data-parser": "0.1.0",
-                "points-on-curve": "0.2.0"
             }
         },
         "node_modules/polished": {
@@ -28618,15 +28261,6 @@
             },
             "peerDependencies": {
                 "postcss": "^8.4"
-            }
-        },
-        "node_modules/postcss-prefix-selector": {
-            "version": "1.16.1",
-            "resolved": "https://registry.npmjs.org/postcss-prefix-selector/-/postcss-prefix-selector-1.16.1.tgz",
-            "integrity": "sha512-Umxu+FvKMwlY6TyDzGFoSUnzW+NOfMBLyC1tAkIjgX+Z/qGspJeRjVC903D7mx7TuBpJlwti2ibXtWuA7fKMeQ==",
-            "license": "MIT",
-            "peerDependencies": {
-                "postcss": ">4 <9"
             }
         },
         "node_modules/postcss-preset-env": {
@@ -30368,18 +30002,6 @@
                 "styled-components": "^4.1.1 || ^5.1.1 || ^6.0.5"
             }
         },
-        "node_modules/redoc/node_modules/marked": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
-            "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
-            "license": "MIT",
-            "bin": {
-                "marked": "bin/marked.js"
-            },
-            "engines": {
-                "node": ">= 12"
-            }
-        },
         "node_modules/redoc/node_modules/slugify": {
             "version": "1.4.7",
             "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.4.7.tgz",
@@ -30390,13 +30012,13 @@
             }
         },
         "node_modules/redocusaurus": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/redocusaurus/-/redocusaurus-2.2.0.tgz",
-            "integrity": "sha512-cf7kq5RRlwiLNtB4tMH6DBAhmLpZJ3UAOP9QkCHodvf2d46O9m5DOq1o7u6O4XZF65weCm3oDW8eFk6UvLrrtg==",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/redocusaurus/-/redocusaurus-2.1.1.tgz",
+            "integrity": "sha512-uaiuSsty0TcYuibabEw72DzN5JL6eF9KTIR5dL61qP7smFwIY8THEsNogzKTfcKCb6MJ8ug4vohrnrANn3K3cg==",
             "license": "MIT",
             "dependencies": {
                 "docusaurus-plugin-redoc": "2.1.1",
-                "docusaurus-theme-redoc": "2.2.0"
+                "docusaurus-theme-redoc": "2.1.1"
             },
             "engines": {
                 "node": ">=14"
@@ -30405,6 +30027,13 @@
                 "@docusaurus/theme-common": "^3.0.0",
                 "@docusaurus/utils": "^3.0.0"
             }
+        },
+        "node_modules/reduce-configs": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/reduce-configs/-/reduce-configs-1.1.0.tgz",
+            "integrity": "sha512-DQxy6liNadHfrLahZR7lMdc227NYVaQZhY5FMsxLEjX8X0SCuH+ESHSLCoz2yDZFq1/CLMDOAHdsEHwOEXKtvg==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/redux": {
             "version": "4.2.1",
@@ -31724,18 +31353,6 @@
             "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.2.tgz",
             "integrity": "sha512-IXgzBWvWQwE6PrDI05OvmXUIruQTcoMDzRsOd5CDvHCVLcLHMTSYvOK5Cm46kWqlV3yAbuSpBZdJ5oP5OUoStg==",
             "license": "Unlicense"
-        },
-        "node_modules/roughjs": {
-            "version": "4.6.6",
-            "resolved": "https://registry.npmjs.org/roughjs/-/roughjs-4.6.6.tgz",
-            "integrity": "sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ==",
-            "license": "MIT",
-            "dependencies": {
-                "hachure-fill": "^0.5.2",
-                "path-data-parser": "^0.1.0",
-                "points-on-curve": "^0.2.0",
-                "points-on-path": "^0.2.1"
-            }
         },
         "node_modules/rtl-detect": {
             "version": "1.1.2",
@@ -33663,12 +33280,6 @@
             "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==",
             "license": "MIT"
         },
-        "node_modules/tinyexec": {
-            "version": "0.3.1",
-            "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.1.tgz",
-            "integrity": "sha512-WiCJLEECkO18gwqIp6+hJg0//p23HXp4S+gGtAKu3mI2F2/sXC4FvHvXvB0zJVVaTPhx1/tOwdbRsa1sOBIKqQ==",
-            "license": "MIT"
-        },
         "node_modules/to-regex-range": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -33931,12 +33542,6 @@
             "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
             "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
             "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/ufo": {
-            "version": "1.5.4",
-            "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.5.4.tgz",
-            "integrity": "sha512-UsUk3byDzKd04EyoZ7U4DOlxQaD14JUKQl6/P7wiX4FNvUfm3XL246n9W5AmqwW5RSFJ27NAuM0iLscAOYUiGQ==",
             "license": "MIT"
         },
         "node_modules/uglify-js": {
@@ -34658,47 +34263,18 @@
                 "vscode-uri": "^3.0.3"
             }
         },
-        "node_modules/vscode-jsonrpc": {
-            "version": "8.2.0",
-            "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz",
-            "integrity": "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/vscode-languageserver": {
-            "version": "9.0.1",
-            "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-9.0.1.tgz",
-            "integrity": "sha512-woByF3PDpkHFUreUa7Hos7+pUWdeWMXRd26+ZX2A8cFx6v/JPTtd4/uN0/jB6XQHYaOlHbio03NTHCqrgG5n7g==",
-            "license": "MIT",
-            "dependencies": {
-                "vscode-languageserver-protocol": "3.17.5"
-            },
-            "bin": {
-                "installServerIntoExtension": "bin/installServerIntoExtension"
-            }
-        },
-        "node_modules/vscode-languageserver-protocol": {
-            "version": "3.17.5",
-            "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.5.tgz",
-            "integrity": "sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==",
-            "license": "MIT",
-            "dependencies": {
-                "vscode-jsonrpc": "8.2.0",
-                "vscode-languageserver-types": "3.17.5"
-            }
-        },
         "node_modules/vscode-languageserver-textdocument": {
             "version": "1.0.12",
             "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.12.tgz",
             "integrity": "sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/vscode-languageserver-types": {
             "version": "3.17.5",
             "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
             "integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/vscode-nls": {
@@ -34712,6 +34288,7 @@
             "version": "3.0.8",
             "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.0.8.tgz",
             "integrity": "sha512-AyFQ0EVmsOZOlAnxoFOGOq1SQDWAB7C6aqMGS23svWAllfOaxbuFvcT8D1i8z3Gyn8fraVeZNNmN6e9bxxXkKw==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/warning": {
@@ -34754,6 +34331,12 @@
                 "type": "github",
                 "url": "https://github.com/sponsors/wooorm"
             }
+        },
+        "node_modules/web-worker": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/web-worker/-/web-worker-1.3.0.tgz",
+            "integrity": "sha512-BSR9wyRsy/KOValMgd5kMyr3JzpdeoR9KVId8u5GVlTTAtNChlsE4yTxeY7zMdNSyOmoKBv8NH2qeRY9Tg+IaA==",
+            "license": "Apache-2.0"
         },
         "node_modules/webidl-conversions": {
             "version": "3.0.1",
@@ -34983,17 +34566,17 @@
             }
         },
         "node_modules/webpack-merge": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-6.0.1.tgz",
-            "integrity": "sha512-hXXvrjtx2PLYx4qruKl+kyRSLc52V+cCvMxRjmKwoA+CBbbF5GfIBtR6kCvl0fYGqTUPKB+1ktVmTHqMOzgCBg==",
+            "version": "5.10.0",
+            "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
+            "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
             "license": "MIT",
             "dependencies": {
                 "clone-deep": "^4.0.1",
                 "flat": "^5.0.2",
-                "wildcard": "^2.0.1"
+                "wildcard": "^2.0.0"
             },
             "engines": {
-                "node": ">=18.0.0"
+                "node": ">=10.0.0"
             }
         },
         "node_modules/webpack-sources": {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "devDependencies": {
         "@apify/eslint-config-ts": "^0.4.1",
         "@apify/tsconfig": "^0.1.0",
+        "@rsbuild/plugin-styled-components": "^1.1.0",
         "@types/react": "^18.2.8",
         "@typescript-eslint/eslint-plugin": "^7.0.0",
         "@typescript-eslint/parser": "^7.0.0",


### PR DESCRIPTION
Styled components are not working in the production build with `@docusaurus/faster`, since babel (nor webpack) is no longer used with that approach.

We need to find a way to make this work, probably with `@rsbuild/plugin-styled-components`, but it didn't work for me now.

Waiting for feedback here: https://github.com/facebook/docusaurus/discussions/10730