### PR TITLE
feat(api): added openapi endpoints

### DIFF
--- a/apify-api/openapi/components/schemas/actor-builds/GetOpenApiResponse.yaml
+++ b/apify-api/openapi/components/schemas/actor-builds/GetOpenApiResponse.yaml
@@ -1,0 +1,348 @@
+title: GetOpenApiResponse
+type: object
+properties:
+  openapi:
+    type: string
+    example: 3.0.1
+  info:
+    type: object
+    properties:
+      title: 
+        type: string
+        example: Your Magic Actor
+      version: 
+        type: string
+        example: "1.0"
+      x-build-id: 
+        type: string
+        example: "ID of build"
+  servers:
+    type: array
+    items:
+      type: object
+      properties:
+        url: 
+          type: string
+          example: https://api.apify.com/v2
+  paths:
+    type: object
+    properties:
+      /acts/<username>~<actor>/run-sync-get-dataset-items:
+        type: object
+        properties:
+          post:
+            type: object
+            properties:
+              operationId:
+                type: string
+                example: run-sync-get-dataset-items
+              x-openai-isConsequential:
+                type: boolean
+                example: false
+              summary:
+                type: string
+                example: Executes an Actor, waits for its completion, and returns Actor's dataset items in response.
+              tags:
+                type: array
+                items:
+                  type: string
+                example: ["Run Actor"]
+              requestBody:
+                type: object
+                properties:
+                  required:
+                    type: boolean
+                    example: true
+                  content:
+                    type: object
+                    properties:
+                      application/json:
+                        type: object
+                        properties:
+                          schema:
+                            type: object
+                            properties:
+                              $ref:
+                                type: string
+                                example: '#/components/schemas/inputSchema'
+              parameters:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                      example: token
+                    in:
+                      type: string
+                      example: query
+                    required:
+                      type: boolean
+                      example: true
+                    schema:
+                      type: object
+                      properties:
+                        type:
+                          type: string
+                          example: string
+                    description:
+                      type: string
+                      example: Enter your Apify token here
+              responses:
+                type: object
+                properties:
+                  '200':
+                    type: object
+                    properties:
+                      description:
+                        type: string
+                        example: OK
+      /acts/<username>~<actor>/runs:
+        type: object
+        properties:
+          post:
+            type: object
+            properties:
+              operationId:
+                type: string
+                example: runs
+              x-openai-isConsequential:
+                type: boolean
+                example: false
+              summary:
+                type: string
+                example: Executes an Actor and returns information about the initiated run in response.
+              tags:
+                type: array
+                items:
+                  type: string
+                example: ["Run Actor"]
+              requestBody:
+                type: object
+                properties:
+                  required:
+                    type: boolean
+                    example: true
+                  content:
+                    type: object
+                    properties:
+                      application/json:
+                        type: object
+                        properties:
+                          schema:
+                            type: object
+                            properties:
+                              $ref:
+                                type: string
+                                example: '#/components/schemas/inputSchema'
+              parameters:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                    in:
+                      type: string
+                      example: query
+                    required:
+                      type: boolean
+                    schema:
+                      type: object
+                      properties:
+                        type:
+                          type: string
+                    description:
+                      type: string
+              responses:
+                type: object
+                properties:
+                  '200':
+                    type: object
+                    properties:
+                      description:
+                        type: string
+                        example: OK
+                      content:
+                        type: object
+                        properties:
+                          application/json:
+                            type: object
+                            properties:
+                              schema:
+                                type: object
+                                properties:
+                                  $ref:
+                                    type: string
+                                    example: '#/components/schemas/runsResponseSchema'
+      /acts/<username>~<actor>/run-sync:
+        type: object
+        properties:
+          post:
+            type: object
+            properties:
+              operationId:
+                type: string
+                example: run-sync
+              x-openai-isConsequential:
+                type: boolean
+                example: false
+              summary:
+                type: string
+                example: Executes an Actor, waits for completion, and returns the OUTPUT from Key-value store in response.
+              tags:
+                type: array
+                items:
+                  type: string
+                example: ["Run Actor"]
+              requestBody:
+                type: object
+                properties:
+                  required:
+                    type: boolean
+                    example: true
+                  content:
+                    type: object
+                    properties:
+                      application/json:
+                        type: object
+                        properties:
+                          schema:
+                            type: object
+                            properties:
+                              $ref:
+                                type: string
+                                example: '#/components/schemas/inputSchema'
+              parameters:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                    in:
+                      type: string
+                      example: query
+                    required:
+                      type: boolean
+                    schema:
+                      type: object
+                      properties:
+                        type:
+                          type: string
+                    description:
+                      type: string
+              responses:
+                type: object
+                properties:
+                  '200':
+                    type: object
+                    properties:
+                      description:
+                        type: string
+                        example: OK
+  components:
+    type: object
+    properties:
+      schemas:
+        type: object
+        properties:
+          inputSchema:
+            type: object
+            properties:
+              type:
+                type: string
+                example: object
+          runsResponseSchema:
+            type: object
+            properties:
+              type:
+                type: string
+                example: object
+              properties:
+                type: object
+                properties:
+                  data:
+                    type: object
+                    properties:
+                      type:
+                        type: string
+                        example: object
+                      properties:
+                        type: object
+                        properties:
+                          id:
+                            type: object
+                            properties:
+                              type:
+                                type: string
+                                example: string
+                          actId:
+                            type: object
+                            properties:
+                              type:
+                                type: string
+                                example: string
+                          userId:
+                            type: object
+                            properties:
+                              type:
+                                type: string
+                                example: string
+                          startedAt:
+                            type: object
+                            properties:
+                              type:
+                                type: string
+                                example: string
+                              format:
+                                type: string
+                                example: date-time
+                              example:
+                                type: string
+                                example: "2025-01-08T00:00:00.000Z"
+                          finishedAt:
+                            type: object
+                            properties:
+                              type:
+                                type: string
+                                example: string
+                              format:
+                                type: string
+                                example: date-time
+                              example:
+                                type: string
+                                example: "2025-01-08T00:00:00.000Z"
+                          status:
+                            type: object
+                            properties:
+                              type:
+                                type: string
+                                example: string
+                              example:
+                                type: string
+                                example: "READY"
+                          meta:
+                            type: object
+                            properties:
+                              type:
+                                type: string
+                                example: object
+                              properties:
+                                type: object
+                                properties:
+                                  origin:
+                                    type: object
+                                    properties:
+                                      type:
+                                        type: string
+                                        example: string
+                                      example:
+                                        type: string
+                                        example: "API"
+                                  userAgent:
+                                    type: object
+                                    properties:
+                                      type:
+                                        type: string
+                                        example: string

--- a/apify-api/openapi/components/tags.yaml
+++ b/apify-api/openapi/components/tags.yaml
@@ -251,6 +251,17 @@
     ```
 
     In order to save new items to the dataset, send HTTP POST request with JSON payload to the same URL.
+- name: Actors/Build OpenAPI specification
+  x-displayName: Build OpenAPI Specification
+  x-parent-tag-name: Actors
+  x-trait: 'true'
+  description: |
+    To obtain the OpenAPI schema for actor builds, two similar endpoints are available:
+
+    - [First Endpoint](/api/v2/act-openapi-specification-get): Requires both `actorId` and `buildId`. You can pass `default` instead of buildId to retrieve the OpenAPI schema for the default actor build.
+    - [Second Endpoint](/api/v2/actor-build-openapi-specification-get): Requires only `buildId`.
+  x-legacy-doc-urls:
+  - '#/reference/actors/openapi-specification'
 - name: Actor tasks
   x-displayName: Actor tasks
   x-legacy-doc-urls:
@@ -548,6 +559,17 @@
   - '#tag/Actor-buildsBuild-log'
   x-trait: 'true'
   description: Check out [Logs](#/reference/logs) for full reference.
+- name: Actor builds/Build OpenAPI specification
+  x-displayName: Build OpenAPI Specification
+  x-parent-tag-name: Actor builds
+  x-trait: 'true'
+  description: |
+    To obtain the OpenAPI schema for actor builds, two similar endpoints are available:
+
+    - [First Endpoint](/api/v2/act-openapi-specification-get): Requires both `actorId` and `buildId`. You can pass `default` instead of buildId to retrieve the OpenAPI schema for the default actor build.
+    - [Second Endpoint](/api/v2/actor-build-openapi-specification-get): Requires only `buildId`.
+  x-legacy-doc-urls:
+  - '#/reference/actor-builds/openapi-specification'
 - name: Key-value stores
   x-displayName: Key-value stores
   x-legacy-doc-urls:

--- a/apify-api/openapi/components/x-tag-groups.yaml
+++ b/apify-api/openapi/components/x-tag-groups.yaml
@@ -19,6 +19,7 @@
   - Actors/Metamorph run
   - Actors/Resurrect run
   - Actors/Last run object and its storages
+  - Actors/Build OpenAPI specification
 - name: Actor tasks
   tags:
   - Actor tasks
@@ -50,6 +51,7 @@
   - Actor builds/Delete build
   - Actor builds/Abort build
   - Actor builds/Build log
+  - Actor builds/Build OpenAPI specification
 - name: Key-value stores
   tags:
   - Key-value stores

--- a/apify-api/openapi/openapi.yaml
+++ b/apify-api/openapi/openapi.yaml
@@ -501,6 +501,8 @@ paths:
     $ref: 'paths/actors/acts@{actorId}@builds@{buildId}.yaml'
   '/v2/acts/{actorId}/builds/{buildId}/abort':
     $ref: 'paths/actors/acts@{actorId}@builds@{buildId}@abort.yaml'
+  '/v2/acts/{actorId}/builds/{buildId}/openapi-specification':
+    $ref: 'paths/actors/acts@{actorId}@builds@{buildId}@openapi-specification.yaml'
   '/v2/acts/{actorId}/runs':
     $ref: 'paths/actors/acts@{actorId}@runs.yaml'
   '/v2/acts/{actorId}/run-sync':
@@ -553,6 +555,8 @@ paths:
     $ref: 'paths/actor-builds/actor-builds@{buildId}@abort.yaml'
   '/v2/actor-builds/{buildId}/log':
     $ref: 'paths/actor-builds/actor-builds@{buildId}@log.yaml'
+  '/v2/actor-builds/{buildId}/openapi-specification':
+    $ref: 'paths/actor-builds/actor-builds@{buildId}@openapi-specification.yaml'
   /v2/key-value-stores:
     $ref: paths/key-value-stores/key-value-stores.yaml
   '/v2/key-value-stores/{storeId}':

--- a/apify-api/openapi/paths/actor-builds/actor-builds@{buildId}@openapi-specification.yaml
+++ b/apify-api/openapi/paths/actor-builds/actor-builds@{buildId}@openapi-specification.yaml
@@ -1,0 +1,31 @@
+get:
+  tags:
+    - Actor builds/Build OpenAPI specification
+  summary: Get OpenAPI specification
+  description: |
+
+    > **You can also use a [similar endpoint](/api/v2/act-openapi-specification-get)**
+    > from the `acts` namespace to retrieve the OpenAPI specification for a build.
+
+    This endpoint does not require the authentication token. Instead, calls are authenticated using a hard-to-guess ID of the build.
+  operationId: actorBuild_openapiSpecification_get
+  security:
+    - apiKeyActorBuilds: []
+    - httpBearerActorBuilds: []
+  parameters:
+    - name: buildId
+      in: path
+      description: 'ID of the build you want to get, found in the build''s `Info` tab.'
+      required: true
+      style: simple
+      schema:
+        type: string
+        example: soSkq9ekdmfOslopH
+  responses:
+    '200':
+      description: ''
+      headers: {}
+      content:
+        application/json:
+          schema:
+            $ref: "../../components/schemas/actor-builds/GetOpenApiResponse.yaml"

--- a/apify-api/openapi/paths/actors/acts@{actorId}@builds@{buildId}@openapi-specification.yaml
+++ b/apify-api/openapi/paths/actors/acts@{actorId}@builds@{buildId}@openapi-specification.yaml
@@ -1,0 +1,41 @@
+get:
+  tags:
+    - Actors/Build OpenAPI specification
+  summary: Get OpenAPI specification
+  description: |
+
+    > **You can also use a [similar endpoint](/api/v2/actor-build-openapi-specification-get)**
+    > from the `actor-builds` namespace to retrieve the OpenAPI specification for a build.
+
+    To fetch the default actor build, simply pass `default` in place of `buildId`.
+
+    This endpoint does not require the authentication token. Instead, calls are authenticated using a hard-to-guess ID of the build.
+  operationId: act_openapiSpecification_get
+  security:
+    - apiKeyActorBuilds: []
+    - httpBearerActorBuilds: []
+  parameters:
+    - name: actorId
+      in: path
+      description: Actor ID or a tilde-separated owner's username and Actor name.
+      required: true
+      style: simple
+      schema:
+        type: string
+        example: janedoe~my-actor
+    - name: buildId
+      in: path
+      description: 'ID of the build you want to get, found in the build''s `Info` tab. Pass `default` for default actor build.'
+      required: true
+      style: simple
+      schema:
+        type: string
+        example: soSkq9ekdmfOslopH
+  responses:
+    '200':
+      description: ''
+      headers: {}
+      content:
+        application/json:
+          schema:
+            $ref: "../../components/schemas/actor-builds/GetOpenApiResponse.yaml"


### PR DESCRIPTION
Recently, we introduced two new endpoints that return the OpenAPI specification:

- `/acts/<actorId>/builds/<buildId>/openapi-specification`
- `/actor-builds/<buildId>/openapi-specification`

**This PR updates the documentation to include these endpoints.**


@TC-MO Let me, please, know if you think we should add any additional information 🙏 
