### PR TITLE
chore: add links to JS & python clients

### DIFF
--- a/apify-api/openapi/paths/actor-builds/actor-builds@{buildId}@openapi.json.yaml
+++ b/apify-api/openapi/paths/actor-builds/actor-builds@{buildId}@openapi.json.yaml
@@ -37,3 +37,9 @@ get:
         application/json:
           schema:
             $ref: '../../components/schemas/actor-builds/GetOpenApiResponse.yaml'
+  x-js-parent: BuildClient
+  x-js-name: getOpenApiDefinition
+  x-js-doc-url: https://docs.apify.com/api/client/js/reference/class/BuildClient#getOpenApiDefinition
+  x-py-parent: BuildClient
+  x-py-name: get_open_api_definition
+  x-py-doc-url: https://docs.apify.com/api/client/python/reference/class/BuildClient#get_open_api_definition

--- a/apify-api/openapi/paths/actors/acts@{actorId}@builds@default.yaml
+++ b/apify-api/openapi/paths/actors/acts@{actorId}@builds@default.yaml
@@ -74,3 +74,9 @@ get:
               inputSchema: '{\n  \"title\": \"Schema for ... }'
               readme: '# Magic Actor\nThis Actor is magic.'
               buildNumber: 0.1.1
+  x-js-parent: ActorClient
+  x-js-name: defaultBuild
+  x-js-doc-url: https://docs.apify.com/api/client/js/reference/class/ActorClient#defaultBuild
+  x-py-parent: ActorClient
+  x-py-name: default_build
+  x-py-doc-url: https://docs.apify.com/api/client/python/reference/class/ActorClient#default_build


### PR DESCRIPTION
This PR adds correct links to JS & Python clients for:
- `/v2/actor-builds/:buildId/openapi.json`
- `/v2/acts/:actorId/builds/default`