### PR TITLE
fix: import `unified` plugins correctly in Node `>=22.12`

### DIFF
--- a/apify-docs-theme/src/markdown.js
+++ b/apify-docs-theme/src/markdown.js
@@ -1,5 +1,5 @@
-const remarkParse = require('remark-parse');
-const remarkStringify = require('remark-stringify');
+const remarkParse = require('remark-parse').default;
+const remarkStringify = require('remark-stringify').default;
 const { unified } = require('unified');
 const { visitParents, CONTINUE } = require('unist-util-visit-parents');
 


### PR DESCRIPTION
[Changes in `require` / `esm` implementation](https://github.com/nodejs/node/releases/tag/v22.12.0) in the recent Node 22 versions caused the changelog transformation to fail on Node >=22.12. 

This should fix the missing changelogs in all the dependent projects (`apify-sdk-python`, `client-js`, `client-python`).