### PR TITLE
docs: Fix ActorRunStats OpenAPI schema

### DIFF
--- a/apify-api/openapi/components/schemas/actor-runs/RunStats.yaml
+++ b/apify-api/openapi/components/schemas/actor-runs/RunStats.yaml
@@ -1,6 +1,5 @@
 title: RunStats
 required:
-  - inputBodyLen
   - restartCount
   - resurrectCount
   - computeUnits


### PR DESCRIPTION
The value can be omitted for runs started without input.