### PR TITLE
chore: use `@apify/ui-components` package from NPM

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -25,8 +25,6 @@ jobs:
                     cache: 'npm'
                     cache-dependency-path: 'package-lock.json'
                     always-auth: 'true'
-                    registry-url: 'https://npm.pkg.github.com/'
-                    scope: '@apify-packages'
 
             -   name: Enable corepack
                 run: |

--- a/.github/workflows/lychee.yml
+++ b/.github/workflows/lychee.yml
@@ -18,8 +18,6 @@ jobs:
                     cache: 'npm'
                     cache-dependency-path: 'package-lock.json'
                     always-auth: 'true'
-                    registry-url: 'https://npm.pkg.github.com/'
-                    scope: '@apify-packages'
 
             -   name: Enable corepack
                 run: |

--- a/.github/workflows/openapi.yaml
+++ b/.github/workflows/openapi.yaml
@@ -20,8 +20,6 @@ jobs:
                     node-version: 22
                     cache: 'npm'
                     cache-dependency-path: 'package-lock.json'
-                    registry-url: 'https://npm.pkg.github.com/'
-                    scope: '@apify-packages'
 
             -   name: Enable corepack
                 run: |

--- a/.github/workflows/publish-theme.yaml
+++ b/.github/workflows/publish-theme.yaml
@@ -63,9 +63,7 @@ jobs:
                     git config --global user.email "noreply@apify.com"
 
                     echo "access=public" > ~/.npmrc
-                    echo "@apify-packages:registry=https://npm.pkg.github.com/" >> ~/.npmrc
                     echo "//registry.npmjs.org/:_authToken=${{ secrets.APIFY_SERVICE_ACCOUNT_NPM_TOKEN }}" >> ~/.npmrc
-                    echo "//npm.pkg.github.com/:_authToken=${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}" >> ~/.npmrc
 
             -   name: Bump the theme version
                 run: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -20,8 +20,6 @@ jobs:
                     cache: 'npm'
                     cache-dependency-path: 'package-lock.json'
                     always-auth: 'true'
-                    registry-url: 'https://npm.pkg.github.com/'
-                    scope: '@apify-packages'
 
             -   name: Enable corepack
                 run: |
@@ -58,8 +56,6 @@ jobs:
                     node-version: 22
                     cache: 'npm'
                     cache-dependency-path: 'package-lock.json'
-                    registry-url: 'https://npm.pkg.github.com/'
-                    scope: '@apify-packages'
 
             -   name: Enable corepack
                 run: |
@@ -93,8 +89,6 @@ jobs:
                     node-version: 22
                     cache: 'npm'
                     cache-dependency-path: 'package-lock.json'
-                    registry-url: 'https://npm.pkg.github.com/'
-                    scope: '@apify-packages'
 
             -   name: Enable corepack
                 run: |

--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,1 @@
-@apify-packages:registry=https://npm.pkg.github.com
 legacy-peer-deps=true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,18 +15,14 @@
 3. GitHub access
 
 ### Installation steps
+
 <!-- vale off -->
 1. Clone the repository
-2. Configure GitHub access:
-
-    ```bash
-    npm login --scope@apify-packages -registry=https://npm.pkg.github.com --auth-type=legacy
-    ```
-
-3. Run `npm install`
-4. Start development server: `npm start`
+2. Run `npm install`
+3. Start development server: `npm start`
 <!-- vale on -->
-This will be enough to work on Platform, Academy and, OpenAPI. If you want to work on entire documentation set you need to join them using nginx.
+
+This will be enough to work on Platform, Academy and OpenAPI. If you want to work on the entire documentation set, you need to join them using nginx.
 
 #### Join all repositories with nginx
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -273,13 +273,6 @@ module.exports = {
                     module: {
                         rules: [
                             {
-                                test: /@apify-packages\/ui-library\/.*/,
-                                resolve: {
-                                    fullySpecified: false,
-                                },
-                                loader: 'babel-loader',
-                            },
-                            {
                                 test: /apify-docs\/examples\//i,
                                 type: 'asset/source',
                             },

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
                 "apify-docs-theme"
             ],
             "dependencies": {
-                "@apify-packages/ui-library": "^0.28.1",
+                "@apify/ui-library": "^0.61.0",
                 "@docusaurus/core": "3.7.0",
                 "@docusaurus/faster": "3.7.0",
                 "@docusaurus/plugin-client-redirects": "3.7.0",
@@ -97,20 +97,23 @@
                 "react-dom": "*"
             }
         },
-        "apify-docs-theme/node_modules/babel-loader": {
-            "version": "10.0.0",
-            "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-10.0.0.tgz",
-            "integrity": "sha512-z8jt+EdS61AMw22nSfoNJAZ0vrtmhPRVi6ghL3rCeRZI8cdNYFiV5xeV3HbE7rlZZNmGH8BVccwWt8/ED0QOHA==",
+        "apify-docs-theme/node_modules/unified": {
+            "version": "11.0.5",
+            "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
+            "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
             "license": "MIT",
             "dependencies": {
-                "find-up": "^5.0.0"
+                "@types/unist": "^3.0.0",
+                "bail": "^2.0.0",
+                "devlop": "^1.0.0",
+                "extend": "^3.0.0",
+                "is-plain-obj": "^4.0.0",
+                "trough": "^2.0.0",
+                "vfile": "^6.0.0"
             },
-            "engines": {
-                "node": "^18.20.0 || ^20.10.0 || >=22.0.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.12.0",
-                "webpack": ">=5.61.0"
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
             }
         },
         "node_modules/@algolia/autocomplete-core": {
@@ -507,40 +510,11 @@
                 "url": "https://github.com/sponsors/philsturgeon"
             }
         },
-        "node_modules/@apify-packages/icons": {
-            "version": "0.33.0",
-            "resolved": "https://npm.pkg.github.com/download/@apify-packages/icons/0.33.0/ff61c9934a9d1867ed77f0345442051122adf8f7",
-            "integrity": "sha512-ztQFGVOCvIZTIVWRNnab2osRCofgh59o2TOsjHQnm2CSh4zgLIP3wJ1zOT0IIfnrKqpQJozeC+qL4VCk9MHzWQ==",
-            "license": "UNLICENSED",
-            "peerDependencies": {
-                "react": "17.x || 18.x"
-            }
-        },
-        "node_modules/@apify-packages/ui-library": {
-            "version": "0.28.3",
-            "resolved": "https://npm.pkg.github.com/download/@apify-packages/ui-library/0.28.3/9c25af1666b3fcb6f35029319fbff9dbc98edecc",
-            "integrity": "sha512-99Jp2oHD1M6CqC/zXhgRHwEePW98HN2lkk051gEFqB3ccgh1U8RVDhA+7Tllqx5cTH3uJL9ne8PMkmyBK0WjlQ==",
-            "license": "UNLICENSED",
-            "dependencies": {
-                "@apify-packages/icons": "^0.33.0",
-                "@floating-ui/react": "^0.26.2",
-                "clsx": "^2.0.0",
-                "dayjs": "1.11.9",
-                "history": "^5.3.0",
-                "lodash": "^4.17.21",
-                "query-string": "^8.1.0",
-                "react-markdown": "^8.0.5",
-                "react-syntax-highlighter": "^15.5.0",
-                "rehype-raw": "^6.1.1",
-                "remark-gfm": "^3.0.1",
-                "remark-toc": "8.0.1",
-                "slugify": "^1.6.6"
-            },
-            "peerDependencies": {
-                "react": "17.x || 18.x",
-                "react-dom": "17.x || 18.x",
-                "styled-components": "^5.3.3"
-            }
+        "node_modules/@apify/consts": {
+            "version": "2.38.0",
+            "resolved": "https://registry.npmjs.org/@apify/consts/-/consts-2.38.0.tgz",
+            "integrity": "sha512-pP/sNuW+6ekdBZHLBy1alyzrxzcSc4xEhVgHx8Rwoyc7Q8nAA6Oybi7ChZv3KLToPITYCpSoSmopDoqrajld0A==",
+            "license": "Apache-2.0"
         },
         "node_modules/@apify/docs-search-modal": {
             "version": "1.2.0",
@@ -704,12 +678,67 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/@apify/log": {
+            "version": "2.5.14",
+            "resolved": "https://registry.npmjs.org/@apify/log/-/log-2.5.14.tgz",
+            "integrity": "sha512-s5cjADcGiqSql6szGkM3EkdiHXPo9Ea6lGiXb3Gew2XxQKYMrOpX9ZEEIeQfQPW5nhKcUwxREkptfEsxES3MDQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@apify/consts": "^2.38.0",
+                "ansi-colors": "^4.1.1"
+            }
+        },
         "node_modules/@apify/tsconfig": {
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/@apify/tsconfig/-/tsconfig-0.1.0.tgz",
             "integrity": "sha512-ba9Y6AMocRucO3AVTb6GM2V+oy1wByNlCDzamK+IC+aqU3pCgJwSN87uNu6iEgu+uetsqYvVbXJYakwiQO1LGA==",
             "dev": true,
             "license": "Apache-2.0"
+        },
+        "node_modules/@apify/ui-icons": {
+            "version": "0.7.0",
+            "resolved": "https://registry.npmjs.org/@apify/ui-icons/-/ui-icons-0.7.0.tgz",
+            "integrity": "sha512-+DfLFUaOgDZ7nK2hib9ZvMUYsx7/3muvKF05bJ8gWcKDxK5/sxMK7ZLWXherqxllVjRnmw4/Lw+hGwjiLHHFbA==",
+            "hasInstallScript": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "clsx": "^2.0.0"
+            },
+            "peerDependencies": {
+                "react": "17.x || 18.x",
+                "react-dom": "17.x || 18.x"
+            }
+        },
+        "node_modules/@apify/ui-library": {
+            "version": "0.61.0",
+            "resolved": "https://registry.npmjs.org/@apify/ui-library/-/ui-library-0.61.0.tgz",
+            "integrity": "sha512-Ou5amCde3OQflWxqywlwKsF7xLT4MHU0l+bc/9jLHf14o+q9Q4bVf86ZzAO8GgxJoBpSmZHzlKJPM4oHxd0Xpw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@apify/log": "^2.5.11",
+                "@apify/ui-icons": "^0.7.0",
+                "@floating-ui/react": "^0.26.2",
+                "clsx": "^2.0.0",
+                "dayjs": "1.11.9",
+                "fast-average-color": "^9.4.0",
+                "history": "^5.3.0",
+                "lodash": "^4.17.21",
+                "query-string": "^8.1.0",
+                "react-markdown": "^8.0.5",
+                "react-syntax-highlighter": "^15.5.0",
+                "rehype-raw": "^6.1.1",
+                "rehype-sanitize": "^6.0.0",
+                "remark-gfm": "^3.0.1",
+                "remark-toc": "8.0.1",
+                "slugify": "^1.6.6",
+                "unified": "^10.0.0",
+                "unist-util-visit": "^5.0.0"
+            },
+            "peerDependencies": {
+                "react": "17.x || 18.x",
+                "react-dom": "17.x || 18.x",
+                "styled-components": "^5.3.3"
+            }
         },
         "node_modules/@babel/code-frame": {
             "version": "7.26.2",
@@ -3741,6 +3770,23 @@
                 }
             }
         },
+        "node_modules/@docusaurus/bundler/node_modules/babel-loader": {
+            "version": "9.2.1",
+            "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-9.2.1.tgz",
+            "integrity": "sha512-fqe8naHt46e0yIdkjUZYqddSXfej3AHajX+CSO5X7oy0EmPc6o5Xh+RClNoHjnieWz9AW4kZxW9yyFMhVB1QLA==",
+            "license": "MIT",
+            "dependencies": {
+                "find-cache-dir": "^4.0.0",
+                "schema-utils": "^4.0.0"
+            },
+            "engines": {
+                "node": ">= 14.15.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.12.0",
+                "webpack": ">=5"
+            }
+        },
         "node_modules/@docusaurus/core": {
             "version": "3.7.0",
             "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-3.7.0.tgz",
@@ -4291,6 +4337,25 @@
                 "remark-parse": "^11.0.0",
                 "remark-stringify": "^11.0.0",
                 "unified": "^11.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/@docusaurus/mdx-loader/node_modules/unified": {
+            "version": "11.0.5",
+            "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
+            "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/unist": "^3.0.0",
+                "bail": "^2.0.0",
+                "devlop": "^1.0.0",
+                "extend": "^3.0.0",
+                "is-plain-obj": "^4.0.0",
+                "trough": "^2.0.0",
+                "vfile": "^6.0.0"
             },
             "funding": {
                 "type": "opencollective",
@@ -4947,6 +5012,30 @@
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             }
         },
+        "node_modules/@eslint/config-array/node_modules/brace-expansion": {
+            "version": "1.1.11",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+            "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+            }
+        },
+        "node_modules/@eslint/config-array/node_modules/minimatch": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "brace-expansion": "^1.1.7"
+            },
+            "engines": {
+                "node": "*"
+            }
+        },
         "node_modules/@eslint/config-helpers": {
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.2.0.tgz",
@@ -5011,6 +5100,17 @@
                 "url": "https://github.com/sponsors/epoberezkin"
             }
         },
+        "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
+            "version": "1.1.11",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+            "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+            }
+        },
         "node_modules/@eslint/eslintrc/node_modules/globals": {
             "version": "14.0.0",
             "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
@@ -5030,6 +5130,19 @@
             "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/@eslint/eslintrc/node_modules/minimatch": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "brace-expansion": "^1.1.7"
+            },
+            "engines": {
+                "node": "*"
+            }
         },
         "node_modules/@eslint/js": {
             "version": "9.23.0",
@@ -5492,6 +5605,25 @@
                 "unist-util-position-from-estree": "^2.0.0",
                 "unist-util-stringify-position": "^4.0.0",
                 "unist-util-visit": "^5.0.0",
+                "vfile": "^6.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/@mdx-js/mdx/node_modules/unified": {
+            "version": "11.0.5",
+            "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
+            "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/unist": "^3.0.0",
+                "bail": "^2.0.0",
+                "devlop": "^1.0.0",
+                "extend": "^3.0.0",
+                "is-plain-obj": "^4.0.0",
+                "trough": "^2.0.0",
                 "vfile": "^6.0.0"
             },
             "funding": {
@@ -6281,9 +6413,9 @@
             }
         },
         "node_modules/@redocly/cli": {
-            "version": "1.34.0",
-            "resolved": "https://registry.npmjs.org/@redocly/cli/-/cli-1.34.0.tgz",
-            "integrity": "sha512-Kg/t9zMjZB5cyb0YQLa+gne5E5Rz6wZP/goug1+2qaR17UqeupidBzwqDdr3lszEK3q2A37g4+W7pvdBOkiGQA==",
+            "version": "1.34.1",
+            "resolved": "https://registry.npmjs.org/@redocly/cli/-/cli-1.34.1.tgz",
+            "integrity": "sha512-12aTw7A/0n+8T7yKM1E8qlFRFPZnm2i1me0sZ1WOAiGT4I2j4iUcCp+93B0nrjIs1ZdNmrT0TTrMYLhsMJYjaQ==",
             "license": "MIT",
             "dependencies": {
                 "@opentelemetry/api": "1.9.0",
@@ -6292,8 +6424,8 @@
                 "@opentelemetry/sdk-trace-node": "1.26.0",
                 "@opentelemetry/semantic-conventions": "1.27.0",
                 "@redocly/config": "^0.22.0",
-                "@redocly/openapi-core": "1.34.0",
-                "@redocly/respect-core": "1.34.0",
+                "@redocly/openapi-core": "1.34.1",
+                "@redocly/respect-core": "1.34.1",
                 "abort-controller": "^3.0.0",
                 "chokidar": "^3.5.1",
                 "colorette": "^1.2.0",
@@ -6329,9 +6461,9 @@
             "license": "MIT"
         },
         "node_modules/@redocly/openapi-core": {
-            "version": "1.34.0",
-            "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-1.34.0.tgz",
-            "integrity": "sha512-Ji00EiLQRXq0pJIz5pAjGF9MfQvQVsQehc6uIis6sqat8tG/zh25Zi64w6HVGEDgJEzUeq/CuUlD0emu3Hdaqw==",
+            "version": "1.34.1",
+            "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-1.34.1.tgz",
+            "integrity": "sha512-KI1QOGvDk6oREbTu0JORxZX1NBxraXUbXczv0LYDs9EPp06coq874hQORqSHGEUV/DX2A6gjv4Ax33g/LFJBww==",
             "license": "MIT",
             "dependencies": {
                 "@redocly/ajv": "^8.11.2",
@@ -6349,36 +6481,15 @@
                 "npm": ">=9.5.0"
             }
         },
-        "node_modules/@redocly/openapi-core/node_modules/brace-expansion": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-            "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-            "license": "MIT",
-            "dependencies": {
-                "balanced-match": "^1.0.0"
-            }
-        },
-        "node_modules/@redocly/openapi-core/node_modules/minimatch": {
-            "version": "5.1.6",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
-            "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
-            "license": "ISC",
-            "dependencies": {
-                "brace-expansion": "^2.0.1"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
         "node_modules/@redocly/respect-core": {
-            "version": "1.34.0",
-            "resolved": "https://registry.npmjs.org/@redocly/respect-core/-/respect-core-1.34.0.tgz",
-            "integrity": "sha512-CO2XxJ0SUYHKixKPTQm2U6QrGLnNhQy88CnX20llCxXDKd485cSioRMZ8MMNhHrnDsUlprSuM3ui2z5JGf1ftw==",
+            "version": "1.34.1",
+            "resolved": "https://registry.npmjs.org/@redocly/respect-core/-/respect-core-1.34.1.tgz",
+            "integrity": "sha512-Lzea25WqwxVK5+aCiq/pr7lUFdsZPYSqNzl05Z4jEtuP1DEIxJNG31ID75dZt30pPtyxjaa/dBuccruYlYflzw==",
             "license": "MIT",
             "dependencies": {
                 "@faker-js/faker": "^7.6.0",
                 "@redocly/ajv": "8.11.2",
-                "@redocly/openapi-core": "1.34.0",
+                "@redocly/openapi-core": "1.34.1",
                 "better-ajv-errors": "^1.2.0",
                 "colorette": "^2.0.20",
                 "concat-stream": "^2.0.0",
@@ -6976,14 +7087,14 @@
             }
         },
         "node_modules/@swc/core": {
-            "version": "1.11.13",
-            "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.11.13.tgz",
-            "integrity": "sha512-9BXdYz12Wl0zWmZ80PvtjBWeg2ncwJ9L5WJzjhN6yUTZWEV/AwAdVdJnIEp4pro3WyKmAaMxcVOSbhuuOZco5g==",
+            "version": "1.11.15",
+            "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.11.15.tgz",
+            "integrity": "sha512-SqXjJrwydXA2OVVAFv9EdCb2kkhEM2+b4ajereGzFSQuK2FN/SlKPklvFMh9sj1sG0tgXwyLGSMgyn3FUx83DA==",
             "hasInstallScript": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "@swc/counter": "^0.1.3",
-                "@swc/types": "^0.1.19"
+                "@swc/types": "^0.1.21"
             },
             "engines": {
                 "node": ">=10"
@@ -6993,16 +7104,16 @@
                 "url": "https://opencollective.com/swc"
             },
             "optionalDependencies": {
-                "@swc/core-darwin-arm64": "1.11.13",
-                "@swc/core-darwin-x64": "1.11.13",
-                "@swc/core-linux-arm-gnueabihf": "1.11.13",
-                "@swc/core-linux-arm64-gnu": "1.11.13",
-                "@swc/core-linux-arm64-musl": "1.11.13",
-                "@swc/core-linux-x64-gnu": "1.11.13",
-                "@swc/core-linux-x64-musl": "1.11.13",
-                "@swc/core-win32-arm64-msvc": "1.11.13",
-                "@swc/core-win32-ia32-msvc": "1.11.13",
-                "@swc/core-win32-x64-msvc": "1.11.13"
+                "@swc/core-darwin-arm64": "1.11.15",
+                "@swc/core-darwin-x64": "1.11.15",
+                "@swc/core-linux-arm-gnueabihf": "1.11.15",
+                "@swc/core-linux-arm64-gnu": "1.11.15",
+                "@swc/core-linux-arm64-musl": "1.11.15",
+                "@swc/core-linux-x64-gnu": "1.11.15",
+                "@swc/core-linux-x64-musl": "1.11.15",
+                "@swc/core-win32-arm64-msvc": "1.11.15",
+                "@swc/core-win32-ia32-msvc": "1.11.15",
+                "@swc/core-win32-x64-msvc": "1.11.15"
             },
             "peerDependencies": {
                 "@swc/helpers": "*"
@@ -7014,9 +7125,9 @@
             }
         },
         "node_modules/@swc/core-darwin-arm64": {
-            "version": "1.11.13",
-            "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.11.13.tgz",
-            "integrity": "sha512-loSERhLaQ9XDS+5Kdx8cLe2tM1G0HLit8MfehipAcsdctpo79zrRlkW34elOf3tQoVPKUItV0b/rTuhjj8NtHg==",
+            "version": "1.11.15",
+            "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.11.15.tgz",
+            "integrity": "sha512-mMoQy6TrYrvhrpi70eD01uu4WeB+Wy+9To5b95gHcyiAMRyd7afnFHo9OcPynk0Ep01PvReiB6hL2hYfNcDKvw==",
             "cpu": [
                 "arm64"
             ],
@@ -7030,9 +7141,9 @@
             }
         },
         "node_modules/@swc/core-darwin-x64": {
-            "version": "1.11.13",
-            "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.11.13.tgz",
-            "integrity": "sha512-uSA4UwgsDCIysUPfPS8OrQTH2h9spO7IYFd+1NB6dJlVGUuR6jLKuMBOP1IeLeax4cGHayvkcwSJ3OvxHwgcZQ==",
+            "version": "1.11.15",
+            "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.11.15.tgz",
+            "integrity": "sha512-yBWcP5v3OXq1Nxamqh1+qecty3TFRlxAMNXMBzq/Rv6Fu9eOAU6lTSfozO0BaOoETTzorlR2/3Jn+3amyviQMw==",
             "cpu": [
                 "x64"
             ],
@@ -7046,9 +7157,9 @@
             }
         },
         "node_modules/@swc/core-linux-arm-gnueabihf": {
-            "version": "1.11.13",
-            "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.11.13.tgz",
-            "integrity": "sha512-boVtyJzS8g30iQfe8Q46W5QE/cmhKRln/7NMz/5sBP/am2Lce9NL0d05NnFwEWJp1e2AMGHFOdRr3Xg1cDiPKw==",
+            "version": "1.11.15",
+            "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.11.15.tgz",
+            "integrity": "sha512-OprUQ0AvIiA2FCZqDYcnZ1nZhiCABqJPGgC9KwX8p8tC+t1mYkAeboik23S9gxzwGQImMNYYojGbNGTmLATLrA==",
             "cpu": [
                 "arm"
             ],
@@ -7062,9 +7173,9 @@
             }
         },
         "node_modules/@swc/core-linux-arm64-gnu": {
-            "version": "1.11.13",
-            "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.11.13.tgz",
-            "integrity": "sha512-+IK0jZ84zHUaKtwpV+T+wT0qIUBnK9v2xXD03vARubKF+eUqCsIvcVHXmLpFuap62dClMrhCiwW10X3RbXNlHw==",
+            "version": "1.11.15",
+            "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.11.15.tgz",
+            "integrity": "sha512-Uq3FjjKEw1CTtFpz7Mi+CC//4KQODQ8vXFx7J/cBO6nj+/Os9J1huyqa1LljlBTCeDXTpeC7qlqO6swZ0HPaJw==",
             "cpu": [
                 "arm64"
             ],
@@ -7078,9 +7189,9 @@
             }
         },
         "node_modules/@swc/core-linux-arm64-musl": {
-            "version": "1.11.13",
-            "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.11.13.tgz",
-            "integrity": "sha512-+ukuB8RHD5BHPCUjQwuLP98z+VRfu+NkKQVBcLJGgp0/+w7y0IkaxLY/aKmrAS5ofCNEGqKL+AOVyRpX1aw+XA==",
+            "version": "1.11.15",
+            "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.11.15.tgz",
+            "integrity": "sha512-G5orst6QzXyTXgOTnjrkYaLaK3emMXBWkQ7CDFyZNCGo6Fztn0vzYcCmr31Cvqs66BsM0sdGbcrBd5br8g/pJg==",
             "cpu": [
                 "arm64"
             ],
@@ -7094,9 +7205,9 @@
             }
         },
         "node_modules/@swc/core-linux-x64-gnu": {
-            "version": "1.11.13",
-            "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.11.13.tgz",
-            "integrity": "sha512-q9H3WI3U3dfJ34tdv60zc8oTuWvSd5fOxytyAO9Pc5M82Hic3jjWaf2xBekUg07ubnMZpyfnv+MlD+EbUI3Llw==",
+            "version": "1.11.15",
+            "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.11.15.tgz",
+            "integrity": "sha512-T0iR9yUcGyo1yLudL73jKbPS4AYo2iAWWH2I9u7QYiRTXPduwkH0nETNr+nsWBsYdMu+H2g169rCiGhhx6FPHw==",
             "cpu": [
                 "x64"
             ],
@@ -7110,9 +7221,9 @@
             }
         },
         "node_modules/@swc/core-linux-x64-musl": {
-            "version": "1.11.13",
-            "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.11.13.tgz",
-            "integrity": "sha512-9aaZnnq2pLdTbAzTSzy/q8dr7Woy3aYIcQISmw1+Q2/xHJg5y80ZzbWSWKYca/hKonDMjIbGR6dp299I5J0aeA==",
+            "version": "1.11.15",
+            "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.11.15.tgz",
+            "integrity": "sha512-2d8pHehwsHdQ71PRLeJ/XM69t5LCMzf1KZQDTVJTOSWRbuKGArtD+md5lVzTu458gt+JawdUgFdkdHtF7ke0AA==",
             "cpu": [
                 "x64"
             ],
@@ -7126,9 +7237,9 @@
             }
         },
         "node_modules/@swc/core-win32-arm64-msvc": {
-            "version": "1.11.13",
-            "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.11.13.tgz",
-            "integrity": "sha512-n3QZmDewkHANcoHvtwvA6yJbmS4XJf0MBMmwLZoKDZ2dOnC9D/jHiXw7JOohEuzYcpLoL5tgbqmjxa3XNo9Oow==",
+            "version": "1.11.15",
+            "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.11.15.tgz",
+            "integrity": "sha512-Vz5xg03VdYftMvruvziV1doU7B64rQ8rw72bKf2+yflt1gU7BlLk4DPu2IZlUc0Xk8lrVcEDiheXATbHexKsmw==",
             "cpu": [
                 "arm64"
             ],
@@ -7142,9 +7253,9 @@
             }
         },
         "node_modules/@swc/core-win32-ia32-msvc": {
-            "version": "1.11.13",
-            "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.11.13.tgz",
-            "integrity": "sha512-wM+Nt4lc6YSJFthCx3W2dz0EwFNf++j0/2TQ0Js9QLJuIxUQAgukhNDVCDdq8TNcT0zuA399ALYbvj5lfIqG6g==",
+            "version": "1.11.15",
+            "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.11.15.tgz",
+            "integrity": "sha512-R9jS92ubQgHQfyNVCMnuQfNPeBgAs3QaWC+DqPbhXtOyWUdSGcImbHMDCxShDj+nn8J7bPeb7L4sZqr6gBkZnQ==",
             "cpu": [
                 "ia32"
             ],
@@ -7158,9 +7269,9 @@
             }
         },
         "node_modules/@swc/core-win32-x64-msvc": {
-            "version": "1.11.13",
-            "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.11.13.tgz",
-            "integrity": "sha512-+X5/uW3s1L5gK7wAo0E27YaAoidJDo51dnfKSfU7gF3mlEUuWH8H1bAy5OTt2mU4eXtfsdUMEVXSwhDlLtQkuA==",
+            "version": "1.11.15",
+            "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.11.15.tgz",
+            "integrity": "sha512-UpSX492qVVTJQkRBYw3qC49ae4QRHwuC1cDgA47XBP0l31vjR83r3qEYue1Nn173etzGzbDJnygyLpqv/ieCCA==",
             "cpu": [
                 "x64"
             ],
@@ -7180,9 +7291,9 @@
             "license": "Apache-2.0"
         },
         "node_modules/@swc/html": {
-            "version": "1.11.13",
-            "resolved": "https://registry.npmjs.org/@swc/html/-/html-1.11.13.tgz",
-            "integrity": "sha512-LHfnHudI9faOMO+TtDqiJT2acFsb994flQml8NJ1gAwSZHHd1l5K2lmgOT/YZGQSuwmZ0Wzfw3kKIpJQ0PK1xA==",
+            "version": "1.11.15",
+            "resolved": "https://registry.npmjs.org/@swc/html/-/html-1.11.15.tgz",
+            "integrity": "sha512-ioOt+3eaKf39hGjMXc3vg+JMZImB2ZenHiKiGkF4Y6h19iIGqtxw+/qKrm+eKfsBFEhsebYIJnuHN+UlBS5CFA==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@swc/counter": "^0.1.3"
@@ -7191,22 +7302,22 @@
                 "node": ">=14"
             },
             "optionalDependencies": {
-                "@swc/html-darwin-arm64": "1.11.13",
-                "@swc/html-darwin-x64": "1.11.13",
-                "@swc/html-linux-arm-gnueabihf": "1.11.13",
-                "@swc/html-linux-arm64-gnu": "1.11.13",
-                "@swc/html-linux-arm64-musl": "1.11.13",
-                "@swc/html-linux-x64-gnu": "1.11.13",
-                "@swc/html-linux-x64-musl": "1.11.13",
-                "@swc/html-win32-arm64-msvc": "1.11.13",
-                "@swc/html-win32-ia32-msvc": "1.11.13",
-                "@swc/html-win32-x64-msvc": "1.11.13"
+                "@swc/html-darwin-arm64": "1.11.15",
+                "@swc/html-darwin-x64": "1.11.15",
+                "@swc/html-linux-arm-gnueabihf": "1.11.15",
+                "@swc/html-linux-arm64-gnu": "1.11.15",
+                "@swc/html-linux-arm64-musl": "1.11.15",
+                "@swc/html-linux-x64-gnu": "1.11.15",
+                "@swc/html-linux-x64-musl": "1.11.15",
+                "@swc/html-win32-arm64-msvc": "1.11.15",
+                "@swc/html-win32-ia32-msvc": "1.11.15",
+                "@swc/html-win32-x64-msvc": "1.11.15"
             }
         },
         "node_modules/@swc/html-darwin-arm64": {
-            "version": "1.11.13",
-            "resolved": "https://registry.npmjs.org/@swc/html-darwin-arm64/-/html-darwin-arm64-1.11.13.tgz",
-            "integrity": "sha512-lSUDurzYr53qbojckF0T3V0PR8fLaqIq/0u5Stw+OEiV+5G7sfn+3fQzMR3jvrJW2DbwymPI0mPYDNw0xiniTw==",
+            "version": "1.11.15",
+            "resolved": "https://registry.npmjs.org/@swc/html-darwin-arm64/-/html-darwin-arm64-1.11.15.tgz",
+            "integrity": "sha512-yn4cRc/odibIkbvKWdVEzW6SB4nZAb+sHQFqGDyGtj1iR9Yl4rr+oSKRbUg6O3IAYxZ7Eeq6SlkD09Iuci5IkA==",
             "cpu": [
                 "arm64"
             ],
@@ -7220,9 +7331,9 @@
             }
         },
         "node_modules/@swc/html-darwin-x64": {
-            "version": "1.11.13",
-            "resolved": "https://registry.npmjs.org/@swc/html-darwin-x64/-/html-darwin-x64-1.11.13.tgz",
-            "integrity": "sha512-mw6AdPht8TJ93wkmG3d2tAD5vlNZ4X5KT+S7IQT3tz8QcaDe97TvKZWd/FBhuAdwyuNWJFFDMbgzCaqn41JHCw==",
+            "version": "1.11.15",
+            "resolved": "https://registry.npmjs.org/@swc/html-darwin-x64/-/html-darwin-x64-1.11.15.tgz",
+            "integrity": "sha512-JKxoeHMR5Wl40dDVyFTMlQU8wY8hNZbiH+FYmfA8pnmaOrHEPVLxzzeiSZa2u8X2JSZr4AHI072UzMHKxFmaEg==",
             "cpu": [
                 "x64"
             ],
@@ -7236,9 +7347,9 @@
             }
         },
         "node_modules/@swc/html-linux-arm-gnueabihf": {
-            "version": "1.11.13",
-            "resolved": "https://registry.npmjs.org/@swc/html-linux-arm-gnueabihf/-/html-linux-arm-gnueabihf-1.11.13.tgz",
-            "integrity": "sha512-rQweCcJTb8x+UOYNAYoWGANJPx++hOf7tzyaHQKOrH4Ydh/lWpmU9qHo6x6j6YF5u5OOeEj8poo8pTPs94rnVw==",
+            "version": "1.11.15",
+            "resolved": "https://registry.npmjs.org/@swc/html-linux-arm-gnueabihf/-/html-linux-arm-gnueabihf-1.11.15.tgz",
+            "integrity": "sha512-XIcD1l5U5FF5VyrgujyNU4PO3jR/yLxXasMbNFflOuNbeMn83XM5qJ2BVmdWqN5C4lZBjDHNNUuQIIqreIhRwg==",
             "cpu": [
                 "arm"
             ],
@@ -7252,9 +7363,9 @@
             }
         },
         "node_modules/@swc/html-linux-arm64-gnu": {
-            "version": "1.11.13",
-            "resolved": "https://registry.npmjs.org/@swc/html-linux-arm64-gnu/-/html-linux-arm64-gnu-1.11.13.tgz",
-            "integrity": "sha512-p51hj6GMJCCyV1oDK+L6Upd9t9rea0J+dp4zfAP2xO4YE1fwn72GY44CS53Ww79smrJfmUDrN2PJDMlffqNIOw==",
+            "version": "1.11.15",
+            "resolved": "https://registry.npmjs.org/@swc/html-linux-arm64-gnu/-/html-linux-arm64-gnu-1.11.15.tgz",
+            "integrity": "sha512-3kUzdN38tGkMubfw/5B1+aOvP4WjTpKKOV7EP+t0auls1sQdDARg0VuKbpwBsjTzlIyPLb8q/5BL5nLijI9pOQ==",
             "cpu": [
                 "arm64"
             ],
@@ -7268,9 +7379,9 @@
             }
         },
         "node_modules/@swc/html-linux-arm64-musl": {
-            "version": "1.11.13",
-            "resolved": "https://registry.npmjs.org/@swc/html-linux-arm64-musl/-/html-linux-arm64-musl-1.11.13.tgz",
-            "integrity": "sha512-W3IfNK27gFY7Nm0PCDF5SLzAgskjT+18G+1gIJPTmTaaurvrjhkF3lhKUIVM73RFnOLIQyR9ZinzVCqBbT6TpA==",
+            "version": "1.11.15",
+            "resolved": "https://registry.npmjs.org/@swc/html-linux-arm64-musl/-/html-linux-arm64-musl-1.11.15.tgz",
+            "integrity": "sha512-vy+bA7RBI6cfUXbAtdPWrxrhjO4M6yBeoJ2eOJ/W057/ZA4HE5IfPq+/xzuG9FkYumf7gmNKb1PJQY6CzBK3OA==",
             "cpu": [
                 "arm64"
             ],
@@ -7284,9 +7395,9 @@
             }
         },
         "node_modules/@swc/html-linux-x64-gnu": {
-            "version": "1.11.13",
-            "resolved": "https://registry.npmjs.org/@swc/html-linux-x64-gnu/-/html-linux-x64-gnu-1.11.13.tgz",
-            "integrity": "sha512-CRWcqxsZT7fEwrz3kYf0OQSCf79MP9rOG/+JhUq8YKvh5VYfGFjnhlcqqE757k+GHeSIFYBbBmhr8AQ5ZbbkMw==",
+            "version": "1.11.15",
+            "resolved": "https://registry.npmjs.org/@swc/html-linux-x64-gnu/-/html-linux-x64-gnu-1.11.15.tgz",
+            "integrity": "sha512-8csOri424hppNbI97EH9y6UEe7zB0qJYTm7z4qjhJi7ICb0gyYlhKvSeSiLP3i4F1xkzkr/mr39JNu7V0F/q7g==",
             "cpu": [
                 "x64"
             ],
@@ -7300,9 +7411,9 @@
             }
         },
         "node_modules/@swc/html-linux-x64-musl": {
-            "version": "1.11.13",
-            "resolved": "https://registry.npmjs.org/@swc/html-linux-x64-musl/-/html-linux-x64-musl-1.11.13.tgz",
-            "integrity": "sha512-i96M1eUn1zrlhN0cpLlgnlpsuuQS1soHyf8cdvLnn+GRpHcG2rFNaFmBeGoTdFdblcfpPUFK2zpsgl9sVpxW7Q==",
+            "version": "1.11.15",
+            "resolved": "https://registry.npmjs.org/@swc/html-linux-x64-musl/-/html-linux-x64-musl-1.11.15.tgz",
+            "integrity": "sha512-t3FV8t2vZ2SVz3TXu65gtQyoaN4hIy0QOBMgL5YDNAr0jJrEwBhIah05UuoZ1FoLTecIzWYOR9c9V18/obAcEg==",
             "cpu": [
                 "x64"
             ],
@@ -7316,9 +7427,9 @@
             }
         },
         "node_modules/@swc/html-win32-arm64-msvc": {
-            "version": "1.11.13",
-            "resolved": "https://registry.npmjs.org/@swc/html-win32-arm64-msvc/-/html-win32-arm64-msvc-1.11.13.tgz",
-            "integrity": "sha512-yO0ua2dfJZkWEuzieAH++CW3TPm9SPj7y0qKw78ApKXNXOAlyoGRlVRdiej0d16UcfiNdElQsCJYUZ5+mw7PGg==",
+            "version": "1.11.15",
+            "resolved": "https://registry.npmjs.org/@swc/html-win32-arm64-msvc/-/html-win32-arm64-msvc-1.11.15.tgz",
+            "integrity": "sha512-GQt26/2M5y8PKLE3HhGjgagp1CGRyp29k4FE7qEPZT+mw4abW2kw2077drehNRlQvtxZCYpuUVZSf7WneiIV9g==",
             "cpu": [
                 "arm64"
             ],
@@ -7332,9 +7443,9 @@
             }
         },
         "node_modules/@swc/html-win32-ia32-msvc": {
-            "version": "1.11.13",
-            "resolved": "https://registry.npmjs.org/@swc/html-win32-ia32-msvc/-/html-win32-ia32-msvc-1.11.13.tgz",
-            "integrity": "sha512-ZmpmAPigeqVeO1WSp0+GvGfwRwm7mvSy4cg0n51pUpiZXCo8GHa7UJGtMJi9CfelPi9XtV067zyu+KDDkFgOuA==",
+            "version": "1.11.15",
+            "resolved": "https://registry.npmjs.org/@swc/html-win32-ia32-msvc/-/html-win32-ia32-msvc-1.11.15.tgz",
+            "integrity": "sha512-XX53X25892KawkHFSyxmu80nd6yr1BkU8Tkp7lkie8EWa1k7wDbWAMnittiDLj3vAjD4NPL6BDYu8BzapJDZFA==",
             "cpu": [
                 "ia32"
             ],
@@ -7348,9 +7459,9 @@
             }
         },
         "node_modules/@swc/html-win32-x64-msvc": {
-            "version": "1.11.13",
-            "resolved": "https://registry.npmjs.org/@swc/html-win32-x64-msvc/-/html-win32-x64-msvc-1.11.13.tgz",
-            "integrity": "sha512-emi6vzEahNvmshHU+fMuRGJ+xBdMP0iUx/7xoxV3cHSwAvvk9k9HSY9iTnMU0aZOvBg/YrVdtyZRETOwPkWFlg==",
+            "version": "1.11.15",
+            "resolved": "https://registry.npmjs.org/@swc/html-win32-x64-msvc/-/html-win32-x64-msvc-1.11.15.tgz",
+            "integrity": "sha512-H55qWdbnOezvJoQ6BLPs87F9V4QY5aU4zCYvvEdL3OdqmzXyW4epe2go5lghwdV3/UQEpHx0V6qDeeGx8JnXXg==",
             "cpu": [
                 "x64"
             ],
@@ -7374,9 +7485,9 @@
             }
         },
         "node_modules/@swc/types": {
-            "version": "0.1.20",
-            "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.20.tgz",
-            "integrity": "sha512-/rlIpxwKrhz4BIplXf6nsEHtqlhzuNN34/k3kMAXH4/lvVoA3cdq+60aqVNnyvw2uITEaCi0WV3pxBe4dQqoXQ==",
+            "version": "0.1.21",
+            "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.21.tgz",
+            "integrity": "sha512-2YEtj5HJVbKivud9N4bpPBAyZhj4S2Ipe5LkUG94alTpr7in/GU/EARgPAd3BwU+YOmFVJC2+kjqhGRi3r0ZpQ==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@swc/counter": "^0.1.3"
@@ -7922,9 +8033,9 @@
             "license": "MIT"
         },
         "node_modules/@types/node": {
-            "version": "22.13.14",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.14.tgz",
-            "integrity": "sha512-Zs/Ollc1SJ8nKUAgc7ivOEdIBM8JAKgrqqUYi2J997JuKO7/tpQC+WCetQ1sypiKCQWHdvdg9wBNpUPEWZae7w==",
+            "version": "22.13.16",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.16.tgz",
+            "integrity": "sha512-15tM+qA4Ypml/N7kyRdvfRjBQT2RL461uF1Bldn06K0Nzn1lY3nAPgHlsVrJxdZ9WhZiW0Fmc1lOYMtDsAuB3w==",
             "license": "MIT",
             "dependencies": {
                 "undici-types": "~6.20.0"
@@ -8102,9 +8213,9 @@
             "license": "MIT"
         },
         "node_modules/@types/ws": {
-            "version": "8.18.0",
-            "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.0.tgz",
-            "integrity": "sha512-8svvI3hMyvN0kKCJMvTJP/x6Y/EoQbepff882wL+Sn5QsXb3etnamgrJq4isrBxSJj5L2AuXcI0+bgkoAXGUJw==",
+            "version": "8.18.1",
+            "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+            "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
             "license": "MIT",
             "dependencies": {
                 "@types/node": "*"
@@ -8126,17 +8237,17 @@
             "license": "MIT"
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
-            "version": "8.28.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.28.0.tgz",
-            "integrity": "sha512-lvFK3TCGAHsItNdWZ/1FkvpzCxTHUVuFrdnOGLMa0GGCFIbCgQWVk3CzCGdA7kM3qGVc+dfW9tr0Z/sHnGDFyg==",
+            "version": "8.29.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.29.0.tgz",
+            "integrity": "sha512-PAIpk/U7NIS6H7TEtN45SPGLQaHNgB7wSjsQV/8+KYokAb2T/gloOA/Bee2yd4/yKVhPKe5LlaUGhAZk5zmSaQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/regexpp": "^4.10.0",
-                "@typescript-eslint/scope-manager": "8.28.0",
-                "@typescript-eslint/type-utils": "8.28.0",
-                "@typescript-eslint/utils": "8.28.0",
-                "@typescript-eslint/visitor-keys": "8.28.0",
+                "@typescript-eslint/scope-manager": "8.29.0",
+                "@typescript-eslint/type-utils": "8.29.0",
+                "@typescript-eslint/utils": "8.29.0",
+                "@typescript-eslint/visitor-keys": "8.29.0",
                 "graphemer": "^1.4.0",
                 "ignore": "^5.3.1",
                 "natural-compare": "^1.4.0",
@@ -8156,16 +8267,16 @@
             }
         },
         "node_modules/@typescript-eslint/parser": {
-            "version": "8.28.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.28.0.tgz",
-            "integrity": "sha512-LPcw1yHD3ToaDEoljFEfQ9j2xShY367h7FZ1sq5NJT9I3yj4LHer1Xd1yRSOdYy9BpsrxU7R+eoDokChYM53lQ==",
+            "version": "8.29.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.29.0.tgz",
+            "integrity": "sha512-8C0+jlNJOwQso2GapCVWWfW/rzaq7Lbme+vGUFKE31djwNncIpgXD7Cd4weEsDdkoZDjH0lwwr3QDQFuyrMg9g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/scope-manager": "8.28.0",
-                "@typescript-eslint/types": "8.28.0",
-                "@typescript-eslint/typescript-estree": "8.28.0",
-                "@typescript-eslint/visitor-keys": "8.28.0",
+                "@typescript-eslint/scope-manager": "8.29.0",
+                "@typescript-eslint/types": "8.29.0",
+                "@typescript-eslint/typescript-estree": "8.29.0",
+                "@typescript-eslint/visitor-keys": "8.29.0",
                 "debug": "^4.3.4"
             },
             "engines": {
@@ -8181,14 +8292,14 @@
             }
         },
         "node_modules/@typescript-eslint/scope-manager": {
-            "version": "8.28.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.28.0.tgz",
-            "integrity": "sha512-u2oITX3BJwzWCapoZ/pXw6BCOl8rJP4Ij/3wPoGvY8XwvXflOzd1kLrDUUUAIEdJSFh+ASwdTHqtan9xSg8buw==",
+            "version": "8.29.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.29.0.tgz",
+            "integrity": "sha512-aO1PVsq7Gm+tcghabUpzEnVSFMCU4/nYIgC2GOatJcllvWfnhrgW0ZEbnTxm36QsikmCN1K/6ZgM7fok2I7xNw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.28.0",
-                "@typescript-eslint/visitor-keys": "8.28.0"
+                "@typescript-eslint/types": "8.29.0",
+                "@typescript-eslint/visitor-keys": "8.29.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -8199,14 +8310,14 @@
             }
         },
         "node_modules/@typescript-eslint/type-utils": {
-            "version": "8.28.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.28.0.tgz",
-            "integrity": "sha512-oRoXu2v0Rsy/VoOGhtWrOKDiIehvI+YNrDk5Oqj40Mwm0Yt01FC/Q7nFqg088d3yAsR1ZcZFVfPCTTFCe/KPwg==",
+            "version": "8.29.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.29.0.tgz",
+            "integrity": "sha512-ahaWQ42JAOx+NKEf5++WC/ua17q5l+j1GFrbbpVKzFL/tKVc0aYY8rVSYUpUvt2hUP1YBr7mwXzx+E/DfUWI9Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/typescript-estree": "8.28.0",
-                "@typescript-eslint/utils": "8.28.0",
+                "@typescript-eslint/typescript-estree": "8.29.0",
+                "@typescript-eslint/utils": "8.29.0",
                 "debug": "^4.3.4",
                 "ts-api-utils": "^2.0.1"
             },
@@ -8223,9 +8334,9 @@
             }
         },
         "node_modules/@typescript-eslint/types": {
-            "version": "8.28.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.28.0.tgz",
-            "integrity": "sha512-bn4WS1bkKEjx7HqiwG2JNB3YJdC1q6Ue7GyGlwPHyt0TnVq6TtD/hiOdTZt71sq0s7UzqBFXD8t8o2e63tXgwA==",
+            "version": "8.29.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.29.0.tgz",
+            "integrity": "sha512-wcJL/+cOXV+RE3gjCyl/V2G877+2faqvlgtso/ZRbTCnZazh0gXhe+7gbAnfubzN2bNsBtZjDvlh7ero8uIbzg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -8237,14 +8348,14 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree": {
-            "version": "8.28.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.28.0.tgz",
-            "integrity": "sha512-H74nHEeBGeklctAVUvmDkxB1mk+PAZ9FiOMPFncdqeRBXxk1lWSYraHw8V12b7aa6Sg9HOBNbGdSHobBPuQSuA==",
+            "version": "8.29.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.29.0.tgz",
+            "integrity": "sha512-yOfen3jE9ISZR/hHpU/bmNvTtBW1NjRbkSFdZOksL1N+ybPEE7UVGMwqvS6CP022Rp00Sb0tdiIkhSCe6NI8ow==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.28.0",
-                "@typescript-eslint/visitor-keys": "8.28.0",
+                "@typescript-eslint/types": "8.29.0",
+                "@typescript-eslint/visitor-keys": "8.29.0",
                 "debug": "^4.3.4",
                 "fast-glob": "^3.3.2",
                 "is-glob": "^4.0.3",
@@ -8261,16 +8372,6 @@
             },
             "peerDependencies": {
                 "typescript": ">=4.8.4 <5.9.0"
-            }
-        },
-        "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-            "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "balanced-match": "^1.0.0"
             }
         },
         "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
@@ -8290,16 +8391,16 @@
             }
         },
         "node_modules/@typescript-eslint/utils": {
-            "version": "8.28.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.28.0.tgz",
-            "integrity": "sha512-OELa9hbTYciYITqgurT1u/SzpQVtDLmQMFzy/N8pQE+tefOyCWT79jHsav294aTqV1q1u+VzqDGbuujvRYaeSQ==",
+            "version": "8.29.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.29.0.tgz",
+            "integrity": "sha512-gX/A0Mz9Bskm8avSWFcK0gP7cZpbY4AIo6B0hWYFCaIsz750oaiWR4Jr2CI+PQhfW1CpcQr9OlfPS+kMFegjXA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.4.0",
-                "@typescript-eslint/scope-manager": "8.28.0",
-                "@typescript-eslint/types": "8.28.0",
-                "@typescript-eslint/typescript-estree": "8.28.0"
+                "@typescript-eslint/scope-manager": "8.29.0",
+                "@typescript-eslint/types": "8.29.0",
+                "@typescript-eslint/typescript-estree": "8.29.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -8314,13 +8415,13 @@
             }
         },
         "node_modules/@typescript-eslint/visitor-keys": {
-            "version": "8.28.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.28.0.tgz",
-            "integrity": "sha512-hbn8SZ8w4u2pRwgQ1GlUrPKE+t2XvcCW5tTRF7j6SMYIuYG37XuzIW44JCZPa36evi0Oy2SnM664BlIaAuQcvg==",
+            "version": "8.29.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.29.0.tgz",
+            "integrity": "sha512-Sne/pVz8ryR03NFK21VpN88dZ2FdQXOlq3VIklbrTYEt8yXtRFr9tvUhqvCeKjqYk5FSim37sHbooT6vzBTZcg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.28.0",
+                "@typescript-eslint/types": "8.29.0",
                 "eslint-visitor-keys": "^4.2.0"
             },
             "engines": {
@@ -8733,6 +8834,15 @@
                 "node": ">=8"
             }
         },
+        "node_modules/ansi-colors": {
+            "version": "4.1.3",
+            "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
+            "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
         "node_modules/ansi-escapes": {
             "version": "4.3.2",
             "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
@@ -9105,20 +9215,19 @@
             }
         },
         "node_modules/babel-loader": {
-            "version": "9.2.1",
-            "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-9.2.1.tgz",
-            "integrity": "sha512-fqe8naHt46e0yIdkjUZYqddSXfej3AHajX+CSO5X7oy0EmPc6o5Xh+RClNoHjnieWz9AW4kZxW9yyFMhVB1QLA==",
+            "version": "10.0.0",
+            "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-10.0.0.tgz",
+            "integrity": "sha512-z8jt+EdS61AMw22nSfoNJAZ0vrtmhPRVi6ghL3rCeRZI8cdNYFiV5xeV3HbE7rlZZNmGH8BVccwWt8/ED0QOHA==",
             "license": "MIT",
             "dependencies": {
-                "find-cache-dir": "^4.0.0",
-                "schema-utils": "^4.0.0"
+                "find-up": "^5.0.0"
             },
             "engines": {
-                "node": ">= 14.15.0"
+                "node": "^18.20.0 || ^20.10.0 || >=22.0.0"
             },
             "peerDependencies": {
                 "@babel/core": "^7.12.0",
-                "webpack": ">=5"
+                "webpack": ">=5.61.0"
             }
         },
         "node_modules/babel-plugin-dynamic-import-node": {
@@ -9391,13 +9500,12 @@
             }
         },
         "node_modules/brace-expansion": {
-            "version": "1.1.11",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-            "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+            "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
             "license": "MIT",
             "dependencies": {
-                "balanced-match": "^1.0.0",
-                "concat-map": "0.0.1"
+                "balanced-match": "^1.0.0"
             }
         },
         "node_modules/braces": {
@@ -12038,15 +12146,6 @@
                 "npm": ">=7.0.0"
             }
         },
-        "node_modules/docusaurus-plugin-redoc/node_modules/brace-expansion": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-            "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-            "license": "MIT",
-            "dependencies": {
-                "balanced-match": "^1.0.0"
-            }
-        },
         "node_modules/docusaurus-plugin-redoc/node_modules/marked": {
             "version": "4.3.0",
             "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
@@ -12057,18 +12156,6 @@
             },
             "engines": {
                 "node": ">= 12"
-            }
-        },
-        "node_modules/docusaurus-plugin-redoc/node_modules/minimatch": {
-            "version": "5.1.6",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
-            "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
-            "license": "ISC",
-            "dependencies": {
-                "brace-expansion": "^2.0.1"
-            },
-            "engines": {
-                "node": ">=10"
             }
         },
         "node_modules/docusaurus-plugin-redoc/node_modules/redoc": {
@@ -12227,15 +12314,6 @@
                 "npm": ">=7.0.0"
             }
         },
-        "node_modules/docusaurus-theme-redoc/node_modules/brace-expansion": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-            "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-            "license": "MIT",
-            "dependencies": {
-                "balanced-match": "^1.0.0"
-            }
-        },
         "node_modules/docusaurus-theme-redoc/node_modules/clsx": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
@@ -12255,18 +12333,6 @@
             },
             "engines": {
                 "node": ">= 12"
-            }
-        },
-        "node_modules/docusaurus-theme-redoc/node_modules/minimatch": {
-            "version": "5.1.6",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
-            "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
-            "license": "ISC",
-            "dependencies": {
-                "brace-expansion": "^2.0.1"
-            },
-            "engines": {
-                "node": ">=10"
             }
         },
         "node_modules/docusaurus-theme-redoc/node_modules/redoc": {
@@ -12471,9 +12537,9 @@
             "license": "MIT"
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.5.128",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.128.tgz",
-            "integrity": "sha512-bo1A4HH/NS522Ws0QNFIzyPcyUUNV/yyy70Ho1xqfGYzPUme2F/xr4tlEOuM6/A538U1vDA7a4XfCd1CKRegKQ==",
+            "version": "1.5.129",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.129.tgz",
+            "integrity": "sha512-JlXUemX4s0+9f8mLqib/bHH8gOHf5elKS6KeWG3sk3xozb/JTq/RLXIv8OKUWiK4Ah00Wm88EFj5PYkFr4RUPA==",
             "license": "ISC"
         },
         "node_modules/emoji-regex": {
@@ -12991,6 +13057,17 @@
                 "eslint": "^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8 || ^9"
             }
         },
+        "node_modules/eslint-plugin-import/node_modules/brace-expansion": {
+            "version": "1.1.11",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+            "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+            }
+        },
         "node_modules/eslint-plugin-import/node_modules/debug": {
             "version": "3.2.7",
             "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
@@ -12999,6 +13076,19 @@
             "license": "MIT",
             "dependencies": {
                 "ms": "^2.1.1"
+            }
+        },
+        "node_modules/eslint-plugin-import/node_modules/minimatch": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "brace-expansion": "^1.1.7"
+            },
+            "engines": {
+                "node": "*"
             }
         },
         "node_modules/eslint-plugin-import/node_modules/semver": {
@@ -13087,6 +13177,30 @@
                 "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0"
             }
         },
+        "node_modules/eslint-plugin-react/node_modules/brace-expansion": {
+            "version": "1.1.11",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+            "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+            }
+        },
+        "node_modules/eslint-plugin-react/node_modules/minimatch": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "brace-expansion": "^1.1.7"
+            },
+            "engines": {
+                "node": "*"
+            }
+        },
         "node_modules/eslint-plugin-react/node_modules/resolve": {
             "version": "2.0.0-next.5",
             "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.5.tgz",
@@ -13162,6 +13276,17 @@
                 "url": "https://github.com/sponsors/epoberezkin"
             }
         },
+        "node_modules/eslint/node_modules/brace-expansion": {
+            "version": "1.1.11",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+            "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+            }
+        },
         "node_modules/eslint/node_modules/glob-parent": {
             "version": "6.0.2",
             "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -13181,6 +13306,19 @@
             "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/eslint/node_modules/minimatch": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "brace-expansion": "^1.1.7"
+            },
+            "engines": {
+                "node": "*"
+            }
         },
         "node_modules/espree": {
             "version": "10.3.0",
@@ -13579,6 +13717,15 @@
             },
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/fast-average-color": {
+            "version": "9.5.0",
+            "resolved": "https://registry.npmjs.org/fast-average-color/-/fast-average-color-9.5.0.tgz",
+            "integrity": "sha512-nC6x2YIlJ9xxgkMFMd1BNoM1ctMjNoRKfRliPmiEWW3S6rLTHiQcy9g3pt/xiKv/D0NAAkhb9VyV+WJFvTqMGg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 12"
             }
         },
         "node_modules/fast-deep-equal": {
@@ -14095,6 +14242,16 @@
                 "ajv": "^6.9.1"
             }
         },
+        "node_modules/fork-ts-checker-webpack-plugin/node_modules/brace-expansion": {
+            "version": "1.1.11",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+            "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+            "license": "MIT",
+            "dependencies": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+            }
+        },
         "node_modules/fork-ts-checker-webpack-plugin/node_modules/cosmiconfig": {
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-6.0.0.tgz",
@@ -14131,6 +14288,18 @@
             "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
             "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
             "license": "MIT"
+        },
+        "node_modules/fork-ts-checker-webpack-plugin/node_modules/minimatch": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "license": "ISC",
+            "dependencies": {
+                "brace-expansion": "^1.1.7"
+            },
+            "engines": {
+                "node": "*"
+            }
         },
         "node_modules/fork-ts-checker-webpack-plugin/node_modules/schema-utils": {
             "version": "2.7.0",
@@ -14456,6 +14625,28 @@
             "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
             "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
             "license": "BSD-2-Clause"
+        },
+        "node_modules/glob/node_modules/brace-expansion": {
+            "version": "1.1.11",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+            "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+            "license": "MIT",
+            "dependencies": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+            }
+        },
+        "node_modules/glob/node_modules/minimatch": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "license": "ISC",
+            "dependencies": {
+                "brace-expansion": "^1.1.7"
+            },
+            "engines": {
+                "node": "*"
+            }
         },
         "node_modules/global-dirs": {
             "version": "3.0.1",
@@ -15150,6 +15341,21 @@
                 "url": "https://opencollective.com/unified"
             }
         },
+        "node_modules/hast-util-sanitize": {
+            "version": "5.0.2",
+            "resolved": "https://registry.npmjs.org/hast-util-sanitize/-/hast-util-sanitize-5.0.2.tgz",
+            "integrity": "sha512-3yTWghByc50aGS7JlGhk61SPenfE/p1oaFeNwkOOyrscaOkMGrcW9+Cy/QAIOBpZxP1yqDIzFMR0+Np0i0+usg==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/hast": "^3.0.0",
+                "@ungap/structured-clone": "^1.0.0",
+                "unist-util-position": "^5.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
         "node_modules/hast-util-to-estree": {
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/hast-util-to-estree/-/hast-util-to-estree-3.1.3.tgz",
@@ -15429,9 +15635,9 @@
             "license": "Apache-2.0"
         },
         "node_modules/html-entities": {
-            "version": "2.5.3",
-            "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.5.3.tgz",
-            "integrity": "sha512-D3AfvN7SjhTgBSA8L1BN4FpPzuEd06uy4lHwSoRWr0lndi9BKaNzPLKGOWZ2ocSGguozr08TTb2jhCLHaemruw==",
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.6.0.tgz",
+            "integrity": "sha512-kig+rMn/QOVRvr7c86gQ8lWXq+Hkv6CbAH1hLu+RG338StTpE8Z0b44SDVaqVu7HGKf27frdmUYEs9hTUX/cLQ==",
             "funding": [
                 {
                     "type": "github",
@@ -17695,16 +17901,6 @@
             },
             "engines": {
                 "node": ">=18"
-            }
-        },
-        "node_modules/markdownlint-cli/node_modules/brace-expansion": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-            "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "balanced-match": "^1.0.0"
             }
         },
         "node_modules/markdownlint-cli/node_modules/commander": {
@@ -22932,15 +23128,15 @@
             "license": "ISC"
         },
         "node_modules/minimatch": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "version": "5.1.6",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+            "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
             "license": "ISC",
             "dependencies": {
-                "brace-expansion": "^1.1.7"
+                "brace-expansion": "^2.0.1"
             },
             "engines": {
-                "node": "*"
+                "node": ">=10"
             }
         },
         "node_modules/minimist": {
@@ -24152,9 +24348,9 @@
             }
         },
         "node_modules/patch-package/node_modules/yaml": {
-            "version": "2.7.0",
-            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.7.0.tgz",
-            "integrity": "sha512-+hSoy/QHluxmC9kCIJyL/uyFmLmc+e5CFR5Wa+bpIhIj85LVb9ZH2nVnqrHoSvKogwODv0ClqZkmiSSaIH5LTA==",
+            "version": "2.7.1",
+            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.7.1.tgz",
+            "integrity": "sha512-10ULxpnOCQXxJvBgxsn9ptjq6uviG/htZKk9veJGhlqn3w/DxQ631zFF+nlQXLwmImeS5amR2dl2U8sg6U9jsQ==",
             "dev": true,
             "license": "ISC",
             "bin": {
@@ -26699,9 +26895,9 @@
             }
         },
         "node_modules/react-hook-form": {
-            "version": "7.54.2",
-            "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.54.2.tgz",
-            "integrity": "sha512-eHpAUgUjWbZocoQYUHposymRb4ZP6d0uwUnooL2uOybA9/3tPUvoAKqEWK1WaSiTxxOfTpffNZP7QwlnM3/gEg==",
+            "version": "7.55.0",
+            "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.55.0.tgz",
+            "integrity": "sha512-XRnjsH3GVMQz1moZTW53MxfoWN7aDpUg/GpVNc4A3eXRVNdGXfbzJ4vM4aLQ8g6XCUh1nIbx70aaNCl7kxnjog==",
             "license": "MIT",
             "engines": {
                 "node": ">=18.0.0"
@@ -27351,25 +27547,6 @@
                 "url": "https://opencollective.com/unified"
             }
         },
-        "node_modules/react-markdown/node_modules/unified": {
-            "version": "10.1.2",
-            "resolved": "https://registry.npmjs.org/unified/-/unified-10.1.2.tgz",
-            "integrity": "sha512-pUSWAi/RAnVy1Pif2kAoeWNBa3JVrx0MId2LASj8G+7AiHWoKZNTomq6LG326T68U7/e263X6fTdcXIy7XnF7Q==",
-            "license": "MIT",
-            "dependencies": {
-                "@types/unist": "^2.0.0",
-                "bail": "^2.0.0",
-                "extend": "^3.0.0",
-                "is-buffer": "^2.0.0",
-                "is-plain-obj": "^4.0.0",
-                "trough": "^2.0.0",
-                "vfile": "^5.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/unified"
-            }
-        },
         "node_modules/react-markdown/node_modules/unist-util-is": {
             "version": "5.2.1",
             "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-5.2.1.tgz",
@@ -27718,6 +27895,25 @@
                 "url": "https://opencollective.com/unified"
             }
         },
+        "node_modules/recma-jsx/node_modules/unified": {
+            "version": "11.0.5",
+            "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
+            "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/unist": "^3.0.0",
+                "bail": "^2.0.0",
+                "devlop": "^1.0.0",
+                "extend": "^3.0.0",
+                "is-plain-obj": "^4.0.0",
+                "trough": "^2.0.0",
+                "vfile": "^6.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
         "node_modules/recma-parse": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/recma-parse/-/recma-parse-1.0.0.tgz",
@@ -27727,6 +27923,25 @@
                 "@types/estree": "^1.0.0",
                 "esast-util-from-js": "^2.0.0",
                 "unified": "^11.0.0",
+                "vfile": "^6.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/recma-parse/node_modules/unified": {
+            "version": "11.0.5",
+            "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
+            "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/unist": "^3.0.0",
+                "bail": "^2.0.0",
+                "devlop": "^1.0.0",
+                "extend": "^3.0.0",
+                "is-plain-obj": "^4.0.0",
+                "trough": "^2.0.0",
                 "vfile": "^6.0.0"
             },
             "funding": {
@@ -27750,6 +27965,25 @@
                 "url": "https://opencollective.com/unified"
             }
         },
+        "node_modules/recma-stringify/node_modules/unified": {
+            "version": "11.0.5",
+            "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
+            "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/unist": "^3.0.0",
+                "bail": "^2.0.0",
+                "devlop": "^1.0.0",
+                "extend": "^3.0.0",
+                "is-plain-obj": "^4.0.0",
+                "trough": "^2.0.0",
+                "vfile": "^6.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
         "node_modules/recursive-readdir": {
             "version": "2.2.3",
             "resolved": "https://registry.npmjs.org/recursive-readdir/-/recursive-readdir-2.2.3.tgz",
@@ -27760,6 +27994,28 @@
             },
             "engines": {
                 "node": ">=6.0.0"
+            }
+        },
+        "node_modules/recursive-readdir/node_modules/brace-expansion": {
+            "version": "1.1.11",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+            "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+            "license": "MIT",
+            "dependencies": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+            }
+        },
+        "node_modules/recursive-readdir/node_modules/minimatch": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "license": "ISC",
+            "dependencies": {
+                "brace-expansion": "^1.1.7"
+            },
+            "engines": {
+                "node": "*"
             }
         },
         "node_modules/redoc": {
@@ -28079,68 +28335,6 @@
             "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
             "license": "MIT"
         },
-        "node_modules/rehype-raw/node_modules/unified": {
-            "version": "10.1.2",
-            "resolved": "https://registry.npmjs.org/unified/-/unified-10.1.2.tgz",
-            "integrity": "sha512-pUSWAi/RAnVy1Pif2kAoeWNBa3JVrx0MId2LASj8G+7AiHWoKZNTomq6LG326T68U7/e263X6fTdcXIy7XnF7Q==",
-            "license": "MIT",
-            "dependencies": {
-                "@types/unist": "^2.0.0",
-                "bail": "^2.0.0",
-                "extend": "^3.0.0",
-                "is-buffer": "^2.0.0",
-                "is-plain-obj": "^4.0.0",
-                "trough": "^2.0.0",
-                "vfile": "^5.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/unified"
-            }
-        },
-        "node_modules/rehype-raw/node_modules/unist-util-stringify-position": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-3.0.3.tgz",
-            "integrity": "sha512-k5GzIBZ/QatR8N5X2y+drfpWG8IDBzdnVj6OInRNWm1oXrzydiaAT2OQiA8DPRRZyAKb9b6I2a6PxYklZD0gKg==",
-            "license": "MIT",
-            "dependencies": {
-                "@types/unist": "^2.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/unified"
-            }
-        },
-        "node_modules/rehype-raw/node_modules/vfile": {
-            "version": "5.3.7",
-            "resolved": "https://registry.npmjs.org/vfile/-/vfile-5.3.7.tgz",
-            "integrity": "sha512-r7qlzkgErKjobAmyNIkkSpizsFPYiUPuJb5pNW1RB4JcYVZhs4lIbVqk8XPk033CV/1z8ss5pkax8SuhGpcG8g==",
-            "license": "MIT",
-            "dependencies": {
-                "@types/unist": "^2.0.0",
-                "is-buffer": "^2.0.0",
-                "unist-util-stringify-position": "^3.0.0",
-                "vfile-message": "^3.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/unified"
-            }
-        },
-        "node_modules/rehype-raw/node_modules/vfile-message": {
-            "version": "3.1.4",
-            "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-3.1.4.tgz",
-            "integrity": "sha512-fa0Z6P8HUrQN4BZaX05SIVXic+7kE3b05PWAtPuYP9QLHsLKYR7/AlLW3NtOrpXRLeawpDLMsVkmk5DG0NXgWw==",
-            "license": "MIT",
-            "dependencies": {
-                "@types/unist": "^2.0.0",
-                "unist-util-stringify-position": "^3.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/unified"
-            }
-        },
         "node_modules/rehype-recma": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/rehype-recma/-/rehype-recma-1.0.0.tgz",
@@ -28150,6 +28344,20 @@
                 "@types/estree": "^1.0.0",
                 "@types/hast": "^3.0.0",
                 "hast-util-to-estree": "^3.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/rehype-sanitize": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/rehype-sanitize/-/rehype-sanitize-6.0.0.tgz",
+            "integrity": "sha512-CsnhKNsyI8Tub6L4sm5ZFsme4puGfc6pYylvXo1AeqaGbjOYyzNv3qZPwvs0oMJ39eryyeOdmxwUIo94IpEhqg==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/hast": "^3.0.0",
+                "hast-util-sanitize": "^5.0.0"
             },
             "funding": {
                 "type": "opencollective",
@@ -28190,6 +28398,25 @@
                 "@types/unist": "*"
             }
         },
+        "node_modules/remark-directive/node_modules/unified": {
+            "version": "11.0.5",
+            "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
+            "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/unist": "^3.0.0",
+                "bail": "^2.0.0",
+                "devlop": "^1.0.0",
+                "extend": "^3.0.0",
+                "is-plain-obj": "^4.0.0",
+                "trough": "^2.0.0",
+                "vfile": "^6.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
         "node_modules/remark-emoji": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/remark-emoji/-/remark-emoji-4.0.1.tgz",
@@ -28213,6 +28440,25 @@
             "license": "MIT",
             "dependencies": {
                 "@types/unist": "*"
+            }
+        },
+        "node_modules/remark-emoji/node_modules/unified": {
+            "version": "11.0.5",
+            "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
+            "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/unist": "^3.0.0",
+                "bail": "^2.0.0",
+                "devlop": "^1.0.0",
+                "extend": "^3.0.0",
+                "is-plain-obj": "^4.0.0",
+                "trough": "^2.0.0",
+                "vfile": "^6.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
             }
         },
         "node_modules/remark-frontmatter": {
@@ -28240,6 +28486,25 @@
                 "@types/unist": "*"
             }
         },
+        "node_modules/remark-frontmatter/node_modules/unified": {
+            "version": "11.0.5",
+            "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
+            "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/unist": "^3.0.0",
+                "bail": "^2.0.0",
+                "devlop": "^1.0.0",
+                "extend": "^3.0.0",
+                "is-plain-obj": "^4.0.0",
+                "trough": "^2.0.0",
+                "vfile": "^6.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
         "node_modules/remark-gfm": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-3.0.1.tgz",
@@ -28250,74 +28515,6 @@
                 "mdast-util-gfm": "^2.0.0",
                 "micromark-extension-gfm": "^2.0.0",
                 "unified": "^10.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/unified"
-            }
-        },
-        "node_modules/remark-gfm/node_modules/@types/unist": {
-            "version": "2.0.11",
-            "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
-            "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
-            "license": "MIT"
-        },
-        "node_modules/remark-gfm/node_modules/unified": {
-            "version": "10.1.2",
-            "resolved": "https://registry.npmjs.org/unified/-/unified-10.1.2.tgz",
-            "integrity": "sha512-pUSWAi/RAnVy1Pif2kAoeWNBa3JVrx0MId2LASj8G+7AiHWoKZNTomq6LG326T68U7/e263X6fTdcXIy7XnF7Q==",
-            "license": "MIT",
-            "dependencies": {
-                "@types/unist": "^2.0.0",
-                "bail": "^2.0.0",
-                "extend": "^3.0.0",
-                "is-buffer": "^2.0.0",
-                "is-plain-obj": "^4.0.0",
-                "trough": "^2.0.0",
-                "vfile": "^5.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/unified"
-            }
-        },
-        "node_modules/remark-gfm/node_modules/unist-util-stringify-position": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-3.0.3.tgz",
-            "integrity": "sha512-k5GzIBZ/QatR8N5X2y+drfpWG8IDBzdnVj6OInRNWm1oXrzydiaAT2OQiA8DPRRZyAKb9b6I2a6PxYklZD0gKg==",
-            "license": "MIT",
-            "dependencies": {
-                "@types/unist": "^2.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/unified"
-            }
-        },
-        "node_modules/remark-gfm/node_modules/vfile": {
-            "version": "5.3.7",
-            "resolved": "https://registry.npmjs.org/vfile/-/vfile-5.3.7.tgz",
-            "integrity": "sha512-r7qlzkgErKjobAmyNIkkSpizsFPYiUPuJb5pNW1RB4JcYVZhs4lIbVqk8XPk033CV/1z8ss5pkax8SuhGpcG8g==",
-            "license": "MIT",
-            "dependencies": {
-                "@types/unist": "^2.0.0",
-                "is-buffer": "^2.0.0",
-                "unist-util-stringify-position": "^3.0.0",
-                "vfile-message": "^3.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/unified"
-            }
-        },
-        "node_modules/remark-gfm/node_modules/vfile-message": {
-            "version": "3.1.4",
-            "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-3.1.4.tgz",
-            "integrity": "sha512-fa0Z6P8HUrQN4BZaX05SIVXic+7kE3b05PWAtPuYP9QLHsLKYR7/AlLW3NtOrpXRLeawpDLMsVkmk5DG0NXgWw==",
-            "license": "MIT",
-            "dependencies": {
-                "@types/unist": "^2.0.0",
-                "unist-util-stringify-position": "^3.0.0"
             },
             "funding": {
                 "type": "opencollective",
@@ -28403,6 +28600,25 @@
             ],
             "license": "MIT"
         },
+        "node_modules/remark-parse/node_modules/unified": {
+            "version": "11.0.5",
+            "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
+            "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/unist": "^3.0.0",
+                "bail": "^2.0.0",
+                "devlop": "^1.0.0",
+                "extend": "^3.0.0",
+                "is-plain-obj": "^4.0.0",
+                "trough": "^2.0.0",
+                "vfile": "^6.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
         "node_modules/remark-rehype": {
             "version": "11.1.1",
             "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-11.1.1.tgz",
@@ -28429,6 +28645,25 @@
                 "@types/unist": "*"
             }
         },
+        "node_modules/remark-rehype/node_modules/unified": {
+            "version": "11.0.5",
+            "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
+            "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/unist": "^3.0.0",
+                "bail": "^2.0.0",
+                "devlop": "^1.0.0",
+                "extend": "^3.0.0",
+                "is-plain-obj": "^4.0.0",
+                "trough": "^2.0.0",
+                "vfile": "^6.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
         "node_modules/remark-stringify": {
             "version": "11.0.0",
             "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-11.0.0.tgz",
@@ -28453,6 +28688,25 @@
                 "@types/unist": "*"
             }
         },
+        "node_modules/remark-stringify/node_modules/unified": {
+            "version": "11.0.5",
+            "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
+            "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/unist": "^3.0.0",
+                "bail": "^2.0.0",
+                "devlop": "^1.0.0",
+                "extend": "^3.0.0",
+                "is-plain-obj": "^4.0.0",
+                "trough": "^2.0.0",
+                "vfile": "^6.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
         "node_modules/remark-toc": {
             "version": "8.0.1",
             "resolved": "https://registry.npmjs.org/remark-toc/-/remark-toc-8.0.1.tgz",
@@ -28462,74 +28716,6 @@
                 "@types/mdast": "^3.0.0",
                 "mdast-util-toc": "^6.0.0",
                 "unified": "^10.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/unified"
-            }
-        },
-        "node_modules/remark-toc/node_modules/@types/unist": {
-            "version": "2.0.11",
-            "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
-            "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
-            "license": "MIT"
-        },
-        "node_modules/remark-toc/node_modules/unified": {
-            "version": "10.1.2",
-            "resolved": "https://registry.npmjs.org/unified/-/unified-10.1.2.tgz",
-            "integrity": "sha512-pUSWAi/RAnVy1Pif2kAoeWNBa3JVrx0MId2LASj8G+7AiHWoKZNTomq6LG326T68U7/e263X6fTdcXIy7XnF7Q==",
-            "license": "MIT",
-            "dependencies": {
-                "@types/unist": "^2.0.0",
-                "bail": "^2.0.0",
-                "extend": "^3.0.0",
-                "is-buffer": "^2.0.0",
-                "is-plain-obj": "^4.0.0",
-                "trough": "^2.0.0",
-                "vfile": "^5.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/unified"
-            }
-        },
-        "node_modules/remark-toc/node_modules/unist-util-stringify-position": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-3.0.3.tgz",
-            "integrity": "sha512-k5GzIBZ/QatR8N5X2y+drfpWG8IDBzdnVj6OInRNWm1oXrzydiaAT2OQiA8DPRRZyAKb9b6I2a6PxYklZD0gKg==",
-            "license": "MIT",
-            "dependencies": {
-                "@types/unist": "^2.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/unified"
-            }
-        },
-        "node_modules/remark-toc/node_modules/vfile": {
-            "version": "5.3.7",
-            "resolved": "https://registry.npmjs.org/vfile/-/vfile-5.3.7.tgz",
-            "integrity": "sha512-r7qlzkgErKjobAmyNIkkSpizsFPYiUPuJb5pNW1RB4JcYVZhs4lIbVqk8XPk033CV/1z8ss5pkax8SuhGpcG8g==",
-            "license": "MIT",
-            "dependencies": {
-                "@types/unist": "^2.0.0",
-                "is-buffer": "^2.0.0",
-                "unist-util-stringify-position": "^3.0.0",
-                "vfile-message": "^3.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/unified"
-            }
-        },
-        "node_modules/remark-toc/node_modules/vfile-message": {
-            "version": "3.1.4",
-            "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-3.1.4.tgz",
-            "integrity": "sha512-fa0Z6P8HUrQN4BZaX05SIVXic+7kE3b05PWAtPuYP9QLHsLKYR7/AlLW3NtOrpXRLeawpDLMsVkmk5DG0NXgWw==",
-            "license": "MIT",
-            "dependencies": {
-                "@types/unist": "^2.0.0",
-                "unist-util-stringify-position": "^3.0.0"
             },
             "funding": {
                 "type": "opencollective",
@@ -28776,16 +28962,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
-            }
-        },
-        "node_modules/rimraf/node_modules/brace-expansion": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-            "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "balanced-match": "^1.0.0"
             }
         },
         "node_modules/rimraf/node_modules/glob": {
@@ -29068,9 +29244,9 @@
             "license": "MIT"
         },
         "node_modules/sass": {
-            "version": "1.86.0",
-            "resolved": "https://registry.npmjs.org/sass/-/sass-1.86.0.tgz",
-            "integrity": "sha512-zV8vGUld/+mP4KbMLJMX7TyGCuUp7hnkOScgCMsWuHtns8CWBoz+vmEhoGMXsaJrbUP8gj+F1dLvVe79sK8UdA==",
+            "version": "1.86.1",
+            "resolved": "https://registry.npmjs.org/sass/-/sass-1.86.1.tgz",
+            "integrity": "sha512-Yaok4XELL1L9Im/ZUClKu//D2OP1rOljKj0Gf34a+GzLbMveOzL7CfqYo+JUa5Xt1nhTCW+OcKp/FtR7/iqj1w==",
             "license": "MIT",
             "dependencies": {
                 "chokidar": "^4.0.0",
@@ -29335,6 +29511,16 @@
                 "range-parser": "1.2.0"
             }
         },
+        "node_modules/serve-handler/node_modules/brace-expansion": {
+            "version": "1.1.11",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+            "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+            "license": "MIT",
+            "dependencies": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+            }
+        },
         "node_modules/serve-handler/node_modules/mime-db": {
             "version": "1.33.0",
             "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
@@ -29354,6 +29540,18 @@
             },
             "engines": {
                 "node": ">= 0.6"
+            }
+        },
+        "node_modules/serve-handler/node_modules/minimatch": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "license": "ISC",
+            "dependencies": {
+                "brace-expansion": "^1.1.7"
+            },
+            "engines": {
+                "node": "*"
             }
         },
         "node_modules/serve-handler/node_modules/path-to-regexp": {
@@ -30428,15 +30626,6 @@
                 "node": ">=16 || 14 >=14.17"
             }
         },
-        "node_modules/sucrase/node_modules/brace-expansion": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-            "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-            "license": "MIT",
-            "dependencies": {
-                "balanced-match": "^1.0.0"
-            }
-        },
         "node_modules/sucrase/node_modules/commander": {
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
@@ -31003,6 +31192,7 @@
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
             "integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
             "dev": true,
+            "license": "Apache-2.0",
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -31012,15 +31202,15 @@
             }
         },
         "node_modules/typescript-eslint": {
-            "version": "8.28.0",
-            "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.28.0.tgz",
-            "integrity": "sha512-jfZtxJoHm59bvoCMYCe2BM0/baMswRhMmYhy+w6VfcyHrjxZ0OJe0tGasydCpIpA+A/WIJhTyZfb3EtwNC/kHQ==",
+            "version": "8.29.0",
+            "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.29.0.tgz",
+            "integrity": "sha512-ep9rVd9B4kQsZ7ZnWCVxUE/xDLUUUsRzE0poAeNu+4CkFErLfuvPt/qtm2EpnSyfvsR0S6QzDFSrPCFBwf64fg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/eslint-plugin": "8.28.0",
-                "@typescript-eslint/parser": "8.28.0",
-                "@typescript-eslint/utils": "8.28.0"
+                "@typescript-eslint/eslint-plugin": "8.29.0",
+                "@typescript-eslint/parser": "8.29.0",
+                "@typescript-eslint/utils": "8.29.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -31157,18 +31347,67 @@
             }
         },
         "node_modules/unified": {
-            "version": "11.0.5",
-            "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
-            "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
+            "version": "10.1.2",
+            "resolved": "https://registry.npmjs.org/unified/-/unified-10.1.2.tgz",
+            "integrity": "sha512-pUSWAi/RAnVy1Pif2kAoeWNBa3JVrx0MId2LASj8G+7AiHWoKZNTomq6LG326T68U7/e263X6fTdcXIy7XnF7Q==",
             "license": "MIT",
             "dependencies": {
-                "@types/unist": "^3.0.0",
+                "@types/unist": "^2.0.0",
                 "bail": "^2.0.0",
-                "devlop": "^1.0.0",
                 "extend": "^3.0.0",
+                "is-buffer": "^2.0.0",
                 "is-plain-obj": "^4.0.0",
                 "trough": "^2.0.0",
-                "vfile": "^6.0.0"
+                "vfile": "^5.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/unified/node_modules/@types/unist": {
+            "version": "2.0.11",
+            "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
+            "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
+            "license": "MIT"
+        },
+        "node_modules/unified/node_modules/unist-util-stringify-position": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-3.0.3.tgz",
+            "integrity": "sha512-k5GzIBZ/QatR8N5X2y+drfpWG8IDBzdnVj6OInRNWm1oXrzydiaAT2OQiA8DPRRZyAKb9b6I2a6PxYklZD0gKg==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/unist": "^2.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/unified/node_modules/vfile": {
+            "version": "5.3.7",
+            "resolved": "https://registry.npmjs.org/vfile/-/vfile-5.3.7.tgz",
+            "integrity": "sha512-r7qlzkgErKjobAmyNIkkSpizsFPYiUPuJb5pNW1RB4JcYVZhs4lIbVqk8XPk033CV/1z8ss5pkax8SuhGpcG8g==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/unist": "^2.0.0",
+                "is-buffer": "^2.0.0",
+                "unist-util-stringify-position": "^3.0.0",
+                "vfile-message": "^3.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/unified/node_modules/vfile-message": {
+            "version": "3.1.4",
+            "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-3.1.4.tgz",
+            "integrity": "sha512-fa0Z6P8HUrQN4BZaX05SIVXic+7kE3b05PWAtPuYP9QLHsLKYR7/AlLW3NtOrpXRLeawpDLMsVkmk5DG0NXgWw==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/unist": "^2.0.0",
+                "unist-util-stringify-position": "^3.0.0"
             },
             "funding": {
                 "type": "opencollective",
@@ -31529,9 +31768,9 @@
             }
         },
         "node_modules/use-sync-external-store": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.4.0.tgz",
-            "integrity": "sha512-9WXSPC5fMv61vaupRkCKCxsPxBocVnwakBEkMIHHpkTTg6icbJtg6jzgtLDm4bl3cSHAca52rYWih0k4K3PfHw==",
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.5.0.tgz",
+            "integrity": "sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==",
             "license": "MIT",
             "peerDependencies": {
                 "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
         "typescript-eslint": "^8.22.0"
     },
     "dependencies": {
-        "@apify-packages/ui-library": "^0.28.1",
+        "@apify/ui-library": "^0.61.0",
         "@docusaurus/core": "3.7.0",
         "@docusaurus/faster": "3.7.0",
         "@docusaurus/plugin-client-redirects": "3.7.0",

--- a/src/components/ActionCard/ActionCard.tsx
+++ b/src/components/ActionCard/ActionCard.tsx
@@ -2,7 +2,7 @@ import Link from '@docusaurus/Link';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import styled from 'styled-components';
 
-import { HorizontalTile, theme } from '@apify-packages/ui-library';
+import { HorizontalTile, theme } from '@apify/ui-library';
 
 import styles from './styles.module.css';
 import ArrowRight20 from '../../pages/img/arrow-right-20.svg';

--- a/src/components/ActorTemplates/ActorTemplates.tsx
+++ b/src/components/ActorTemplates/ActorTemplates.tsx
@@ -9,7 +9,7 @@ import styled from 'styled-components';
 import {
     ActorTemplateCard,
     theme,
-} from '@apify-packages/ui-library';
+} from '@apify/ui-library';
 
 interface ActorTemplate {
     id: string,

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -1,7 +1,7 @@
 import type { PropsWithChildren } from 'react';
 import styled, { css } from 'styled-components';
 
-import { theme } from '@apify-packages/ui-library';
+import { theme } from '@apify/ui-library';
 
 // TODO: implement secondary, success and danger
 export const BUTTON_VARIANTS = {

--- a/src/components/CardWithIcon/CardWithIcon.tsx
+++ b/src/components/CardWithIcon/CardWithIcon.tsx
@@ -1,7 +1,7 @@
 import Link from '@docusaurus/Link';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 
-import { VerticalTile, theme } from '@apify-packages/ui-library';
+import { VerticalTile, theme } from '@apify/ui-library';
 
 import styles from './styles.module.css';
 import { Heading } from '../Heading';

--- a/src/components/Heading.tsx
+++ b/src/components/Heading.tsx
@@ -1,7 +1,7 @@
 import styled, { css } from 'styled-components';
 
-import type { TextBaseProps } from '@apify-packages/ui-library';
-import { TextBaseComponent, theme } from '@apify-packages/ui-library';
+import type { TextBaseProps } from '@apify/ui-library';
+import { TextBaseComponent, theme } from '@apify/ui-library';
 
 /**
  * @typedef {Object} HeadingProps

--- a/src/components/OpenSourceCards/OpenSourceCards.tsx
+++ b/src/components/OpenSourceCards/OpenSourceCards.tsx
@@ -5,7 +5,7 @@ import ThemedImage from '@theme/ThemedImage';
 import type React from 'react';
 import GitHubButton from 'react-github-btn';
 
-import { theme } from '@apify-packages/ui-library';
+import { theme } from '@apify/ui-library';
 
 import styles from './styles.module.css';
 import CardWithImageAndContent from '../CardWithImageAndContent/ImageWithContent';

--- a/src/components/PlainCard/PlainCard.tsx
+++ b/src/components/PlainCard/PlainCard.tsx
@@ -1,7 +1,7 @@
 import Link from '@docusaurus/Link';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 
-import { VerticalTile, theme } from '@apify-packages/ui-library';
+import { VerticalTile, theme } from '@apify/ui-library';
 
 import styles from './styles.module.css';
 import { Heading } from '../Heading';

--- a/src/components/SdkSection/SdkSection.tsx
+++ b/src/components/SdkSection/SdkSection.tsx
@@ -5,7 +5,7 @@ import ThemedImage from '@theme/ThemedImage';
 import GitHubButton from 'react-github-btn';
 import styled from 'styled-components';
 
-import { ActionLink, Button, theme } from '@apify-packages/ui-library';
+import { ActionLink, Button, theme } from '@apify/ui-library';
 
 import { Heading } from '../Heading';
 import { Text } from '../Text';

--- a/src/components/Section/Section.tsx
+++ b/src/components/Section/Section.tsx
@@ -1,6 +1,6 @@
 import clsx from 'clsx';
 
-import { theme } from '@apify-packages/ui-library';
+import { theme } from '@apify/ui-library';
 
 import styles from './styles.module.css';
 import { Heading } from '../Heading';

--- a/src/components/Tabs.tsx
+++ b/src/components/Tabs.tsx
@@ -2,7 +2,7 @@ import clsx from 'clsx';
 import React from 'react';
 import styled from 'styled-components';
 
-import { theme } from '@apify-packages/ui-library';
+import { theme } from '@apify/ui-library';
 
 import { Heading } from './Heading';
 

--- a/src/components/Text.tsx
+++ b/src/components/Text.tsx
@@ -1,10 +1,10 @@
 import styled, { css } from 'styled-components';
 
-import type { TextBaseProps } from '@apify-packages/ui-library';
+import type { TextBaseProps } from '@apify/ui-library';
 import {
     TextBaseComponent,
     theme,
-} from '@apify-packages/ui-library';
+} from '@apify/ui-library';
 
 /**
  * @typedef {Object} TextProps

--- a/src/components/UiLibraryWrapper.tsx
+++ b/src/components/UiLibraryWrapper.tsx
@@ -4,7 +4,7 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 import type { PropsWithChildren } from 'react';
 import { useEffect, useState } from 'react';
 
-import { UiDependencyProvider } from '@apify-packages/ui-library';
+import { UiDependencyProvider } from '@apify/ui-library';
 
 export default function UiLibraryWrapper({ children }: PropsWithChildren) {
     const [themeIsDark, setThemeIsDark] = useState(true);

--- a/src/pages/api/index.tsx
+++ b/src/pages/api/index.tsx
@@ -11,7 +11,7 @@ import {
     BlogArticle,
     Button,
     theme,
-} from '@apify-packages/ui-library';
+} from '@apify/ui-library';
 
 import styles from './styles.module.css';
 import GitButton from '../../components/GitButton';

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -6,7 +6,7 @@ import ThemedImage from '@theme/ThemedImage';
 import React from 'react';
 import styled from 'styled-components';
 
-import { Banner, theme } from '@apify-packages/ui-library';
+import { Banner, theme } from '@apify/ui-library';
 
 import ActionCard from '../components/ActionCard/ActionCard';
 import { ActorTemplates } from '../components/ActorTemplates/ActorTemplates';

--- a/src/pages/open-source/index.tsx
+++ b/src/pages/open-source/index.tsx
@@ -4,7 +4,7 @@ import clsx from 'clsx';
 import React from 'react';
 import styled from 'styled-components';
 
-import { Banner, Heading, Link, Text, theme } from '@apify-packages/ui-library';
+import { Banner, Heading, Link, Text, theme } from '@apify/ui-library';
 
 import ActionCard from '../../components/ActionCard/ActionCard';
 import { ActorTemplates } from '../../components/ActorTemplates/ActorTemplates';

--- a/src/pages/sdk/index.tsx
+++ b/src/pages/sdk/index.tsx
@@ -2,7 +2,7 @@ import Layout from '@theme/Layout';
 import React from 'react';
 import styled from 'styled-components';
 
-import { theme } from '@apify-packages/ui-library';
+import { theme } from '@apify/ui-library';
 
 import Hero from '../../components/Hero/Hero';
 import SdkSection from '../../components/SdkSection/SdkSection';


### PR DESCRIPTION
This PR adopts the new `@apify/ui-components` library which was previously available only on our private NPM registry. This means we should be finally open source again - and people from outside apify org should be able to run things locally (as well as PR checks should work again on PRs from forks).

I also did a full lockfile update to be sure we have no duplicates or dated dependencies after the update.