### PR TITLE
docs: add standby request timeout info

### DIFF
--- a/sources/platform/actors/development/programming_interface/actor_standby.md
+++ b/sources/platform/actors/development/programming_interface/actor_standby.md
@@ -176,6 +176,10 @@ async def main() -> None:
 </TabItem>
 </Tabs>
 
+## Timeouts
+
+When you send a request to an Actor in Standby mode, the total timeout is 5 minutes to the first response. But before the request is sent to a specific Actor run, the platform needs to decide to which run should the request go. The "run choosing" process has an internal timeout of 2 minutes.
+
 ## Getting the URL of the Standby Actor
 
 The URL is exposed as an environment variable `ACTOR_STANDBY_URL`. You can also use `Actor.config`, where the `standbyUrl` option is available.

--- a/sources/platform/actors/development/programming_interface/actor_standby.md
+++ b/sources/platform/actors/development/programming_interface/actor_standby.md
@@ -178,7 +178,7 @@ async def main() -> None:
 
 ## Timeouts
 
-When you send a request to an Actor in Standby mode, the total timeout is 5 minutes to the first response. But before the request is sent to a specific Actor run, the platform needs to decide to which run should the request go. The "run choosing" process has an internal timeout of 2 minutes.
+When you send a request to an Actor in Standby mode, the total timeout for receiving the first response is _5 minutes_. Before the platform forwards the request to a specific Actor run, it performs a _run selection_ process to determine the specific Actor run that will handle it. This process has internal timeout of _2 minutes_.
 
 ## Getting the URL of the Standby Actor
 

--- a/sources/platform/actors/running/actor_standby.md
+++ b/sources/platform/actors/running/actor_standby.md
@@ -67,6 +67,10 @@ it well. Please head to the Actor README to learn more about the capabilities of
 When you use the Actor in Standby mode, the system automatically scales the Actor to accommodate the incoming requests. Under the hood,
 the system starts new Actor runs, which you will see in the Actor runs tab, with the origin set to Standby.
 
+## What is the timeout for incoming requests
+
+When you send a request to an Actor in Standby mode, the timeout is 5 minutes to the first response.
+
 ## How do I customize Standby configuration
 
 The Standby configuration currently consists of the following properties:

--- a/sources/platform/actors/running/actor_standby.md
+++ b/sources/platform/actors/running/actor_standby.md
@@ -69,7 +69,7 @@ the system starts new Actor runs, which you will see in the Actor runs tab, with
 
 ## What is the timeout for incoming requests
 
-When you send a request to an Actor in Standby mode, the timeout is 5 minutes to the first response.
+For requests sent to an Actor in Standby mode, the maximum time allowed until receiving the first response is _5 minutes_. This represents the overall timeout for the operation.
 
 ## How do I customize Standby configuration
 


### PR DESCRIPTION
This PR adds info about the request timeout for standby:
- 5 minutes as the total timeout
- 2 minutes as the timeout for "run choosing", only mentioned for devs