### PR TITLE
feat: added default build endpoint

### DIFF
--- a/apify-api/openapi/components/tags.yaml
+++ b/apify-api/openapi/components/tags.yaml
@@ -127,6 +127,10 @@
   x-trait: 'true'
   description: '**[DEPRECATED]** API endpoints related to build of the actor were
     moved under new namespace [`actor-builds`](#/reference/actor-builds).'
+- name: Actors/Default build object
+  x-displayName: Default build object
+  x-parent-tag-name: Actor builds
+  x-trait: 'true'
 - name: Actors/Abort build
   x-displayName: Abort build
   x-parent-tag-name: Actors

--- a/apify-api/openapi/components/x-tag-groups.yaml
+++ b/apify-api/openapi/components/x-tag-groups.yaml
@@ -10,6 +10,7 @@
   - Actors/Webhook collection
   - Actors/Build collection
   - Actors/Build object
+  - Actors/Default build object
   - Actors/Abort build
   - Actors/Run collection
   - Actors/Run actor synchronously

--- a/apify-api/openapi/openapi.yaml
+++ b/apify-api/openapi/openapi.yaml
@@ -499,6 +499,8 @@ paths:
     $ref: 'paths/actors/acts@{actorId}@builds.yaml'
   '/v2/acts/{actorId}/builds/{buildId}':
     $ref: 'paths/actors/acts@{actorId}@builds@{buildId}.yaml'
+  '/v2/acts/{actorId}/builds/default':
+    $ref: 'paths/actors/acts@{actorId}@builds@default.yaml'
   '/v2/acts/{actorId}/builds/{buildId}/abort':
     $ref: 'paths/actors/acts@{actorId}@builds@{buildId}@abort.yaml'
   '/v2/acts/{actorId}/runs':

--- a/apify-api/openapi/paths/actors/acts@{actorId}@builds@default.yaml
+++ b/apify-api/openapi/paths/actors/acts@{actorId}@builds@default.yaml
@@ -44,7 +44,7 @@ get:
       content:
         application/json:
           schema:
-            $ref: "../../components/schemas/actor-builds/GetBuildResponse.yaml"
+            $ref: '../../components/schemas/actor-builds/GetBuildResponse.yaml'
           example:
             data:
               id: HG7ML7M8z78YcAPEB

--- a/apify-api/openapi/paths/actors/acts@{actorId}@builds@default.yaml
+++ b/apify-api/openapi/paths/actors/acts@{actorId}@builds@default.yaml
@@ -1,0 +1,75 @@
+get:
+  tags:
+    - Actors/Default build object
+  summary: Get default build
+  description: |
+    By passing the optional `waitForFinish` parameter the API endpoint will
+    synchronously wait for the build to finish.
+    This is useful to avoid periodic polling when waiting for an Actor build to
+    finish.
+
+    This endpoint does not require the authentication token. Instead, calls are authenticated using a hard-to-guess ID of the build. However,
+    if you access the endpoint without the token, certain attributes, such as `usageUsd` and `usageTotalUsd`, will be hidden.
+  operationId: act_build_default_get
+  security:
+    - apiKeyActorBuilds: []
+    - httpBearerActorBuilds: []
+  parameters:
+    - name: actorId
+      in: path
+      description: Actor ID or a tilde-separated owner's username and Actor name.
+      required: true
+      style: simple
+      schema:
+        type: string
+        example: janedoe~my-actor
+    - name: waitForFinish
+      in: query
+      description: |
+        The maximum number of seconds the server waits for the build to finish.
+        By default it is `0`, the maximum value is `60`. <!-- MAX_ACTOR_JOB_ASYNC_WAIT_SECS -->
+        If the build finishes in time then the returned build object will have a terminal status (e.g. `SUCCEEDED`),
+        otherwise it will have a transitional status (e.g. `RUNNING`).
+      style: form
+      explode: true
+      schema:
+        type: number
+        format: double
+        example: 60
+  responses:
+    '200':
+      description: ''
+      headers: {}
+      content:
+        application/json:
+          schema:
+            $ref: "../../components/schemas/actor-builds/GetBuildResponse.yaml"
+          example:
+            data:
+              id: HG7ML7M8z78YcAPEB
+              actId: janedoe~my-actor
+              userId: klmdEpoiojmdEMlk3
+              startedAt: '2019-11-30T07:34:24.202Z'
+              finishedAt: '2019-12-12T09:30:12.202Z'
+              status: SUCCEEDED
+              meta:
+                origin: WEB
+                clientIp: 172.234.12.34
+                userAgent: Mozilla/5.0 (iPad)
+              stats:
+                durationMillis: 1000
+                runTimeSecs: 45.718
+                computeUnits: 0.012699444444444444
+              options:
+                useCache: false
+                betaPackages: false
+                memoryMbytes: 1024
+                diskMbytes: 2048
+              usage:
+                ACTOR_COMPUTE_UNITS: 0.08
+              usageTotalUsd: 0.02
+              usageUsd:
+                ACTOR_COMPUTE_UNITS: 0.02
+              inputSchema: '{\n  \"title\": \"Schema for ... }'
+              readme: '# Magic Actor\nThis Actor is magic.'
+              buildNumber: 0.1.1

--- a/apify-api/openapi/paths/actors/acts@{actorId}@builds@default.yaml
+++ b/apify-api/openapi/paths/actors/acts@{actorId}@builds@default.yaml
@@ -3,13 +3,13 @@ get:
     - Actors/Default build object
   summary: Get default build
   description: |
-    By passing the optional `waitForFinish` parameter the API endpoint will
-    synchronously wait for the build to finish.
-    This is useful to avoid periodic polling when waiting for an Actor build to
-    finish.
+    Get the default build for an Actor. 
+    
+    Use the optional `waitForFinish` parameter to synchronously wait for the build to finish. 
+    This avoids the need for periodic polling when waiting for the build to complete.
 
-    This endpoint does not require the authentication token. Instead, calls are authenticated using a hard-to-guess ID of the build. However,
-    if you access the endpoint without the token, certain attributes, such as `usageUsd` and `usageTotalUsd`, will be hidden.
+    This endpoint does not require an authentication token. Instead, calls are authenticated using the build's unique ID.
+    However, if you access the endpoint without a token, certain attributes (e.g., `usageUsd` and `usageTotalUsd`) will be hidden.
   operationId: act_build_default_get
   security:
     - apiKeyActorBuilds: []
@@ -27,9 +27,10 @@ get:
       in: query
       description: |
         The maximum number of seconds the server waits for the build to finish.
-        By default it is `0`, the maximum value is `60`. <!-- MAX_ACTOR_JOB_ASYNC_WAIT_SECS -->
-        If the build finishes in time then the returned build object will have a terminal status (e.g. `SUCCEEDED`),
+        If the build finishes within this time, the returned build object will have a terminal status (e.g. `SUCCEEDED`),
         otherwise it will have a transitional status (e.g. `RUNNING`).
+        
+        By default it is `0`, the maximum value is `60`. <!-- MAX_ACTOR_JOB_ASYNC_WAIT_SECS -->
       style: form
       explode: true
       schema:


### PR DESCRIPTION
Recently we released endpoint to get default actor build:

`/v2/acts/:actorId/builds/default`

**This PR updates the documentation to include this endpoint.**

<img width="338" alt="Screenshot 2025-01-22 at 11 22 34" src="https://github.com/user-attachments/assets/2f55917a-6196-4d47-ba65-805699c0a385" />

We already had this endpoint:
`/v2/acts/:actorId/builds/:buildId`

I was considering just adding information, that instead of `buildId` `default` can be passed. But since this endpoint is deprecated it does not make sense to me.

@TC-MO  Let me know what do you think?

