### PR TITLE
feat: Add `ACTOR_FULL_NAME` and `ACTOR_BUILD_TAGS` environment variables

### DIFF
--- a/sources/platform/actors/development/programming_interface/environment_variables.md
+++ b/sources/platform/actors/development/programming_interface/environment_variables.md
@@ -23,9 +23,11 @@ Here's a table of key system environment variables:
 | Environment Variable | Description |
 |----------------------|-------------|
 | `ACTOR_ID` | ID of the Actor. |
+| `ACTOR_FULL_NAME` | Full technical name of the Actor, in the format `owner-username/actor-name`. |
 | `ACTOR_RUN_ID` | ID of the Actor run. |
 | `ACTOR_BUILD_ID` | ID of the Actor build used in the run. |
 | `ACTOR_BUILD_NUMBER` | Build number of the Actor build used in the run. |
+| `ACTOR_BUILD_TAGS` | A comma-separated list of tags of the Actor build used in the run. Note that this environment variable is assigned at the time of start of the Actor and doesn't change over time, even if the assigned build tags change. |
 | `ACTOR_TASK_ID` | ID of the Actor task. Empty if Actor is run outside of any task, e.g. directly using the API. |
 | `ACTOR_EVENTS_WEBSOCKET_URL` | Websocket URL where Actor may listen for [events](/platform/actors/development/programming-interface/system-events) from Actor platform. |
 | `ACTOR_DEFAULT_DATASET_ID` | Unique identifier for the default dataset associated with the current Actor run. |


### PR DESCRIPTION
New environment variables are being added to the Actor runtime, better have them documented.