### PR TITLE
chore: switch to algoliasearch v5

### DIFF
--- a/apify-docs-theme/package.json
+++ b/apify-docs-theme/package.json
@@ -22,6 +22,8 @@
         "@apify/docs-search-modal": "^1.2.0",
         "@docusaurus/theme-common": "3.7.0",
         "@stackql/docusaurus-plugin-hubspot": "^1.1.0",
+        "algoliasearch": "^5.19.0",
+        "algoliasearch-helper": "^3.22.6",
         "axios": "^1.7.9",
         "babel-loader": "^9.2.1",
         "docusaurus-gtm-plugin": "^0.0.2",

--- a/apify-docs-theme/src/theme/SearchPage/index.js
+++ b/apify-docs-theme/src/theme/SearchPage/index.js
@@ -1,8 +1,8 @@
 /* eslint-disable */
 import React, { useEffect, useReducer, useRef, useState } from 'react';
 import clsx from 'clsx';
+import { liteClient } from 'algoliasearch/lite';
 import algoliaSearchHelper from 'algoliasearch-helper';
-import algoliaSearch from 'algoliasearch/lite';
 import ExecutionEnvironment from '@docusaurus/ExecutionEnvironment';
 import Head from '@docusaurus/Head';
 import { useAllDocsData } from '@docusaurus/plugin-content-docs/client';
@@ -117,7 +117,6 @@ function SearchPageContent() {
     const {
         algolia: { appId, apiKey, indexName },
     } = useAlgoliaThemeConfig();
-    const processSearchResultUrl = useSearchResultUrlProcessor();
     const documentsFoundPlural = useDocumentsFoundPlural();
     const docsSearchVersionsHelpers = useDocsSearchVersionsHelpers();
     const [searchQuery, setSearchQuery] = useSearchQueryString();
@@ -167,7 +166,7 @@ function SearchPageContent() {
         },
         initialSearchResultState,
     );
-    const algoliaClient = algoliaSearch(appId, apiKey);
+    const algoliaClient = liteClient(appId, apiKey);
     const algoliaHelper = algoliaSearchHelper(algoliaClient, indexName, {
         hitsPerPage: 15,
         advancedSyntax: true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
             ],
             "dependencies": {
                 "@apify-packages/ui-library": "^0.28.1",
-                "@apify/docsearch-apify-docs": "3.5.3",
                 "@docusaurus/core": "3.7.0",
                 "@docusaurus/faster": "3.7.0",
                 "@docusaurus/plugin-client-redirects": "3.7.0",
@@ -74,12 +73,14 @@
         },
         "apify-docs-theme": {
             "name": "@apify/docs-theme",
-            "version": "1.0.156",
+            "version": "1.0.157",
             "license": "ISC",
             "dependencies": {
                 "@apify/docs-search-modal": "^1.2.0",
                 "@docusaurus/theme-common": "3.7.0",
                 "@stackql/docusaurus-plugin-hubspot": "^1.1.0",
+                "algoliasearch": "^5.19.0",
+                "algoliasearch-helper": "^3.22.6",
                 "axios": "^1.7.9",
                 "babel-loader": "^9.2.1",
                 "docusaurus-gtm-plugin": "^0.0.2",
@@ -97,13 +98,13 @@
             }
         },
         "node_modules/@algolia/autocomplete-core": {
-            "version": "1.9.3",
-            "resolved": "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.9.3.tgz",
-            "integrity": "sha512-009HdfugtGCdC4JdXUbVJClA0q0zh24yyePn+KUGk3rP7j8FEe/m5Yo/z65gn6nP/cM39PxpzqKrL7A6fP6PPw==",
+            "version": "1.17.7",
+            "resolved": "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.17.7.tgz",
+            "integrity": "sha512-BjiPOW6ks90UKl7TwMv7oNQMnzU+t/wk9mgIDi6b1tXpUek7MW0lbNOUHpvam9pe3lVCf4xPFT+lK7s+e+fs7Q==",
             "license": "MIT",
             "dependencies": {
-                "@algolia/autocomplete-plugin-algolia-insights": "1.9.3",
-                "@algolia/autocomplete-shared": "1.9.3"
+                "@algolia/autocomplete-plugin-algolia-insights": "1.17.7",
+                "@algolia/autocomplete-shared": "1.17.7"
             }
         },
         "node_modules/@algolia/autocomplete-js": {
@@ -169,24 +170,24 @@
             }
         },
         "node_modules/@algolia/autocomplete-plugin-algolia-insights": {
-            "version": "1.9.3",
-            "resolved": "https://registry.npmjs.org/@algolia/autocomplete-plugin-algolia-insights/-/autocomplete-plugin-algolia-insights-1.9.3.tgz",
-            "integrity": "sha512-a/yTUkcO/Vyy+JffmAnTWbr4/90cLzw+CC3bRbhnULr/EM0fGNvM13oQQ14f2moLMcVDyAx/leczLlAOovhSZg==",
+            "version": "1.17.7",
+            "resolved": "https://registry.npmjs.org/@algolia/autocomplete-plugin-algolia-insights/-/autocomplete-plugin-algolia-insights-1.17.7.tgz",
+            "integrity": "sha512-Jca5Ude6yUOuyzjnz57og7Et3aXjbwCSDf/8onLHSQgw1qW3ALl9mrMWaXb5FmPVkV3EtkD2F/+NkT6VHyPu9A==",
             "license": "MIT",
             "dependencies": {
-                "@algolia/autocomplete-shared": "1.9.3"
+                "@algolia/autocomplete-shared": "1.17.7"
             },
             "peerDependencies": {
                 "search-insights": ">= 1 < 3"
             }
         },
         "node_modules/@algolia/autocomplete-preset-algolia": {
-            "version": "1.9.3",
-            "resolved": "https://registry.npmjs.org/@algolia/autocomplete-preset-algolia/-/autocomplete-preset-algolia-1.9.3.tgz",
-            "integrity": "sha512-d4qlt6YmrLMYy95n5TB52wtNDr6EgAIPH81dvvvW8UmuWRgxEtY0NJiPwl/h95JtG2vmRM804M0DSwMCNZlzRA==",
+            "version": "1.17.7",
+            "resolved": "https://registry.npmjs.org/@algolia/autocomplete-preset-algolia/-/autocomplete-preset-algolia-1.17.7.tgz",
+            "integrity": "sha512-ggOQ950+nwbWROq2MOCIL71RE0DdQZsceqrg32UqnhDz8FlO9rL8ONHNsI2R1MH0tkgVIDKI/D0sMiUchsFdWA==",
             "license": "MIT",
             "dependencies": {
-                "@algolia/autocomplete-shared": "1.9.3"
+                "@algolia/autocomplete-shared": "1.17.7"
             },
             "peerDependencies": {
                 "@algolia/client-search": ">= 4.9.1 < 6",
@@ -194,9 +195,9 @@
             }
         },
         "node_modules/@algolia/autocomplete-shared": {
-            "version": "1.9.3",
-            "resolved": "https://registry.npmjs.org/@algolia/autocomplete-shared/-/autocomplete-shared-1.9.3.tgz",
-            "integrity": "sha512-Wnm9E4Ye6Rl6sTTqjoymD+l8DjSTHsHboVRYrKgEt8Q7UHm9nYbqhN/i0fhUYA3OAEH7WA8x3jfpnmJm3rKvaQ==",
+            "version": "1.17.7",
+            "resolved": "https://registry.npmjs.org/@algolia/autocomplete-shared/-/autocomplete-shared-1.17.7.tgz",
+            "integrity": "sha512-o/1Vurr42U/qskRSuhBH+VKxMvkkUVTLU6WZQr+L5lGZZLYWyhdzWjW0iGXY7EkwRTjBqvN2EsR81yCTGV/kmg==",
             "license": "MIT",
             "peerDependencies": {
                 "@algolia/client-search": ">= 4.9.1 < 6",
@@ -248,39 +249,6 @@
                 "node": ">= 14.0.0"
             }
         },
-        "node_modules/@algolia/client-abtesting/node_modules/@algolia/client-common": {
-            "version": "5.19.0",
-            "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-5.19.0.tgz",
-            "integrity": "sha512-2ERRbICHXvtj5kfFpY5r8qu9pJII/NAHsdgUXnUitQFwPdPL7wXiupcvZJC7DSntOnE8AE0lM7oDsPhrJfj5nQ==",
-            "license": "MIT",
-            "engines": {
-                "node": ">= 14.0.0"
-            }
-        },
-        "node_modules/@algolia/client-abtesting/node_modules/@algolia/requester-browser-xhr": {
-            "version": "5.19.0",
-            "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.19.0.tgz",
-            "integrity": "sha512-GfnhnQBT23mW/VMNs7m1qyEyZzhZz093aY2x8p0era96MMyNv8+FxGek5pjVX0b57tmSCZPf4EqNCpkGcGsmbw==",
-            "license": "MIT",
-            "dependencies": {
-                "@algolia/client-common": "5.19.0"
-            },
-            "engines": {
-                "node": ">= 14.0.0"
-            }
-        },
-        "node_modules/@algolia/client-abtesting/node_modules/@algolia/requester-node-http": {
-            "version": "5.19.0",
-            "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-5.19.0.tgz",
-            "integrity": "sha512-p6t8ue0XZNjcRiqNkb5QAM0qQRAKsCiebZ6n9JjWA+p8fWf8BvnhO55y2fO28g3GW0Imj7PrAuyBuxq8aDVQwQ==",
-            "license": "MIT",
-            "dependencies": {
-                "@algolia/client-common": "5.19.0"
-            },
-            "engines": {
-                "node": ">= 14.0.0"
-            }
-        },
         "node_modules/@algolia/client-account": {
             "version": "4.24.0",
             "resolved": "https://registry.npmjs.org/@algolia/client-account/-/client-account-4.24.0.tgz",
@@ -292,19 +260,7 @@
                 "@algolia/transporter": "4.24.0"
             }
         },
-        "node_modules/@algolia/client-analytics": {
-            "version": "4.24.0",
-            "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-4.24.0.tgz",
-            "integrity": "sha512-y8jOZt1OjwWU4N2qr8G4AxXAzaa8DBvyHTWlHzX/7Me1LX8OayfgHexqrsL4vSBcoMmVw2XnVW9MhL+Y2ZDJXg==",
-            "license": "MIT",
-            "dependencies": {
-                "@algolia/client-common": "4.24.0",
-                "@algolia/client-search": "4.24.0",
-                "@algolia/requester-common": "4.24.0",
-                "@algolia/transporter": "4.24.0"
-            }
-        },
-        "node_modules/@algolia/client-common": {
+        "node_modules/@algolia/client-account/node_modules/@algolia/client-common": {
             "version": "4.24.0",
             "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.24.0.tgz",
             "integrity": "sha512-bc2ROsNL6w6rqpl5jj/UywlIYC21TwSSoFHKl01lYirGMW+9Eek6r02Tocg4gZ8HAw3iBvu6XQiM3BEbmEMoiA==",
@@ -312,6 +268,41 @@
             "dependencies": {
                 "@algolia/requester-common": "4.24.0",
                 "@algolia/transporter": "4.24.0"
+            }
+        },
+        "node_modules/@algolia/client-account/node_modules/@algolia/client-search": {
+            "version": "4.24.0",
+            "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.24.0.tgz",
+            "integrity": "sha512-uRW6EpNapmLAD0mW47OXqTP8eiIx5F6qN9/x/7HHO6owL3N1IXqydGwW5nhDFBrV+ldouro2W1VX3XlcUXEFCA==",
+            "license": "MIT",
+            "dependencies": {
+                "@algolia/client-common": "4.24.0",
+                "@algolia/requester-common": "4.24.0",
+                "@algolia/transporter": "4.24.0"
+            }
+        },
+        "node_modules/@algolia/client-analytics": {
+            "version": "5.19.0",
+            "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-5.19.0.tgz",
+            "integrity": "sha512-CDW4RwnCHzU10upPJqS6N6YwDpDHno7w6/qXT9KPbPbt8szIIzCHrva4O9KIfx1OhdsHzfGSI5hMAiOOYl4DEQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@algolia/client-common": "5.19.0",
+                "@algolia/requester-browser-xhr": "5.19.0",
+                "@algolia/requester-fetch": "5.19.0",
+                "@algolia/requester-node-http": "5.19.0"
+            },
+            "engines": {
+                "node": ">= 14.0.0"
+            }
+        },
+        "node_modules/@algolia/client-common": {
+            "version": "5.19.0",
+            "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-5.19.0.tgz",
+            "integrity": "sha512-2ERRbICHXvtj5kfFpY5r8qu9pJII/NAHsdgUXnUitQFwPdPL7wXiupcvZJC7DSntOnE8AE0lM7oDsPhrJfj5nQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 14.0.0"
             }
         },
         "node_modules/@algolia/client-insights": {
@@ -329,48 +320,19 @@
                 "node": ">= 14.0.0"
             }
         },
-        "node_modules/@algolia/client-insights/node_modules/@algolia/client-common": {
-            "version": "5.19.0",
-            "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-5.19.0.tgz",
-            "integrity": "sha512-2ERRbICHXvtj5kfFpY5r8qu9pJII/NAHsdgUXnUitQFwPdPL7wXiupcvZJC7DSntOnE8AE0lM7oDsPhrJfj5nQ==",
-            "license": "MIT",
-            "engines": {
-                "node": ">= 14.0.0"
-            }
-        },
-        "node_modules/@algolia/client-insights/node_modules/@algolia/requester-browser-xhr": {
-            "version": "5.19.0",
-            "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.19.0.tgz",
-            "integrity": "sha512-GfnhnQBT23mW/VMNs7m1qyEyZzhZz093aY2x8p0era96MMyNv8+FxGek5pjVX0b57tmSCZPf4EqNCpkGcGsmbw==",
-            "license": "MIT",
-            "dependencies": {
-                "@algolia/client-common": "5.19.0"
-            },
-            "engines": {
-                "node": ">= 14.0.0"
-            }
-        },
-        "node_modules/@algolia/client-insights/node_modules/@algolia/requester-node-http": {
-            "version": "5.19.0",
-            "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-5.19.0.tgz",
-            "integrity": "sha512-p6t8ue0XZNjcRiqNkb5QAM0qQRAKsCiebZ6n9JjWA+p8fWf8BvnhO55y2fO28g3GW0Imj7PrAuyBuxq8aDVQwQ==",
-            "license": "MIT",
-            "dependencies": {
-                "@algolia/client-common": "5.19.0"
-            },
-            "engines": {
-                "node": ">= 14.0.0"
-            }
-        },
         "node_modules/@algolia/client-personalization": {
-            "version": "4.24.0",
-            "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-4.24.0.tgz",
-            "integrity": "sha512-l5FRFm/yngztweU0HdUzz1rC4yoWCFo3IF+dVIVTfEPg906eZg5BOd1k0K6rZx5JzyyoP4LdmOikfkfGsKVE9w==",
+            "version": "5.19.0",
+            "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-5.19.0.tgz",
+            "integrity": "sha512-B9eoce/fk8NLboGje+pMr72pw+PV7c5Z01On477heTZ7jkxoZ4X92dobeGuEQop61cJ93Gaevd1of4mBr4hu2A==",
             "license": "MIT",
             "dependencies": {
-                "@algolia/client-common": "4.24.0",
-                "@algolia/requester-common": "4.24.0",
-                "@algolia/transporter": "4.24.0"
+                "@algolia/client-common": "5.19.0",
+                "@algolia/requester-browser-xhr": "5.19.0",
+                "@algolia/requester-fetch": "5.19.0",
+                "@algolia/requester-node-http": "5.19.0"
+            },
+            "engines": {
+                "node": ">= 14.0.0"
             }
         },
         "node_modules/@algolia/client-query-suggestions": {
@@ -388,48 +350,19 @@
                 "node": ">= 14.0.0"
             }
         },
-        "node_modules/@algolia/client-query-suggestions/node_modules/@algolia/client-common": {
-            "version": "5.19.0",
-            "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-5.19.0.tgz",
-            "integrity": "sha512-2ERRbICHXvtj5kfFpY5r8qu9pJII/NAHsdgUXnUitQFwPdPL7wXiupcvZJC7DSntOnE8AE0lM7oDsPhrJfj5nQ==",
-            "license": "MIT",
-            "engines": {
-                "node": ">= 14.0.0"
-            }
-        },
-        "node_modules/@algolia/client-query-suggestions/node_modules/@algolia/requester-browser-xhr": {
-            "version": "5.19.0",
-            "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.19.0.tgz",
-            "integrity": "sha512-GfnhnQBT23mW/VMNs7m1qyEyZzhZz093aY2x8p0era96MMyNv8+FxGek5pjVX0b57tmSCZPf4EqNCpkGcGsmbw==",
-            "license": "MIT",
-            "dependencies": {
-                "@algolia/client-common": "5.19.0"
-            },
-            "engines": {
-                "node": ">= 14.0.0"
-            }
-        },
-        "node_modules/@algolia/client-query-suggestions/node_modules/@algolia/requester-node-http": {
-            "version": "5.19.0",
-            "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-5.19.0.tgz",
-            "integrity": "sha512-p6t8ue0XZNjcRiqNkb5QAM0qQRAKsCiebZ6n9JjWA+p8fWf8BvnhO55y2fO28g3GW0Imj7PrAuyBuxq8aDVQwQ==",
-            "license": "MIT",
-            "dependencies": {
-                "@algolia/client-common": "5.19.0"
-            },
-            "engines": {
-                "node": ">= 14.0.0"
-            }
-        },
         "node_modules/@algolia/client-search": {
-            "version": "4.24.0",
-            "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.24.0.tgz",
-            "integrity": "sha512-uRW6EpNapmLAD0mW47OXqTP8eiIx5F6qN9/x/7HHO6owL3N1IXqydGwW5nhDFBrV+ldouro2W1VX3XlcUXEFCA==",
+            "version": "5.19.0",
+            "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.19.0.tgz",
+            "integrity": "sha512-Ctg3xXD/1VtcwmkulR5+cKGOMj4r0wC49Y/KZdGQcqpydKn+e86F6l3tb3utLJQVq4lpEJud6kdRykFgcNsp8Q==",
             "license": "MIT",
             "dependencies": {
-                "@algolia/client-common": "4.24.0",
-                "@algolia/requester-common": "4.24.0",
-                "@algolia/transporter": "4.24.0"
+                "@algolia/client-common": "5.19.0",
+                "@algolia/requester-browser-xhr": "5.19.0",
+                "@algolia/requester-fetch": "5.19.0",
+                "@algolia/requester-node-http": "5.19.0"
+            },
+            "engines": {
+                "node": ">= 14.0.0"
             }
         },
         "node_modules/@algolia/events": {
@@ -448,39 +381,6 @@
                 "@algolia/requester-browser-xhr": "5.19.0",
                 "@algolia/requester-fetch": "5.19.0",
                 "@algolia/requester-node-http": "5.19.0"
-            },
-            "engines": {
-                "node": ">= 14.0.0"
-            }
-        },
-        "node_modules/@algolia/ingestion/node_modules/@algolia/client-common": {
-            "version": "5.19.0",
-            "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-5.19.0.tgz",
-            "integrity": "sha512-2ERRbICHXvtj5kfFpY5r8qu9pJII/NAHsdgUXnUitQFwPdPL7wXiupcvZJC7DSntOnE8AE0lM7oDsPhrJfj5nQ==",
-            "license": "MIT",
-            "engines": {
-                "node": ">= 14.0.0"
-            }
-        },
-        "node_modules/@algolia/ingestion/node_modules/@algolia/requester-browser-xhr": {
-            "version": "5.19.0",
-            "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.19.0.tgz",
-            "integrity": "sha512-GfnhnQBT23mW/VMNs7m1qyEyZzhZz093aY2x8p0era96MMyNv8+FxGek5pjVX0b57tmSCZPf4EqNCpkGcGsmbw==",
-            "license": "MIT",
-            "dependencies": {
-                "@algolia/client-common": "5.19.0"
-            },
-            "engines": {
-                "node": ">= 14.0.0"
-            }
-        },
-        "node_modules/@algolia/ingestion/node_modules/@algolia/requester-node-http": {
-            "version": "5.19.0",
-            "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-5.19.0.tgz",
-            "integrity": "sha512-p6t8ue0XZNjcRiqNkb5QAM0qQRAKsCiebZ6n9JjWA+p8fWf8BvnhO55y2fO28g3GW0Imj7PrAuyBuxq8aDVQwQ==",
-            "license": "MIT",
-            "dependencies": {
-                "@algolia/client-common": "5.19.0"
             },
             "engines": {
                 "node": ">= 14.0.0"
@@ -516,16 +416,22 @@
                 "node": ">= 14.0.0"
             }
         },
-        "node_modules/@algolia/monitoring/node_modules/@algolia/client-common": {
+        "node_modules/@algolia/recommend": {
             "version": "5.19.0",
-            "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-5.19.0.tgz",
-            "integrity": "sha512-2ERRbICHXvtj5kfFpY5r8qu9pJII/NAHsdgUXnUitQFwPdPL7wXiupcvZJC7DSntOnE8AE0lM7oDsPhrJfj5nQ==",
+            "resolved": "https://registry.npmjs.org/@algolia/recommend/-/recommend-5.19.0.tgz",
+            "integrity": "sha512-PbgrMTbUPlmwfJsxjFhal4XqZO2kpBNRjemLVTkUiti4w/+kzcYO4Hg5zaBgVqPwvFDNQ8JS4SS3TBBem88u+g==",
             "license": "MIT",
+            "dependencies": {
+                "@algolia/client-common": "5.19.0",
+                "@algolia/requester-browser-xhr": "5.19.0",
+                "@algolia/requester-fetch": "5.19.0",
+                "@algolia/requester-node-http": "5.19.0"
+            },
             "engines": {
                 "node": ">= 14.0.0"
             }
         },
-        "node_modules/@algolia/monitoring/node_modules/@algolia/requester-browser-xhr": {
+        "node_modules/@algolia/requester-browser-xhr": {
             "version": "5.19.0",
             "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.19.0.tgz",
             "integrity": "sha512-GfnhnQBT23mW/VMNs7m1qyEyZzhZz093aY2x8p0era96MMyNv8+FxGek5pjVX0b57tmSCZPf4EqNCpkGcGsmbw==",
@@ -535,46 +441,6 @@
             },
             "engines": {
                 "node": ">= 14.0.0"
-            }
-        },
-        "node_modules/@algolia/monitoring/node_modules/@algolia/requester-node-http": {
-            "version": "5.19.0",
-            "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-5.19.0.tgz",
-            "integrity": "sha512-p6t8ue0XZNjcRiqNkb5QAM0qQRAKsCiebZ6n9JjWA+p8fWf8BvnhO55y2fO28g3GW0Imj7PrAuyBuxq8aDVQwQ==",
-            "license": "MIT",
-            "dependencies": {
-                "@algolia/client-common": "5.19.0"
-            },
-            "engines": {
-                "node": ">= 14.0.0"
-            }
-        },
-        "node_modules/@algolia/recommend": {
-            "version": "4.24.0",
-            "resolved": "https://registry.npmjs.org/@algolia/recommend/-/recommend-4.24.0.tgz",
-            "integrity": "sha512-P9kcgerfVBpfYHDfVZDvvdJv0lEoCvzNlOy2nykyt5bK8TyieYyiD0lguIJdRZZYGre03WIAFf14pgE+V+IBlw==",
-            "license": "MIT",
-            "dependencies": {
-                "@algolia/cache-browser-local-storage": "4.24.0",
-                "@algolia/cache-common": "4.24.0",
-                "@algolia/cache-in-memory": "4.24.0",
-                "@algolia/client-common": "4.24.0",
-                "@algolia/client-search": "4.24.0",
-                "@algolia/logger-common": "4.24.0",
-                "@algolia/logger-console": "4.24.0",
-                "@algolia/requester-browser-xhr": "4.24.0",
-                "@algolia/requester-common": "4.24.0",
-                "@algolia/requester-node-http": "4.24.0",
-                "@algolia/transporter": "4.24.0"
-            }
-        },
-        "node_modules/@algolia/requester-browser-xhr": {
-            "version": "4.24.0",
-            "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-4.24.0.tgz",
-            "integrity": "sha512-Z2NxZMb6+nVXSjF13YpjYTdvV3032YTBSGm2vnYvYPA6mMxzM3v5rsCiSspndn9rzIW4Qp1lPHBvuoKJV6jnAA==",
-            "license": "MIT",
-            "dependencies": {
-                "@algolia/requester-common": "4.24.0"
             }
         },
         "node_modules/@algolia/requester-common": {
@@ -595,22 +461,16 @@
                 "node": ">= 14.0.0"
             }
         },
-        "node_modules/@algolia/requester-fetch/node_modules/@algolia/client-common": {
-            "version": "5.19.0",
-            "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-5.19.0.tgz",
-            "integrity": "sha512-2ERRbICHXvtj5kfFpY5r8qu9pJII/NAHsdgUXnUitQFwPdPL7wXiupcvZJC7DSntOnE8AE0lM7oDsPhrJfj5nQ==",
-            "license": "MIT",
-            "engines": {
-                "node": ">= 14.0.0"
-            }
-        },
         "node_modules/@algolia/requester-node-http": {
-            "version": "4.24.0",
-            "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-4.24.0.tgz",
-            "integrity": "sha512-JF18yTjNOVYvU/L3UosRcvbPMGT9B+/GQWNWnenIImglzNVGpyzChkXLnrSf6uxwVNO6ESGu6oN8MqcGQcjQJw==",
+            "version": "5.19.0",
+            "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-5.19.0.tgz",
+            "integrity": "sha512-p6t8ue0XZNjcRiqNkb5QAM0qQRAKsCiebZ6n9JjWA+p8fWf8BvnhO55y2fO28g3GW0Imj7PrAuyBuxq8aDVQwQ==",
             "license": "MIT",
             "dependencies": {
-                "@algolia/requester-common": "4.24.0"
+                "@algolia/client-common": "5.19.0"
+            },
+            "engines": {
+                "node": ">= 14.0.0"
             }
         },
         "node_modules/@algolia/transporter": {
@@ -730,37 +590,113 @@
                 "react-dom": "> 18.0.0"
             }
         },
+        "node_modules/@apify/docs-search-modal/node_modules/@algolia/client-analytics": {
+            "version": "4.24.0",
+            "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-4.24.0.tgz",
+            "integrity": "sha512-y8jOZt1OjwWU4N2qr8G4AxXAzaa8DBvyHTWlHzX/7Me1LX8OayfgHexqrsL4vSBcoMmVw2XnVW9MhL+Y2ZDJXg==",
+            "license": "MIT",
+            "dependencies": {
+                "@algolia/client-common": "4.24.0",
+                "@algolia/client-search": "4.24.0",
+                "@algolia/requester-common": "4.24.0",
+                "@algolia/transporter": "4.24.0"
+            }
+        },
+        "node_modules/@apify/docs-search-modal/node_modules/@algolia/client-common": {
+            "version": "4.24.0",
+            "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.24.0.tgz",
+            "integrity": "sha512-bc2ROsNL6w6rqpl5jj/UywlIYC21TwSSoFHKl01lYirGMW+9Eek6r02Tocg4gZ8HAw3iBvu6XQiM3BEbmEMoiA==",
+            "license": "MIT",
+            "dependencies": {
+                "@algolia/requester-common": "4.24.0",
+                "@algolia/transporter": "4.24.0"
+            }
+        },
+        "node_modules/@apify/docs-search-modal/node_modules/@algolia/client-personalization": {
+            "version": "4.24.0",
+            "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-4.24.0.tgz",
+            "integrity": "sha512-l5FRFm/yngztweU0HdUzz1rC4yoWCFo3IF+dVIVTfEPg906eZg5BOd1k0K6rZx5JzyyoP4LdmOikfkfGsKVE9w==",
+            "license": "MIT",
+            "dependencies": {
+                "@algolia/client-common": "4.24.0",
+                "@algolia/requester-common": "4.24.0",
+                "@algolia/transporter": "4.24.0"
+            }
+        },
+        "node_modules/@apify/docs-search-modal/node_modules/@algolia/client-search": {
+            "version": "4.24.0",
+            "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.24.0.tgz",
+            "integrity": "sha512-uRW6EpNapmLAD0mW47OXqTP8eiIx5F6qN9/x/7HHO6owL3N1IXqydGwW5nhDFBrV+ldouro2W1VX3XlcUXEFCA==",
+            "license": "MIT",
+            "dependencies": {
+                "@algolia/client-common": "4.24.0",
+                "@algolia/requester-common": "4.24.0",
+                "@algolia/transporter": "4.24.0"
+            }
+        },
+        "node_modules/@apify/docs-search-modal/node_modules/@algolia/recommend": {
+            "version": "4.24.0",
+            "resolved": "https://registry.npmjs.org/@algolia/recommend/-/recommend-4.24.0.tgz",
+            "integrity": "sha512-P9kcgerfVBpfYHDfVZDvvdJv0lEoCvzNlOy2nykyt5bK8TyieYyiD0lguIJdRZZYGre03WIAFf14pgE+V+IBlw==",
+            "license": "MIT",
+            "dependencies": {
+                "@algolia/cache-browser-local-storage": "4.24.0",
+                "@algolia/cache-common": "4.24.0",
+                "@algolia/cache-in-memory": "4.24.0",
+                "@algolia/client-common": "4.24.0",
+                "@algolia/client-search": "4.24.0",
+                "@algolia/logger-common": "4.24.0",
+                "@algolia/logger-console": "4.24.0",
+                "@algolia/requester-browser-xhr": "4.24.0",
+                "@algolia/requester-common": "4.24.0",
+                "@algolia/requester-node-http": "4.24.0",
+                "@algolia/transporter": "4.24.0"
+            }
+        },
+        "node_modules/@apify/docs-search-modal/node_modules/@algolia/requester-browser-xhr": {
+            "version": "4.24.0",
+            "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-4.24.0.tgz",
+            "integrity": "sha512-Z2NxZMb6+nVXSjF13YpjYTdvV3032YTBSGm2vnYvYPA6mMxzM3v5rsCiSspndn9rzIW4Qp1lPHBvuoKJV6jnAA==",
+            "license": "MIT",
+            "dependencies": {
+                "@algolia/requester-common": "4.24.0"
+            }
+        },
+        "node_modules/@apify/docs-search-modal/node_modules/@algolia/requester-node-http": {
+            "version": "4.24.0",
+            "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-4.24.0.tgz",
+            "integrity": "sha512-JF18yTjNOVYvU/L3UosRcvbPMGT9B+/GQWNWnenIImglzNVGpyzChkXLnrSf6uxwVNO6ESGu6oN8MqcGQcjQJw==",
+            "license": "MIT",
+            "dependencies": {
+                "@algolia/requester-common": "4.24.0"
+            }
+        },
+        "node_modules/@apify/docs-search-modal/node_modules/algoliasearch": {
+            "version": "4.24.0",
+            "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-4.24.0.tgz",
+            "integrity": "sha512-bf0QV/9jVejssFBmz2HQLxUadxk574t4iwjCKp5E7NBzwKkrDEhKPISIIjAU/p6K5qDx3qoeh4+26zWN1jmw3g==",
+            "license": "MIT",
+            "dependencies": {
+                "@algolia/cache-browser-local-storage": "4.24.0",
+                "@algolia/cache-common": "4.24.0",
+                "@algolia/cache-in-memory": "4.24.0",
+                "@algolia/client-account": "4.24.0",
+                "@algolia/client-analytics": "4.24.0",
+                "@algolia/client-common": "4.24.0",
+                "@algolia/client-personalization": "4.24.0",
+                "@algolia/client-search": "4.24.0",
+                "@algolia/logger-common": "4.24.0",
+                "@algolia/logger-console": "4.24.0",
+                "@algolia/recommend": "4.24.0",
+                "@algolia/requester-browser-xhr": "4.24.0",
+                "@algolia/requester-common": "4.24.0",
+                "@algolia/requester-node-http": "4.24.0",
+                "@algolia/transporter": "4.24.0"
+            }
+        },
         "node_modules/@apify/docs-theme": {
             "resolved": "apify-docs-theme",
             "link": true
-        },
-        "node_modules/@apify/docsearch-apify-docs": {
-            "version": "3.5.3",
-            "resolved": "https://registry.npmjs.org/@apify/docsearch-apify-docs/-/docsearch-apify-docs-3.5.3.tgz",
-            "integrity": "sha512-HW1r03UqEBmdd/vDXegozrhA1LWpH/XtDJDxSQfs+UL+PTXm/7UmlRCiOzHpI5V3Co2c0GRuJ4Mgab277hj1bg==",
-            "license": "MIT",
-            "dependencies": {
-                "@algolia/autocomplete-core": "1.9.3",
-                "@algolia/autocomplete-preset-algolia": "1.9.3",
-                "@docsearch/css": "3.5.1",
-                "algoliasearch": "^4.0.0"
-            },
-            "peerDependencies": {
-                "@types/react": ">= 16.8.0 < 19.0.0",
-                "react": ">= 16.8.0 < 19.0.0",
-                "react-dom": ">= 16.8.0 < 19.0.0"
-            },
-            "peerDependenciesMeta": {
-                "@types/react": {
-                    "optional": true
-                },
-                "react": {
-                    "optional": true
-                },
-                "react-dom": {
-                    "optional": true
-                }
-            }
         },
         "node_modules/@apify/eslint-config": {
             "version": "0.4.0",
@@ -1821,9 +1757,9 @@
             }
         },
         "node_modules/@babel/plugin-transform-nullish-coalescing-operator": {
-            "version": "7.26.5",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-nullish-coalescing-operator/-/plugin-transform-nullish-coalescing-operator-7.26.5.tgz",
-            "integrity": "sha512-OHqczNm4NTQlW1ghrVY43FPoiRzbmzNVbcgVnMKZN/RQYezHUSdjACjaX50CD3B7UIAjv39+MlsrVDb3v741FA==",
+            "version": "7.26.6",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-nullish-coalescing-operator/-/plugin-transform-nullish-coalescing-operator-7.26.6.tgz",
+            "integrity": "sha512-CKW8Vu+uUZneQCPtXmSBUC6NCAUdya26hWCElAWh5mVSlSRsmiCPUUDKb3Z0szng1hiAJa098Hkhg9o4SE35Qw==",
             "license": "MIT",
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.26.5"
@@ -3696,9 +3632,9 @@
             }
         },
         "node_modules/@docsearch/css": {
-            "version": "3.5.1",
-            "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-3.5.1.tgz",
-            "integrity": "sha512-2Pu9HDg/uP/IT10rbQ+4OrTQuxIWdKVUEdcw9/w7kZJv9NeHS6skJx1xuRiFyoGKwAzcHXnLp7csE99sj+O1YA==",
+            "version": "3.8.2",
+            "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-3.8.2.tgz",
+            "integrity": "sha512-y05ayQFyUmCXze79+56v/4HpycYF3uFqB78pLPrSV5ZKAlDuIAAJNhaRi8tTdRNXh05yxX/TyNnzD6LwSM89vQ==",
             "license": "MIT"
         },
         "node_modules/@docsearch/react": {
@@ -3731,174 +3667,6 @@
                 "search-insights": {
                     "optional": true
                 }
-            }
-        },
-        "node_modules/@docsearch/react/node_modules/@algolia/autocomplete-core": {
-            "version": "1.17.7",
-            "resolved": "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.17.7.tgz",
-            "integrity": "sha512-BjiPOW6ks90UKl7TwMv7oNQMnzU+t/wk9mgIDi6b1tXpUek7MW0lbNOUHpvam9pe3lVCf4xPFT+lK7s+e+fs7Q==",
-            "license": "MIT",
-            "dependencies": {
-                "@algolia/autocomplete-plugin-algolia-insights": "1.17.7",
-                "@algolia/autocomplete-shared": "1.17.7"
-            }
-        },
-        "node_modules/@docsearch/react/node_modules/@algolia/autocomplete-plugin-algolia-insights": {
-            "version": "1.17.7",
-            "resolved": "https://registry.npmjs.org/@algolia/autocomplete-plugin-algolia-insights/-/autocomplete-plugin-algolia-insights-1.17.7.tgz",
-            "integrity": "sha512-Jca5Ude6yUOuyzjnz57og7Et3aXjbwCSDf/8onLHSQgw1qW3ALl9mrMWaXb5FmPVkV3EtkD2F/+NkT6VHyPu9A==",
-            "license": "MIT",
-            "dependencies": {
-                "@algolia/autocomplete-shared": "1.17.7"
-            },
-            "peerDependencies": {
-                "search-insights": ">= 1 < 3"
-            }
-        },
-        "node_modules/@docsearch/react/node_modules/@algolia/autocomplete-preset-algolia": {
-            "version": "1.17.7",
-            "resolved": "https://registry.npmjs.org/@algolia/autocomplete-preset-algolia/-/autocomplete-preset-algolia-1.17.7.tgz",
-            "integrity": "sha512-ggOQ950+nwbWROq2MOCIL71RE0DdQZsceqrg32UqnhDz8FlO9rL8ONHNsI2R1MH0tkgVIDKI/D0sMiUchsFdWA==",
-            "license": "MIT",
-            "dependencies": {
-                "@algolia/autocomplete-shared": "1.17.7"
-            },
-            "peerDependencies": {
-                "@algolia/client-search": ">= 4.9.1 < 6",
-                "algoliasearch": ">= 4.9.1 < 6"
-            }
-        },
-        "node_modules/@docsearch/react/node_modules/@algolia/autocomplete-shared": {
-            "version": "1.17.7",
-            "resolved": "https://registry.npmjs.org/@algolia/autocomplete-shared/-/autocomplete-shared-1.17.7.tgz",
-            "integrity": "sha512-o/1Vurr42U/qskRSuhBH+VKxMvkkUVTLU6WZQr+L5lGZZLYWyhdzWjW0iGXY7EkwRTjBqvN2EsR81yCTGV/kmg==",
-            "license": "MIT",
-            "peerDependencies": {
-                "@algolia/client-search": ">= 4.9.1 < 6",
-                "algoliasearch": ">= 4.9.1 < 6"
-            }
-        },
-        "node_modules/@docsearch/react/node_modules/@algolia/client-analytics": {
-            "version": "5.19.0",
-            "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-5.19.0.tgz",
-            "integrity": "sha512-CDW4RwnCHzU10upPJqS6N6YwDpDHno7w6/qXT9KPbPbt8szIIzCHrva4O9KIfx1OhdsHzfGSI5hMAiOOYl4DEQ==",
-            "license": "MIT",
-            "dependencies": {
-                "@algolia/client-common": "5.19.0",
-                "@algolia/requester-browser-xhr": "5.19.0",
-                "@algolia/requester-fetch": "5.19.0",
-                "@algolia/requester-node-http": "5.19.0"
-            },
-            "engines": {
-                "node": ">= 14.0.0"
-            }
-        },
-        "node_modules/@docsearch/react/node_modules/@algolia/client-common": {
-            "version": "5.19.0",
-            "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-5.19.0.tgz",
-            "integrity": "sha512-2ERRbICHXvtj5kfFpY5r8qu9pJII/NAHsdgUXnUitQFwPdPL7wXiupcvZJC7DSntOnE8AE0lM7oDsPhrJfj5nQ==",
-            "license": "MIT",
-            "engines": {
-                "node": ">= 14.0.0"
-            }
-        },
-        "node_modules/@docsearch/react/node_modules/@algolia/client-personalization": {
-            "version": "5.19.0",
-            "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-5.19.0.tgz",
-            "integrity": "sha512-B9eoce/fk8NLboGje+pMr72pw+PV7c5Z01On477heTZ7jkxoZ4X92dobeGuEQop61cJ93Gaevd1of4mBr4hu2A==",
-            "license": "MIT",
-            "dependencies": {
-                "@algolia/client-common": "5.19.0",
-                "@algolia/requester-browser-xhr": "5.19.0",
-                "@algolia/requester-fetch": "5.19.0",
-                "@algolia/requester-node-http": "5.19.0"
-            },
-            "engines": {
-                "node": ">= 14.0.0"
-            }
-        },
-        "node_modules/@docsearch/react/node_modules/@algolia/client-search": {
-            "version": "5.19.0",
-            "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.19.0.tgz",
-            "integrity": "sha512-Ctg3xXD/1VtcwmkulR5+cKGOMj4r0wC49Y/KZdGQcqpydKn+e86F6l3tb3utLJQVq4lpEJud6kdRykFgcNsp8Q==",
-            "license": "MIT",
-            "dependencies": {
-                "@algolia/client-common": "5.19.0",
-                "@algolia/requester-browser-xhr": "5.19.0",
-                "@algolia/requester-fetch": "5.19.0",
-                "@algolia/requester-node-http": "5.19.0"
-            },
-            "engines": {
-                "node": ">= 14.0.0"
-            }
-        },
-        "node_modules/@docsearch/react/node_modules/@algolia/recommend": {
-            "version": "5.19.0",
-            "resolved": "https://registry.npmjs.org/@algolia/recommend/-/recommend-5.19.0.tgz",
-            "integrity": "sha512-PbgrMTbUPlmwfJsxjFhal4XqZO2kpBNRjemLVTkUiti4w/+kzcYO4Hg5zaBgVqPwvFDNQ8JS4SS3TBBem88u+g==",
-            "license": "MIT",
-            "dependencies": {
-                "@algolia/client-common": "5.19.0",
-                "@algolia/requester-browser-xhr": "5.19.0",
-                "@algolia/requester-fetch": "5.19.0",
-                "@algolia/requester-node-http": "5.19.0"
-            },
-            "engines": {
-                "node": ">= 14.0.0"
-            }
-        },
-        "node_modules/@docsearch/react/node_modules/@algolia/requester-browser-xhr": {
-            "version": "5.19.0",
-            "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.19.0.tgz",
-            "integrity": "sha512-GfnhnQBT23mW/VMNs7m1qyEyZzhZz093aY2x8p0era96MMyNv8+FxGek5pjVX0b57tmSCZPf4EqNCpkGcGsmbw==",
-            "license": "MIT",
-            "dependencies": {
-                "@algolia/client-common": "5.19.0"
-            },
-            "engines": {
-                "node": ">= 14.0.0"
-            }
-        },
-        "node_modules/@docsearch/react/node_modules/@algolia/requester-node-http": {
-            "version": "5.19.0",
-            "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-5.19.0.tgz",
-            "integrity": "sha512-p6t8ue0XZNjcRiqNkb5QAM0qQRAKsCiebZ6n9JjWA+p8fWf8BvnhO55y2fO28g3GW0Imj7PrAuyBuxq8aDVQwQ==",
-            "license": "MIT",
-            "dependencies": {
-                "@algolia/client-common": "5.19.0"
-            },
-            "engines": {
-                "node": ">= 14.0.0"
-            }
-        },
-        "node_modules/@docsearch/react/node_modules/@docsearch/css": {
-            "version": "3.8.2",
-            "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-3.8.2.tgz",
-            "integrity": "sha512-y05ayQFyUmCXze79+56v/4HpycYF3uFqB78pLPrSV5ZKAlDuIAAJNhaRi8tTdRNXh05yxX/TyNnzD6LwSM89vQ==",
-            "license": "MIT"
-        },
-        "node_modules/@docsearch/react/node_modules/algoliasearch": {
-            "version": "5.19.0",
-            "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.19.0.tgz",
-            "integrity": "sha512-zrLtGhC63z3sVLDDKGW+SlCRN9eJHFTgdEmoAOpsVh6wgGL1GgTTDou7tpCBjevzgIvi3AIyDAQO3Xjbg5eqZg==",
-            "license": "MIT",
-            "dependencies": {
-                "@algolia/client-abtesting": "5.19.0",
-                "@algolia/client-analytics": "5.19.0",
-                "@algolia/client-common": "5.19.0",
-                "@algolia/client-insights": "5.19.0",
-                "@algolia/client-personalization": "5.19.0",
-                "@algolia/client-query-suggestions": "5.19.0",
-                "@algolia/client-search": "5.19.0",
-                "@algolia/ingestion": "1.19.0",
-                "@algolia/monitoring": "1.19.0",
-                "@algolia/recommend": "5.19.0",
-                "@algolia/requester-browser-xhr": "5.19.0",
-                "@algolia/requester-fetch": "5.19.0",
-                "@algolia/requester-node-http": "5.19.0"
-            },
-            "engines": {
-                "node": ">= 14.0.0"
             }
         },
         "node_modules/@docusaurus/babel": {
@@ -4938,123 +4706,6 @@
             "peerDependencies": {
                 "react": "^18.0.0 || ^19.0.0",
                 "react-dom": "^18.0.0 || ^19.0.0"
-            }
-        },
-        "node_modules/@docusaurus/theme-search-algolia/node_modules/@algolia/client-analytics": {
-            "version": "5.19.0",
-            "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-5.19.0.tgz",
-            "integrity": "sha512-CDW4RwnCHzU10upPJqS6N6YwDpDHno7w6/qXT9KPbPbt8szIIzCHrva4O9KIfx1OhdsHzfGSI5hMAiOOYl4DEQ==",
-            "license": "MIT",
-            "dependencies": {
-                "@algolia/client-common": "5.19.0",
-                "@algolia/requester-browser-xhr": "5.19.0",
-                "@algolia/requester-fetch": "5.19.0",
-                "@algolia/requester-node-http": "5.19.0"
-            },
-            "engines": {
-                "node": ">= 14.0.0"
-            }
-        },
-        "node_modules/@docusaurus/theme-search-algolia/node_modules/@algolia/client-common": {
-            "version": "5.19.0",
-            "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-5.19.0.tgz",
-            "integrity": "sha512-2ERRbICHXvtj5kfFpY5r8qu9pJII/NAHsdgUXnUitQFwPdPL7wXiupcvZJC7DSntOnE8AE0lM7oDsPhrJfj5nQ==",
-            "license": "MIT",
-            "engines": {
-                "node": ">= 14.0.0"
-            }
-        },
-        "node_modules/@docusaurus/theme-search-algolia/node_modules/@algolia/client-personalization": {
-            "version": "5.19.0",
-            "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-5.19.0.tgz",
-            "integrity": "sha512-B9eoce/fk8NLboGje+pMr72pw+PV7c5Z01On477heTZ7jkxoZ4X92dobeGuEQop61cJ93Gaevd1of4mBr4hu2A==",
-            "license": "MIT",
-            "dependencies": {
-                "@algolia/client-common": "5.19.0",
-                "@algolia/requester-browser-xhr": "5.19.0",
-                "@algolia/requester-fetch": "5.19.0",
-                "@algolia/requester-node-http": "5.19.0"
-            },
-            "engines": {
-                "node": ">= 14.0.0"
-            }
-        },
-        "node_modules/@docusaurus/theme-search-algolia/node_modules/@algolia/client-search": {
-            "version": "5.19.0",
-            "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.19.0.tgz",
-            "integrity": "sha512-Ctg3xXD/1VtcwmkulR5+cKGOMj4r0wC49Y/KZdGQcqpydKn+e86F6l3tb3utLJQVq4lpEJud6kdRykFgcNsp8Q==",
-            "license": "MIT",
-            "dependencies": {
-                "@algolia/client-common": "5.19.0",
-                "@algolia/requester-browser-xhr": "5.19.0",
-                "@algolia/requester-fetch": "5.19.0",
-                "@algolia/requester-node-http": "5.19.0"
-            },
-            "engines": {
-                "node": ">= 14.0.0"
-            }
-        },
-        "node_modules/@docusaurus/theme-search-algolia/node_modules/@algolia/recommend": {
-            "version": "5.19.0",
-            "resolved": "https://registry.npmjs.org/@algolia/recommend/-/recommend-5.19.0.tgz",
-            "integrity": "sha512-PbgrMTbUPlmwfJsxjFhal4XqZO2kpBNRjemLVTkUiti4w/+kzcYO4Hg5zaBgVqPwvFDNQ8JS4SS3TBBem88u+g==",
-            "license": "MIT",
-            "dependencies": {
-                "@algolia/client-common": "5.19.0",
-                "@algolia/requester-browser-xhr": "5.19.0",
-                "@algolia/requester-fetch": "5.19.0",
-                "@algolia/requester-node-http": "5.19.0"
-            },
-            "engines": {
-                "node": ">= 14.0.0"
-            }
-        },
-        "node_modules/@docusaurus/theme-search-algolia/node_modules/@algolia/requester-browser-xhr": {
-            "version": "5.19.0",
-            "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.19.0.tgz",
-            "integrity": "sha512-GfnhnQBT23mW/VMNs7m1qyEyZzhZz093aY2x8p0era96MMyNv8+FxGek5pjVX0b57tmSCZPf4EqNCpkGcGsmbw==",
-            "license": "MIT",
-            "dependencies": {
-                "@algolia/client-common": "5.19.0"
-            },
-            "engines": {
-                "node": ">= 14.0.0"
-            }
-        },
-        "node_modules/@docusaurus/theme-search-algolia/node_modules/@algolia/requester-node-http": {
-            "version": "5.19.0",
-            "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-5.19.0.tgz",
-            "integrity": "sha512-p6t8ue0XZNjcRiqNkb5QAM0qQRAKsCiebZ6n9JjWA+p8fWf8BvnhO55y2fO28g3GW0Imj7PrAuyBuxq8aDVQwQ==",
-            "license": "MIT",
-            "dependencies": {
-                "@algolia/client-common": "5.19.0"
-            },
-            "engines": {
-                "node": ">= 14.0.0"
-            }
-        },
-        "node_modules/@docusaurus/theme-search-algolia/node_modules/algoliasearch": {
-            "version": "5.19.0",
-            "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.19.0.tgz",
-            "integrity": "sha512-zrLtGhC63z3sVLDDKGW+SlCRN9eJHFTgdEmoAOpsVh6wgGL1GgTTDou7tpCBjevzgIvi3AIyDAQO3Xjbg5eqZg==",
-            "license": "MIT",
-            "dependencies": {
-                "@algolia/client-abtesting": "5.19.0",
-                "@algolia/client-analytics": "5.19.0",
-                "@algolia/client-common": "5.19.0",
-                "@algolia/client-insights": "5.19.0",
-                "@algolia/client-personalization": "5.19.0",
-                "@algolia/client-query-suggestions": "5.19.0",
-                "@algolia/client-search": "5.19.0",
-                "@algolia/ingestion": "1.19.0",
-                "@algolia/monitoring": "1.19.0",
-                "@algolia/recommend": "5.19.0",
-                "@algolia/requester-browser-xhr": "5.19.0",
-                "@algolia/requester-fetch": "5.19.0",
-                "@algolia/requester-node-http": "5.19.0"
-            },
-            "engines": {
-                "node": ">= 14.0.0"
             }
         },
         "node_modules/@docusaurus/theme-translations": {
@@ -7789,9 +7440,9 @@
             "license": "MIT"
         },
         "node_modules/@types/node": {
-            "version": "22.10.5",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.5.tgz",
-            "integrity": "sha512-F8Q+SeGimwOo86fiovQh8qiXfFEh2/ocYv7tU5pJ3EXMSSxk1Joj5wefpFK2fHTf/N6HKGSxIDBT9f3gCxXPkQ==",
+            "version": "22.10.6",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.6.tgz",
+            "integrity": "sha512-qNiuwC4ZDAUNcY47xgaSuS92cjf8JbSUoaKS77bmLG1rU7MlATVSiw/IlrjtIyyskXBZ8KkNfjK/P5na7rgXbQ==",
             "license": "MIT",
             "dependencies": {
                 "undici-types": "~6.20.0"
@@ -7831,9 +7482,9 @@
             "license": "MIT"
         },
         "node_modules/@types/qs": {
-            "version": "6.9.17",
-            "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.17.tgz",
-            "integrity": "sha512-rX4/bPcfmvxHDv0XjfJELTTr+iB+tn032nPILqHm5wbthUUUuVtNGGqzhya9XUxjTP8Fpr0qYgSZZKxGY++svQ==",
+            "version": "6.9.18",
+            "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.18.tgz",
+            "integrity": "sha512-kK7dgTYDyGqS+e2Q4aK9X3D7q234CIZ1Bv0q/7Z5IwRDoADNU81xXJK/YVyLbLTZCoIwUoDoffFeF+p/eIklAA==",
             "license": "MIT"
         },
         "node_modules/@types/range-parser": {
@@ -8551,26 +8202,27 @@
             }
         },
         "node_modules/algoliasearch": {
-            "version": "4.24.0",
-            "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-4.24.0.tgz",
-            "integrity": "sha512-bf0QV/9jVejssFBmz2HQLxUadxk574t4iwjCKp5E7NBzwKkrDEhKPISIIjAU/p6K5qDx3qoeh4+26zWN1jmw3g==",
+            "version": "5.19.0",
+            "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.19.0.tgz",
+            "integrity": "sha512-zrLtGhC63z3sVLDDKGW+SlCRN9eJHFTgdEmoAOpsVh6wgGL1GgTTDou7tpCBjevzgIvi3AIyDAQO3Xjbg5eqZg==",
             "license": "MIT",
             "dependencies": {
-                "@algolia/cache-browser-local-storage": "4.24.0",
-                "@algolia/cache-common": "4.24.0",
-                "@algolia/cache-in-memory": "4.24.0",
-                "@algolia/client-account": "4.24.0",
-                "@algolia/client-analytics": "4.24.0",
-                "@algolia/client-common": "4.24.0",
-                "@algolia/client-personalization": "4.24.0",
-                "@algolia/client-search": "4.24.0",
-                "@algolia/logger-common": "4.24.0",
-                "@algolia/logger-console": "4.24.0",
-                "@algolia/recommend": "4.24.0",
-                "@algolia/requester-browser-xhr": "4.24.0",
-                "@algolia/requester-common": "4.24.0",
-                "@algolia/requester-node-http": "4.24.0",
-                "@algolia/transporter": "4.24.0"
+                "@algolia/client-abtesting": "5.19.0",
+                "@algolia/client-analytics": "5.19.0",
+                "@algolia/client-common": "5.19.0",
+                "@algolia/client-insights": "5.19.0",
+                "@algolia/client-personalization": "5.19.0",
+                "@algolia/client-query-suggestions": "5.19.0",
+                "@algolia/client-search": "5.19.0",
+                "@algolia/ingestion": "1.19.0",
+                "@algolia/monitoring": "1.19.0",
+                "@algolia/recommend": "5.19.0",
+                "@algolia/requester-browser-xhr": "5.19.0",
+                "@algolia/requester-fetch": "5.19.0",
+                "@algolia/requester-node-http": "5.19.0"
+            },
+            "engines": {
+                "node": ">= 14.0.0"
             }
         },
         "node_modules/algoliasearch-helper": {
@@ -10289,9 +9941,9 @@
             }
         },
         "node_modules/consola": {
-            "version": "3.3.3",
-            "resolved": "https://registry.npmjs.org/consola/-/consola-3.3.3.tgz",
-            "integrity": "sha512-Qil5KwghMzlqd51UXM0b6fyaGHtOC22scxrwrz4A2882LyUMwQjnvaedN1HAeXzphspQ6CpHkzMAWxBTUruDLg==",
+            "version": "3.4.0",
+            "resolved": "https://registry.npmjs.org/consola/-/consola-3.4.0.tgz",
+            "integrity": "sha512-EiPU8G6dQG0GFHNR8ljnZFki/8a+cQwEQ+7wpxdChl02Q8HXlwEZWD5lqAF8vC2sEC3Tehr8hy7vErz88LHyUA==",
             "license": "MIT",
             "engines": {
                 "node": "^14.18.0 || >=16.10.0"
@@ -11054,9 +10706,9 @@
             "license": "MIT"
         },
         "node_modules/cytoscape": {
-            "version": "3.30.4",
-            "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.30.4.tgz",
-            "integrity": "sha512-OxtlZwQl1WbwMmLiyPSEBuzeTIQnwZhJYYWFzZ2PhEHVFwpeaqNIkUzSiso00D98qk60l8Gwon2RP304d3BJ1A==",
+            "version": "3.31.0",
+            "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.31.0.tgz",
+            "integrity": "sha512-zDGn1K/tfZwEnoGOcHc0H4XazqAAXAuDpcYw9mUnUjATjqljyCNGJv8uEvbvxGaGHaVshxMecyl6oc6uKzRfbw==",
             "license": "MIT",
             "engines": {
                 "node": ">=0.10"
@@ -12126,9 +11778,9 @@
             }
         },
         "node_modules/docusaurus-plugin-redoc": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/docusaurus-plugin-redoc/-/docusaurus-plugin-redoc-2.1.1.tgz",
-            "integrity": "sha512-gf9HbFAKPZu17rbx+3C6vIpfMMTuvUFG8rRKeuHro1B5wUutBSjE5/VjB1owVGjIJQ74OgVKJvgczqUjhcQcjQ==",
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/docusaurus-plugin-redoc/-/docusaurus-plugin-redoc-2.2.1.tgz",
+            "integrity": "sha512-zwP5RfTLH3C4fAzCbOzJ0UJFNQ7rT1CU0C5rAWDiB86m9p2fKWS05NHeDdGE+tOsOjzEBBMSky8ooEFzo78yXA==",
             "license": "MIT",
             "dependencies": {
                 "@redocly/openapi-core": "1.16.0",
@@ -12138,7 +11790,7 @@
                 "node": ">=18"
             },
             "peerDependencies": {
-                "@docusaurus/utils": "^3.0.0"
+                "@docusaurus/utils": "^3.6.0"
             }
         },
         "node_modules/docusaurus-plugin-redoc/node_modules/@redocly/config": {
@@ -12285,9 +11937,9 @@
             }
         },
         "node_modules/docusaurus-theme-redoc": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/docusaurus-theme-redoc/-/docusaurus-theme-redoc-2.2.0.tgz",
-            "integrity": "sha512-oeREQZ7xf3qbkHSAvPVciGlssSb80zx+1GkiymM0sZwuZbD6FbTc6g1Dz81j8oCv0asSiRbsGo62KnpAatjnOg==",
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/docusaurus-theme-redoc/-/docusaurus-theme-redoc-2.2.1.tgz",
+            "integrity": "sha512-QO9ZU4/vWJTuCYiE4S14u4xEZEOHRNCqdT4wvPma0J8YII+z1kNSk2IIDSJDFMVHVZbOVc0KsUh7YpWrCh54nw==",
             "license": "MIT",
             "dependencies": {
                 "@redocly/openapi-core": "1.16.0",
@@ -12303,7 +11955,7 @@
                 "node": ">=18"
             },
             "peerDependencies": {
-                "@docusaurus/theme-common": "^3.0.0",
+                "@docusaurus/theme-common": "^3.6.0",
                 "webpack": "^5.0.0"
             }
         },
@@ -12791,9 +12443,9 @@
             "license": "MIT"
         },
         "node_modules/es-object-atoms": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.0.0.tgz",
-            "integrity": "sha512-MZ4iQ6JwHOBQjahnjwaC1ZtIBH+2ohjamzAO3oaHcXYup7qxjF2fixyH+Q71voWHeOkI2q/TnJao/KfXYIZWbw==",
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.0.1.tgz",
+            "integrity": "sha512-BPOBuyUF9QIVhuNLhbToCLHP6+0MHwZ7xLBkPPCZqK4JmpJgGnv10035STzzQwFpqdzNFMB3irvDI63IagvDwA==",
             "license": "MIT",
             "dependencies": {
                 "es-errors": "^1.3.0"
@@ -20303,9 +19955,9 @@
             "license": "MIT"
         },
         "node_modules/mdast-util-mdx-jsx": {
-            "version": "3.1.3",
-            "resolved": "https://registry.npmjs.org/mdast-util-mdx-jsx/-/mdast-util-mdx-jsx-3.1.3.tgz",
-            "integrity": "sha512-bfOjvNt+1AcbPLTFMFWY149nJz0OjmewJs3LQQ5pIyVGxP4CdOqNVJL6kTaM5c68p8q82Xv3nCyFfUnuEcH3UQ==",
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/mdast-util-mdx-jsx/-/mdast-util-mdx-jsx-3.2.0.tgz",
+            "integrity": "sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==",
             "license": "MIT",
             "dependencies": {
                 "@types/estree-jsx": "^1.0.0",
@@ -25012,9 +24664,9 @@
             }
         },
         "node_modules/postcss": {
-            "version": "8.4.49",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.49.tgz",
-            "integrity": "sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA==",
+            "version": "8.5.0",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.0.tgz",
+            "integrity": "sha512-27VKOqrYfPncKA2NrFOVhP5MGAfHKLYn/Q0mz9cNQyRAKYi3VNHwYU2qKKqPCqgBmeeJ0uAFB56NumXZ5ZReXg==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -25031,7 +24683,7 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "nanoid": "^3.3.7",
+                "nanoid": "^3.3.8",
                 "picocolors": "^1.1.1",
                 "source-map-js": "^1.2.1"
             },
@@ -28238,20 +27890,20 @@
             }
         },
         "node_modules/redocusaurus": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/redocusaurus/-/redocusaurus-2.2.0.tgz",
-            "integrity": "sha512-cf7kq5RRlwiLNtB4tMH6DBAhmLpZJ3UAOP9QkCHodvf2d46O9m5DOq1o7u6O4XZF65weCm3oDW8eFk6UvLrrtg==",
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/redocusaurus/-/redocusaurus-2.2.1.tgz",
+            "integrity": "sha512-eYk807UrZ2/gWX3DoK/NxnmVNCeOuJI9o7rsUwDFkkVMIRDEiwpF/qy/5tSLKQvn7pqmHNxFONqsAozzoDK7Fw==",
             "license": "MIT",
             "dependencies": {
-                "docusaurus-plugin-redoc": "2.1.1",
-                "docusaurus-theme-redoc": "2.2.0"
+                "docusaurus-plugin-redoc": "2.2.1",
+                "docusaurus-theme-redoc": "2.2.1"
             },
             "engines": {
                 "node": ">=14"
             },
             "peerDependencies": {
-                "@docusaurus/theme-common": "^3.0.0",
-                "@docusaurus/utils": "^3.0.0"
+                "@docusaurus/theme-common": "^3.6.0",
+                "@docusaurus/utils": "^3.6.0"
             }
         },
         "node_modules/reduce-configs": {
@@ -29436,9 +29088,9 @@
             "license": "MIT"
         },
         "node_modules/sass": {
-            "version": "1.83.1",
-            "resolved": "https://registry.npmjs.org/sass/-/sass-1.83.1.tgz",
-            "integrity": "sha512-EVJbDaEs4Rr3F0glJzFSOvtg2/oy2V/YrGFPqPY24UqcLDWcI9ZY5sN+qyO3c/QCZwzgfirvhXvINiJCE/OLcA==",
+            "version": "1.83.4",
+            "resolved": "https://registry.npmjs.org/sass/-/sass-1.83.4.tgz",
+            "integrity": "sha512-B1bozCeNQiOgDcLd33e2Cs2U60wZwjUUXzh900ZyQF5qUasvMdDZYbQ566LJu7cqR+sAHlAfO6RMkaID5s6qpA==",
             "license": "MIT",
             "dependencies": {
                 "chokidar": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,6 @@
     },
     "dependencies": {
         "@apify-packages/ui-library": "^0.28.1",
-        "@apify/docsearch-apify-docs": "3.5.3",
         "@docusaurus/core": "3.7.0",
         "@docusaurus/faster": "3.7.0",
         "@docusaurus/plugin-client-redirects": "3.7.0",


### PR DESCRIPTION
Pins dependencies used from the swizzled `SearchPage` component. The undeclared dependencies were causing the documentation build to fail in the dependent packages (e.g. [here](https://github.com/apify/apify-cli/actions/runs/12755096920/job/35550383965)).

Removes the unused `@apify/docsearch-apify-docs` package from the dependencies.