### PR TITLE
fix: remove trailing slash from internal URL

### DIFF
--- a/apify-docs-theme/src/config.js
+++ b/apify-docs-theme/src/config.js
@@ -227,7 +227,7 @@ const themeConfig = ({
                     },
                     {
                         label: 'Open source',
-                        href: `${absoluteUrl}/open-source/`, // we need a trailing slash here, we'd get redirected there anyway
+                        href: `${absoluteUrl}/open-source`,
                         position: 'left',
                         target: '_self',
                         rel: 'dofollow',


### PR DESCRIPTION
This fixes the lychee 404 errors.

https://github.com/apify/apify-docs/actions/runs/12799427833