### PR TITLE
feat: add code samples for Apify CLI

### DIFF
--- a/apify-api/openapi/code_samples/curl/act_builds_get.sh
+++ b/apify-api/openapi/code_samples/curl/act_builds_get.sh
@@ -1,0 +1,1 @@
+apify builds ls

--- a/apify-api/openapi/code_samples/curl/act_builds_post.sh
+++ b/apify-api/openapi/code_samples/curl/act_builds_post.sh
@@ -1,0 +1,1 @@
+apify actors build <ACTOR ID>

--- a/apify-api/openapi/code_samples/curl/act_delete.sh
+++ b/apify-api/openapi/code_samples/curl/act_delete.sh
@@ -1,0 +1,1 @@
+apify actors rm <ACTOR ID>

--- a/apify-api/openapi/code_samples/curl/act_get.sh
+++ b/apify-api/openapi/code_samples/curl/act_get.sh
@@ -1,0 +1,1 @@
+apify actors info <ACTOR ID>

--- a/apify-api/openapi/code_samples/curl/act_run_resurrect_post.sh
+++ b/apify-api/openapi/code_samples/curl/act_run_resurrect_post.sh
@@ -1,0 +1,1 @@
+apify runs resurrect <RUN ID>

--- a/apify-api/openapi/code_samples/curl/act_runs_get.sh
+++ b/apify-api/openapi/code_samples/curl/act_runs_get.sh
@@ -1,0 +1,1 @@
+apify runs ls <ACTOR ID>

--- a/apify-api/openapi/code_samples/curl/act_runs_post.sh
+++ b/apify-api/openapi/code_samples/curl/act_runs_post.sh
@@ -1,0 +1,1 @@
+apify actors start <ACTOR ID>

--- a/apify-api/openapi/code_samples/curl/actorBuild_delete.sh
+++ b/apify-api/openapi/code_samples/curl/actorBuild_delete.sh
@@ -1,0 +1,1 @@
+apify builds rm <BUILD ID>

--- a/apify-api/openapi/code_samples/curl/actorBuild_get.sh
+++ b/apify-api/openapi/code_samples/curl/actorBuild_get.sh
@@ -1,0 +1,1 @@
+apify builds info <BUILD ID>

--- a/apify-api/openapi/code_samples/curl/actorBuild_log_get.sh
+++ b/apify-api/openapi/code_samples/curl/actorBuild_log_get.sh
@@ -1,0 +1,1 @@
+apify builds log <BUILD ID>

--- a/apify-api/openapi/code_samples/curl/actorRun_abort_post.sh
+++ b/apify-api/openapi/code_samples/curl/actorRun_abort_post.sh
@@ -1,0 +1,1 @@
+apify runs abort <RUN ID>

--- a/apify-api/openapi/code_samples/curl/actorRun_delete.sh
+++ b/apify-api/openapi/code_samples/curl/actorRun_delete.sh
@@ -1,0 +1,1 @@
+apify runs rm <RUN ID>

--- a/apify-api/openapi/code_samples/curl/actorRun_get.sh
+++ b/apify-api/openapi/code_samples/curl/actorRun_get.sh
@@ -1,0 +1,1 @@
+apify runs info <RUN ID>

--- a/apify-api/openapi/code_samples/curl/actorRun_resurrect_post.sh
+++ b/apify-api/openapi/code_samples/curl/actorRun_resurrect_post.sh
@@ -1,0 +1,1 @@
+apify runs resurrect <RUN ID>

--- a/apify-api/openapi/code_samples/curl/actorTask_runs_post.sh
+++ b/apify-api/openapi/code_samples/curl/actorTask_runs_post.sh
@@ -1,0 +1,1 @@
+apify task run <TASK ID>

--- a/apify-api/openapi/code_samples/curl/acts_get.sh
+++ b/apify-api/openapi/code_samples/curl/acts_get.sh
@@ -1,0 +1,1 @@
+apify actors ls

--- a/apify-api/openapi/code_samples/curl/acts_post.sh
+++ b/apify-api/openapi/code_samples/curl/acts_post.sh
@@ -1,0 +1,1 @@
+apify create <ACTOR NAME>

--- a/apify-api/openapi/code_samples/curl/dataset_delete.sh
+++ b/apify-api/openapi/code_samples/curl/dataset_delete.sh
@@ -1,0 +1,1 @@
+apify datasets rm <DATASET ID>

--- a/apify-api/openapi/code_samples/curl/dataset_items_post.sh
+++ b/apify-api/openapi/code_samples/curl/dataset_items_post.sh
@@ -1,0 +1,1 @@
+apify datasets push-items <DATASET ID> '{ "foo": "bar" }'

--- a/apify-api/openapi/code_samples/curl/dataset_put.sh
+++ b/apify-api/openapi/code_samples/curl/dataset_put.sh
@@ -1,0 +1,1 @@
+apify datasets rename <DATASET ID> <DATASET NAME>

--- a/apify-api/openapi/code_samples/curl/datasets_get.sh
+++ b/apify-api/openapi/code_samples/curl/datasets_get.sh
@@ -1,0 +1,1 @@
+apify datasets ls

--- a/apify-api/openapi/code_samples/curl/datasets_post.sh
+++ b/apify-api/openapi/code_samples/curl/datasets_post.sh
@@ -1,0 +1,1 @@
+apify datasets create <DATASET NAME>

--- a/apify-api/openapi/code_samples/curl/keyValueStore_delete.sh
+++ b/apify-api/openapi/code_samples/curl/keyValueStore_delete.sh
@@ -1,0 +1,1 @@
+apify key-value-stores rm <STORE ID>

--- a/apify-api/openapi/code_samples/curl/keyValueStore_keys_get.sh
+++ b/apify-api/openapi/code_samples/curl/keyValueStore_keys_get.sh
@@ -1,0 +1,1 @@
+apify key-value-stores keys <STORE ID>

--- a/apify-api/openapi/code_samples/curl/keyValueStore_put.sh
+++ b/apify-api/openapi/code_samples/curl/keyValueStore_put.sh
@@ -1,0 +1,1 @@
+apify key-value-stores rename <STORE ID> <STORE NAME>

--- a/apify-api/openapi/code_samples/curl/keyValueStore_record_delete.sh
+++ b/apify-api/openapi/code_samples/curl/keyValueStore_record_delete.sh
@@ -1,0 +1,1 @@
+apify key-value-stores delete-value <STORE ID> INPUT

--- a/apify-api/openapi/code_samples/curl/keyValueStore_record_get.sh
+++ b/apify-api/openapi/code_samples/curl/keyValueStore_record_get.sh
@@ -1,0 +1,1 @@
+apify key-value-stores get-value <STORE ID> INPUT

--- a/apify-api/openapi/code_samples/curl/keyValueStore_record_put.sh
+++ b/apify-api/openapi/code_samples/curl/keyValueStore_record_put.sh
@@ -1,1 +1,1 @@
-apify key-value-stores set-value <STORE ID> OUTPUT '{"new": "value"}'
+apify key-value-stores set-value <STORE ID> INPUT '{"new": "value"}'

--- a/apify-api/openapi/code_samples/curl/keyValueStore_record_put.sh
+++ b/apify-api/openapi/code_samples/curl/keyValueStore_record_put.sh
@@ -1,0 +1,1 @@
+apify key-value-stores set-value <STORE ID> OUTPUT '{"new": "value"}'

--- a/apify-api/openapi/code_samples/curl/keyValueStores_get.sh
+++ b/apify-api/openapi/code_samples/curl/keyValueStores_get.sh
@@ -1,0 +1,1 @@
+apify key-value-stores ls

--- a/apify-api/openapi/code_samples/curl/keyValueStores_post.sh
+++ b/apify-api/openapi/code_samples/curl/keyValueStores_post.sh
@@ -1,0 +1,1 @@
+apify key-value-stores create <STORE NAME>

--- a/apify-api/openapi/code_samples/curl/users_me_get.sh
+++ b/apify-api/openapi/code_samples/curl/users_me_get.sh
@@ -1,0 +1,1 @@
+apify info

--- a/apify-api/plugins/decorators/code-samples-decorator.js
+++ b/apify-api/plugins/decorators/code-samples-decorator.js
@@ -37,7 +37,7 @@ function CodeSamplesDecorator(target) {
 
         if (!existsSync(codeSamplePath)) {
             // Just use this console log in development to see which operations are missing a code sample.
-            console.log(`Missing code sample for operation ${target.operationId}.${langSuffix}`);
+            // console.log(`Missing code sample for operation ${target.operationId}.${langSuffix}`);
             return;
         }
 

--- a/apify-api/plugins/decorators/code-samples-decorator.js
+++ b/apify-api/plugins/decorators/code-samples-decorator.js
@@ -4,7 +4,8 @@ const path = require('path');
 const X_CODE_SAMPLES_PROPERTY = 'x-codeSamples';
 
 const LANGUAGES = [
-    { lang: 'JavaScript', label: 'JS client' },
+    { lang: 'JavaScript', label: 'JS client', langSuffix: 'js' },
+    { lang: 'cURL', label: 'Apify CLI', langSuffix: 'sh' },
 ];
 
 /**
@@ -28,12 +29,15 @@ function CodeSamplesDecorator(target) {
     // so we change it here to keep the file names consistent
     const operationId = target.operationId === 'PostResurrectRun' ? 'actorRun_resurrect_post' : target.operationId;
 
-    for (const { lang, label } of LANGUAGES) {
-        const codeSamplePath = path.join(__dirname, `../../openapi/code_samples/${lang.toLowerCase()}/${operationId}.js`);
+    for (const { lang, label, langSuffix } of LANGUAGES) {
+        const codeSamplePath = path.join(
+            __dirname,
+            `../../openapi/code_samples/${lang.toLowerCase()}/${operationId}.${langSuffix}`,
+        );
 
         if (!existsSync(codeSamplePath)) {
             // Just use this console log in development to see which operations are missing a code sample.
-            // console.log(`Missing code sample for operation ${target.operationId}`);
+            console.log(`Missing code sample for operation ${target.operationId}.${langSuffix}`);
             return;
         }
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -323,6 +323,12 @@ module.exports = {
         },
         languageTabs: [
             {
+                highlight: 'bash',
+                label: 'CLI',
+                language: 'curl',
+                logoClass: 'curl',
+            },
+            {
                 highlight: 'javascript',
                 label: 'JavaScript',
                 language: 'javascript',
@@ -333,12 +339,6 @@ module.exports = {
                 label: 'Python',
                 language: 'python',
                 logoClass: 'python',
-            },
-            {
-                highlight: 'bash',
-                label: 'cURL',
-                language: 'curl',
-                logoClass: 'curl',
             },
             {
                 highlight: 'php',

--- a/package-lock.json
+++ b/package-lock.json
@@ -73,7 +73,7 @@
         },
         "apify-docs-theme": {
             "name": "@apify/docs-theme",
-            "version": "1.0.157",
+            "version": "1.0.161",
             "license": "ISC",
             "dependencies": {
                 "@apify/docs-search-modal": "^1.2.0",


### PR DESCRIPTION
Adds Apify CLI code samples. These are currently under CURL, since custom languages aren't supported. 

Some of the commands are still in development, I guess. E.g. the request queues are missing from the CLI.

# NOTE 
when this is merged, you'll need to go to Actor `X8D0L4wfpO8fCL1uL` and un-comment `curl` in the `LANGUAGES` const in `main.js`