### PR TITLE
feat: Add "Speeding up migrations" section to "State persistence"

### DIFF
--- a/sources/platform/actors/development/builds_and_runs/state_persistence.md
+++ b/sources/platform/actors/development/builds_and_runs/state_persistence.md
@@ -131,9 +131,9 @@ For improved Actor performance consider [caching repeated page data](/academy/ex
 
 ## Speeding up migrations
 
-Once your Actor receives the `migrating` event, in under a minute, the Apify platform will shut it down and restart it on a new server.
-If you want to speed this process up, once you have persisted the Actor state,
-you can reboot the Actor manually in the `migrating` event handler using the `Actor.reboot()` method
+Once your Actor receives the `migrating` event, the Apify platform will shut it down and restart it on a new server within one minute.
+To speed this process up, once you have persisted the Actor state,
+you can manually reboot the Actor in the `migrating` event handler using the `Actor.reboot()` method
 available in the [Apify SDK for JavaScript](/sdk/js/reference/class/Actor#reboot) or [Apify SDK for Python](/sdk/python/reference/class/Actor#reboot).
 
 <Tabs groupId="main">


### PR DESCRIPTION
We've recently added support to speed up Actor migrations by rebooting the run when it's migrating. This adds docs about that, with code examples.

The support for this in the Apify SDK is not released yet, it'll go out in the next SDK release, I'll only merge the docs then.