### PR TITLE
docs: fix typo in `actors/builds/default` endpoint docs

### DIFF
--- a/apify-api/openapi/paths/actors/acts@{actorId}@builds@default.yaml
+++ b/apify-api/openapi/paths/actors/acts@{actorId}@builds@default.yaml
@@ -8,7 +8,7 @@ get:
     Use the optional `waitForFinish` parameter to synchronously wait for the build to finish.
     This avoids the need for periodic polling when waiting for the build to complete.
 
-    This endpoint does not require an authentication token. Instead, calls are authenticated using the build's unique ID.
+    This endpoint does not require an authentication token. Instead, calls are authenticated using the Actor's unique ID.
     However, if you access the endpoint without a token, certain attributes (e.g., `usageUsd` and `usageTotalUsd`) will be hidden.
   operationId: act_build_default_get
   security:


### PR DESCRIPTION
There's no build `id` among this endpoint's parameters - the "authentication" is ensured by the obscurity of the Actor ID.