### PR TITLE
chore: add consoleUrl field to storages

### DIFF
--- a/apify-api/openapi/components/schemas/datasets/Dataset.yaml
+++ b/apify-api/openapi/components/schemas/datasets/Dataset.yaml
@@ -8,6 +8,7 @@ required:
   - accessedAt
   - itemCount
   - cleanItemCount
+  - consoleUrl
 type: object
 properties:
   id:
@@ -46,3 +47,6 @@ properties:
       type: string
     description: ''
     nullable: true
+  consoleUrl:
+    type: string
+    example: 'https://console.apify.com/storage/datasets/27TmTznX9YPeAYhkC'

--- a/apify-api/openapi/components/schemas/key-value-stores/KeyValueStore.yaml
+++ b/apify-api/openapi/components/schemas/key-value-stores/KeyValueStore.yaml
@@ -5,6 +5,7 @@ required:
   - createdAt
   - modifiedAt
   - accessedAt
+  - consoleUrl
 type: object
 properties:
   id:
@@ -38,5 +39,8 @@ properties:
     type: string
     nullable: true
     example: null
+  consoleUrl:
+    type: string
+    example: 'https://console.apify.com/storage/key-value-stores/27TmTznX9YPeAYhkC'  
   stats:
     $ref: ./KeyValueStoreStats.yaml

--- a/apify-api/openapi/components/schemas/request-queues/RequestQueue.yaml
+++ b/apify-api/openapi/components/schemas/request-queues/RequestQueue.yaml
@@ -9,6 +9,7 @@ required:
   - handledRequestCount
   - pendingRequestCount
   - hadMultipleClients
+  - consoleUrl
 type: object
 properties:
   id:
@@ -42,3 +43,6 @@ properties:
   hadMultipleClients:
     type: boolean
     example: true
+  consoleUrl:
+    type: string
+    example: 'https://api.apify.com/v2/request-queues/27TmTznX9YPeAYhkC'  


### PR DESCRIPTION
Recently, we added a new field, `consoleUrl`, to storage responses (GET, PUT, POST).

This PR updates the documentation to include the `consoleUrl` field in:
- Datasets
- Key-Value Stores
- Request Queues