### PR TITLE
feat: add x-legacy-doc-urls to run charge endpoints

### DIFF
--- a/apify-api/openapi/paths/actor-runs/actor-runs@{runId}@charge.yaml
+++ b/apify-api/openapi/paths/actor-runs/actor-runs@{runId}@charge.yaml
@@ -44,3 +44,5 @@ post:
   x-py-parent: RunClientAsync
   x-py-name: charge
   x-py-doc-url: https://docs.apify.com/api/client/python/reference/class/RunClientAsync#charge
+  x-legacy-doc-urls:
+      - https://docs.apify.com/api/v2#/reference/actor-runs/charge-events-in-run


### PR DESCRIPTION
This PR is adding a legacy doc URL, to be consistent with the rest of the endpoints