### PR TITLE
fix: use correct `unist-util-visit-parents` imports

### DIFF
--- a/apify-docs-theme/src/markdown.js
+++ b/apify-docs-theme/src/markdown.js
@@ -1,7 +1,7 @@
 const remarkParse = require('remark-parse');
 const remarkStringify = require('remark-stringify');
 const { unified } = require('unified');
-const visitParents = require('unist-util-visit-parents');
+const { visitParents } = require('unist-util-visit-parents');
 
 /**
  * Updates the markdown content for better UX and compatibility with Docusaurus v3.


### PR DESCRIPTION
The recent `unist-util-visit-parents` renovate update broke the `changelogFromRoot` theme option (and therefore e.g. [Apify Python SDK changelog](https://docs.apify.com/sdk/python/docs/changelog)). Even though the `unist` package claims to be ESM-only, this fix seems to remedy the issues.