### PR TITLE
fix: Add redirect from crawlee.dev/python/docs

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -324,4 +324,7 @@ server {
   }
   # Redirect rule for "upgrading-to-v03" to "upgrading-to-v0x"
   rewrite ^/python/docs/upgrading/upgrading-to-v03$ /python/docs/upgrading/upgrading-to-v0x permanent;
+
+  # Redirect rule so that /python/docs actually leads somewhere
+  rewrite ^/python/docs/?$ /python/docs/quick-start;
 }


### PR DESCRIPTION
https://crawlee.dev/python/docs now leads to a 404 page, which is not optimal. This should fix that, in a manner consistent with the JS version of the docs
