### PR TITLE
docs: add `stats.migrationCount` to run responses

### DIFF
--- a/apify-api/openapi/components/schemas/actor-runs/RunStats.yaml
+++ b/apify-api/openapi/components/schemas/actor-runs/RunStats.yaml
@@ -8,6 +8,9 @@ properties:
   inputBodyLen:
     type: number
     example: 240
+  migrationCount:
+    type: number
+    example: 0
   restartCount:
     type: number
     example: 0

--- a/apify-api/openapi/paths/actor-runs/actor-runs@{runId}.yaml
+++ b/apify-api/openapi/paths/actor-runs/actor-runs@{runId}.yaml
@@ -122,6 +122,7 @@ get:
                 userAgent: Mozilla/5.0 (iPad)
               stats:
                 inputBodyLen: 240
+                migrationCount: 0
                 restartCount: 0
                 resurrectCount: 2
                 memAvgBytes: 267874071.9
@@ -246,6 +247,7 @@ put:
                 userAgent: Mozilla/5.0 (iPad)
               stats:
                 inputBodyLen: 240
+                migrationCount: 0
                 restartCount: 0
                 resurrectCount: 2
                 memAvgBytes: 267874071.9

--- a/apify-api/openapi/paths/actor-runs/actor-runs@{runId}@abort.yaml
+++ b/apify-api/openapi/paths/actor-runs/actor-runs@{runId}@abort.yaml
@@ -54,6 +54,7 @@ post:
                 userAgent: Mozilla/5.0 (iPad)
               stats:
                 inputBodyLen: 240
+                migrationCount: 0
                 restartCount: 0
                 resurrectCount: 1
                 memAvgBytes: 35914228.4

--- a/apify-api/openapi/paths/actor-runs/actor-runs@{runId}@metamorph.yaml
+++ b/apify-api/openapi/paths/actor-runs/actor-runs@{runId}@metamorph.yaml
@@ -75,6 +75,7 @@ post:
                 userAgent: Mozilla/5.0 (iPad)
               stats:
                 inputBodyLen: 240
+                migrationCount: 0
                 restartCount: 0
                 resurrectCount: 1
                 memAvgBytes: 35914228.4

--- a/apify-api/openapi/paths/actor-runs/actor-runs@{runId}@reboot.yaml
+++ b/apify-api/openapi/paths/actor-runs/actor-runs@{runId}@reboot.yaml
@@ -45,6 +45,7 @@ post:
                 userAgent: Mozilla/5.0 (iPad)
               stats:
                 inputBodyLen: 240
+                migrationCount: 0
                 restartCount: 0
                 resurrectCount: 2
                 memAvgBytes: 267874071.9

--- a/apify-api/openapi/paths/actor-runs/actor-runs@{runId}@resurrect.yaml
+++ b/apify-api/openapi/paths/actor-runs/actor-runs@{runId}@resurrect.yaml
@@ -64,6 +64,7 @@ post:
                 userAgent: Mozilla/5.0 (iPad)
               stats:
                 inputBodyLen: 240
+                migrationCount: 0
                 restartCount: 0
                 resurrectCount: 2
                 memAvgBytes: 267874071.9

--- a/apify-api/openapi/paths/actor-tasks/actor-tasks@{actorTaskId}@runs.yaml
+++ b/apify-api/openapi/paths/actor-tasks/actor-tasks@{actorTaskId}@runs.yaml
@@ -305,6 +305,7 @@ post:
                 scheduledAt: '2019-06-10T11:40:00.000Z'
               stats:
                 inputBodyLen: 240
+                migrationCount: 0
                 restartCount: 0
                 resurrectCount: 2
                 memAvgBytes: 35914228.4

--- a/apify-api/openapi/paths/actor-tasks/actor-tasks@{actorTaskId}@runs@last.yaml
+++ b/apify-api/openapi/paths/actor-tasks/actor-tasks@{actorTaskId}@runs@last.yaml
@@ -9,7 +9,7 @@ get:
 
     The endpoints accept the same HTTP methods and query parameters as
     the respective storage endpoints.
-    The base path represents the last actor task run object is:                                  
+    The base path represents the last actor task run object is:
 
     `/v2/actor-tasks/{actorTaskId}/runs/last{?token,status}`
 
@@ -97,6 +97,7 @@ get:
                 userAgent: Mozilla/5.0 (iPad)
               stats:
                 inputBodyLen: 240
+                migrationCount: 0
                 restartCount: 0
                 resurrectCount: 2
                 memAvgBytes: 267874071.9

--- a/apify-api/openapi/paths/actors/acts@{actorId}@runs.yaml
+++ b/apify-api/openapi/paths/actors/acts@{actorId}@runs.yaml
@@ -285,6 +285,7 @@ post:
                 userAgent: Mozilla/5.0 (iPad)
               stats:
                 inputBodyLen: 240
+                migrationCount: 0
                 restartCount: 0
                 resurrectCount: 2
                 memAvgBytes: 267874071.9

--- a/apify-api/openapi/paths/actors/acts@{actorId}@runs@last.yaml
+++ b/apify-api/openapi/paths/actors/acts@{actorId}@runs@last.yaml
@@ -99,6 +99,7 @@ get:
                 userAgent: Mozilla/5.0 (iPad)
               stats:
                 inputBodyLen: 240
+                migrationCount: 0
                 restartCount: 0
                 resurrectCount: 2
                 memAvgBytes: 267874071.9

--- a/apify-api/openapi/paths/actors/acts@{actorId}@runs@{runId}.yaml
+++ b/apify-api/openapi/paths/actors/acts@{actorId}@runs@{runId}.yaml
@@ -71,6 +71,7 @@ get:
                 userAgent: Mozilla/5.0 (iPad)
               stats:
                 inputBodyLen: 240
+                migrationCount: 0
                 restartCount: 0
                 resurrectCount: 2
                 memAvgBytes: 267874071.9

--- a/apify-api/openapi/paths/actors/acts@{actorId}@runs@{runId}@abort.yaml
+++ b/apify-api/openapi/paths/actors/acts@{actorId}@runs@{runId}@abort.yaml
@@ -63,6 +63,7 @@ post:
                 userAgent: Mozilla/5.0 (iPad)
               stats:
                 inputBodyLen: 240
+                migrationCount: 0
                 restartCount: 0
                 resurrectCount: 1
                 memAvgBytes: 35914228.4

--- a/apify-api/openapi/paths/actors/acts@{actorId}@runs@{runId}@metamorph.yaml
+++ b/apify-api/openapi/paths/actors/acts@{actorId}@runs@{runId}@metamorph.yaml
@@ -87,6 +87,7 @@ post:
                 userAgent: Mozilla/5.0 (iPad)
               stats:
                 inputBodyLen: 240
+                migrationCount: 0
                 restartCount: 0
                 resurrectCount: 1
                 memAvgBytes: 35914228.4

--- a/apify-api/openapi/paths/actors/acts@{actorId}@runs@{runId}@resurrect.yaml
+++ b/apify-api/openapi/paths/actors/acts@{actorId}@runs@{runId}@resurrect.yaml
@@ -93,6 +93,7 @@ post:
                 userAgent: Mozilla/5.0 (iPad)
               stats:
                 inputBodyLen: 240
+                migrationCount: 0
                 restartCount: 0
                 resurrectCount: 2
                 memAvgBytes: 267874071.9


### PR DESCRIPTION
This PR adds `stats.migrationCount` to the run response OpenAPI docs. It was previously missing.