### PR TITLE
fix(request-queue): Update request queue locking docs

### DIFF
--- a/sources/platform/storage/request_queue.md
+++ b/sources/platform/storage/request_queue.md
@@ -416,6 +416,7 @@ This means you can unlock or prolong the lock the locked request only if:
 
 1. You are using the same client key, or
 2. The operation is being called from the same Actor run.
+
 :::
 
 <Tabs groupId="main">

--- a/sources/platform/storage/request_queue.md
+++ b/sources/platform/storage/request_queue.md
@@ -407,15 +407,15 @@ You can lock a request so that no other clients receive it when they fetch the q
 This feature is seamlessly integrated into Crawlee, requiring minimal extra setup. By default, requests are locked for the same duration as the timeout for processing requests in the crawler ([`requestHandlerTimeoutSecs`](https://crawlee.dev/api/next/basic-crawler/interface/BasicCrawlerOptions#requestHandlerTimeoutSecs)).
 If the Actor processing the request fails, the lock expires, and the request is processed again eventually. For more details, refer to the [Crawlee documentation](https://crawlee.dev/docs/next/experiments/experiments-request-locking).
 
-In the following example, we demonstrate how we can use locking mechanisms to avoid concurrent processing of the same request across multiple Actor runs.
+In the following example, we demonstrate how you can use locking mechanisms to avoid concurrent processing of the same request across multiple Actor runs.
 
 :::info
 The lock mechanism works on the client level, as well as the run level, when running the Actor on the Apify platform.
 
 This means you can unlock or prolong the lock the locked request only if:
 
-1. You are using the same client key, or
-2. The operation is being called from the same Actor run.
+- You are using the same client key, or
+- The operation is being called from the same Actor run.
 
 :::
 

--- a/sources/platform/storage/request_queue.md
+++ b/sources/platform/storage/request_queue.md
@@ -409,6 +409,15 @@ If the Actor processing the request fails, the lock expires, and the request is 
 
 In the following example, we demonstrate how we can use locking mechanisms to avoid concurrent processing of the same request across multiple Actor runs.
 
+:::info
+The lock mechanism works on the client level, as well as the run level, when running the Actor on the Apify platform.
+
+This means you can unlock or prolong the lock the locked request only if:
+
+1. You are using the same client key, or
+2. The operation is being called from the same Actor run.
+:::
+
 <Tabs groupId="main">
 <TabItem value="Actor 1" label="Actor 1">
 

--- a/sources/platform/storage/request_queue.md
+++ b/sources/platform/storage/request_queue.md
@@ -515,7 +515,7 @@ const requestQueueClient = client.requestQueue(requestQueue.id, {
 // Get all requests from the queue and check one locked by the first Actor.
 const requests = await requestQueueClient.listRequests();
 const requestsLockedByAnotherRun = requests.items.filter((request) => request.lockByClient === 'requestqueueone');
-const requestLockedByAnotherRun = await requestQueueClient.getRequest(
+const requestLockedByAnotherRunDetail = await requestQueueClient.getRequest(
     requestsLockedByAnotherRun[0].id,
 );
 
@@ -527,16 +527,16 @@ const processingRequestsClientTwo = await requestQueueClient.listAndLockHead(
     },
 );
 const wasBothRunsLockedSameRequest = !!processingRequestsClientTwo.items.find(
-    (request) => request.id === requestLockedByAnotherRun.id,
+    (request) => request.id === requestLockedByAnotherRunDetail.id,
 );
 
 console.log(`Was the request locked by the first run locked by the second run? ${wasBothRunsLockedSameRequest}`);
-console.log(`Request locked until ${requestLockedByAnotherRun?.lockExpiresAt}`);
+console.log(`Request locked until ${requestLockedByAnotherRunDetail?.lockExpiresAt}`);
 
 // Other clients cannot modify the lock; attempting to do so will throw an error.
 try {
     await requestQueueClient.prolongRequestLock(
-        requestLockedByAnotherRun.id,
+        requestLockedByAnotherRunDetail.id,
         { lockSecs: 60 },
     );
 } catch (err) {

--- a/sources/platform/storage/request_queue.md
+++ b/sources/platform/storage/request_queue.md
@@ -544,7 +544,6 @@ try {
     // This will throw an error.
 }
 
-
 await Actor.exit();
 ```
 


### PR DESCRIPTION
I made some changes in docs regarding the API changes.

* stress out that locking works on the client level and the same as on the run level.
* update code example by separating code into two actors using code tabs