### PR TITLE
chore: Set up CODEOWNERS for openapi specs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,4 +8,4 @@
 /sources/academy/ @honzajavorek
 
 # OpenAPI spec
-/apify-api/ @netmilk @janbuchar
+/apify-api/ @netmilk @janbuchar @fnesveda

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,3 +6,6 @@
 
 # Academy
 /sources/academy/ @honzajavorek
+
+# OpenAPI spec
+/apify-api/ @netmilk @janbuchar


### PR DESCRIPTION
- this is so that @netmilk and somebody from Tooling team (I volunteer as tribute) know when something changes in the OpenAPI spec
- we should also add somebody from the platform team - @fnesveda, what do you think?
