### PR TITLE
feat: rename the JS course

### DIFF
--- a/.github/styles/config/vocabularies/Docs/accept.txt
+++ b/.github/styles/config/vocabularies/Docs/accept.txt
@@ -86,6 +86,7 @@ preconfigured
 
 [Mm]ultiselect
 
+devs
 asyncio
 Langflow
 backlinks?

--- a/sources/academy/homepage_content.json
+++ b/sources/academy/homepage_content.json
@@ -1,7 +1,7 @@
 {
     "Beginner courses": [
         {
-            "title": "Web scraping for beginners",
+            "title": "Web scraping basics for JavaScript devs",
             "link": "academy/web-scraping-for-beginners",
             "description": "Learn how to develop web scrapers on your own computer with open-source tools. This web scraping course teaches you all the basics a scraper developer needs to know.",
             "imageUrl": "/img/academy/intro.svg"

--- a/sources/academy/platform/expert_scraping_with_apify/actors_webhooks.md
+++ b/sources/academy/platform/expert_scraping_with_apify/actors_webhooks.md
@@ -15,7 +15,7 @@ Thus far, you've run Actors on the platform and written an Actor of your own, wh
 
 ## Advanced Actor overview {#advanced-actors}
 
-In this course, we'll be working out of the Amazon scraper project from the **Web scraping for beginners** course. If you haven't already built that project, you can do it in three short lessons [here](../../webscraping/scraping_basics_javascript/challenge/index.md). We've made a few small modifications to the project with the Apify SDK, but 99% of the code is still the same.
+In this course, we'll be working out of the Amazon scraper project from the **Web scraping basics for JavaScript devs** course. If you haven't already built that project, you can do it in three short lessons [here](../../webscraping/scraping_basics_javascript/challenge/index.md). We've made a few small modifications to the project with the Apify SDK, but 99% of the code is still the same.
 
 Take another look at the files within your Amazon scraper project. You'll notice that there is a **Dockerfile**. Every single Actor has a Dockerfile (the Actor's **Image**) which tells Docker how to spin up a container on the Apify platform which can successfully run the Actor's code. "Apify Actors" is a serverless platform that runs multiple Docker containers. For a deeper understanding of Actor Dockerfiles, refer to the [Apify Actor Dockerfile docs](/sdk/js/docs/guides/docker-images#example-dockerfile).
 
@@ -41,7 +41,7 @@ Prior to moving forward, please read over these resources:
 
 ## Our task {#our-task}
 
-In this task, we'll be building on top of what we already created in the [Web scraping for beginners](/academy/web-scraping-for-beginners/challenge) course's final challenge, so keep those files safe!
+In this task, we'll be building on top of what we already created in the [Web scraping basics for JavaScript devs](/academy/web-scraping-for-beginners/challenge) course's final challenge, so keep those files safe!
 
 Once our Amazon Actor has completed its run, we will, rather than sending an email to ourselves, call an Actor through a webhook. The Actor called will be a new Actor that we will create together, which will take the dataset ID as input, then subsequently filter through all of the results and return only the cheapest one for each product. All of the results of the Actor will be pushed to its default dataset.
 

--- a/sources/academy/platform/expert_scraping_with_apify/index.md
+++ b/sources/academy/platform/expert_scraping_with_apify/index.md
@@ -18,7 +18,7 @@ This course will teach you the nitty gritty of what it takes to build pro-level 
 
 Before developing a pro-level Apify scraper, there are some important things you should have at least a bit of knowledge about (knowing the basics of each is enough to continue through this section), as well as some things that you should have installed on your system.
 
-> If you've already gone through the [Web scraping for beginners course](../../webscraping/scraping_basics_javascript/index.md) and the first courses of the [Apify platform category](../apify_platform.md), you will be more than well equipped to continue on with the lessons in this course.
+> If you've already gone through the [Web scraping basics for JavaScript devs](../../webscraping/scraping_basics_javascript/index.md) and the first courses of the [Apify platform category](../apify_platform.md), you will be more than well equipped to continue on with the lessons in this course.
 
 <!-- ### Puppeteer/Playwright {#puppeteer-playwright}
 
@@ -26,7 +26,7 @@ Before developing a pro-level Apify scraper, there are some important things you
 
 ### Crawlee, Apify SDK, and the Apify CLI {#crawlee-apify-sdk-and-cli}
 
-If you're feeling ambitious, you don't need to have any prior experience with Crawlee to get started with this course; however, at least 5–10 minutes of exposure is recommended. If you haven't yet tried out Crawlee, you can refer to [this lesson](../../webscraping/scraping_basics_javascript/crawling/pro_scraping.md) in the **Web scraping for beginners** course (and ideally follow along). To familiarize yourself with the Apify SDK, you can refer to the [Apify Platform](../apify_platform.md) category.
+If you're feeling ambitious, you don't need to have any prior experience with Crawlee to get started with this course; however, at least 5–10 minutes of exposure is recommended. If you haven't yet tried out Crawlee, you can refer to [this lesson](../../webscraping/scraping_basics_javascript/crawling/pro_scraping.md) in the **Web scraping basics for JavaScript devs** course (and ideally follow along). To familiarize yourself with the Apify SDK, you can refer to the [Apify Platform](../apify_platform.md) category.
 
 The Apify CLI will play a core role in the running and testing of the Actor you will build, so if you haven't gotten it installed already, please refer to [this short lesson](../../glossary/tools/apify_cli.md).
 

--- a/sources/academy/webscraping/advanced_web_scraping/crawling/sitemaps-vs-search.md
+++ b/sources/academy/webscraping/advanced_web_scraping/crawling/sitemaps-vs-search.md
@@ -1,11 +1,11 @@
 ---
 title: Sitemaps vs search
-description: Learn how to extract all of a website's listings even if they limit the number of results pages. 
+description: Learn how to extract all of a website's listings even if they limit the number of results pages.
 sidebar_position: 1
 slug: /advanced-web-scraping/crawling/sitemaps-vs-search
 ---
 
-The core crawling problem comes to down to ensuring that we reliably find all detail pages on the target website or inside its categories. This is trivial for small sites. We just open the home page or category pages and paginate to the end as we did in the [Web Scraping for Beginners course](/academy/web-scraping-for-beginners).
+The core crawling problem comes to down to ensuring that we reliably find all detail pages on the target website or inside its categories. This is trivial for small sites. We just open the home page or category pages and paginate to the end as we did in the [Web scraping basics for JavaScript devs](/academy/web-scraping-for-beginners) course.
 
 Unfortunately, _most modern websites restrict pagination_ only to somewhere between 1 and 10,000 products. Solving this problem might seem relatively straightforward at first but there are multiple hurdles that we will explore in this lesson.
 

--- a/sources/academy/webscraping/advanced_web_scraping/index.md
+++ b/sources/academy/webscraping/advanced_web_scraping/index.md
@@ -6,7 +6,7 @@ category: web scraping & automation
 slug: /advanced-web-scraping
 ---
 
-In [Web scraping for beginners](/academy/web-scraping-for-beginners) course, we have learned the necessary basics required to create a scraper. In the following courses, we learned more about specific practices and techniques that will help us to solve most of the problems we will face.
+In the [Web scraping basics for JavaScript devs](/academy/web-scraping-for-beginners) course, we have learned the necessary basics required to create a scraper. In the following courses, we learned more about specific practices and techniques that will help us to solve most of the problems we will face.
 
 In this course, we will take all of that knowledge, add a few more advanced concepts, and apply them to learn how to build a production-ready web scraper.
 

--- a/sources/academy/webscraping/anti_scraping/mitigation/using_proxies.md
+++ b/sources/academy/webscraping/anti_scraping/mitigation/using_proxies.md
@@ -11,13 +11,13 @@ slug: /anti-scraping/mitigation/using-proxies
 
 ---
 
-In the [**Web scraping for beginners**](../../scraping_basics_javascript/crawling/pro_scraping.md) course, we learned about the power of Crawlee, and how it can streamline the development process of web crawlers. You've already seen how powerful the `crawlee` package is; however, what you've been exposed to thus far is only the tip of the iceberg.
+In the [**Web scraping basics for JavaScript devs**](../../scraping_basics_javascript/crawling/pro_scraping.md) course, we learned about the power of Crawlee, and how it can streamline the development process of web crawlers. You've already seen how powerful the `crawlee` package is; however, what you've been exposed to thus far is only the tip of the iceberg.
 
 Because proxies are so widely used in the scraping world, Crawlee has built-in features for implementing them in an effective way. One of the main functionalities that comes baked into Crawlee is proxy rotation, which is when each request is sent through a different proxy from a proxy pool.
 
 ## Implementing proxies in a scraper {#implementing-proxies}
 
-Let's borrow some scraper code from the end of the [pro-scraping](../../scraping_basics_javascript/crawling/pro_scraping.md) lesson in our **Web Scraping for Beginners** course and paste it into a new file called **proxies.js**. This code enqueues all of the product links on [demo-webstore.apify.org](https://demo-webstore.apify.org)'s on-sale page, then makes a request to each product page and scrapes data about each one:
+Let's borrow some scraper code from the end of the [pro-scraping](../../scraping_basics_javascript/crawling/pro_scraping.md) lesson in our **Web scraping basics for JavaScript devs** course and paste it into a new file called **proxies.js**. This code enqueues all of the product links on [demo-webstore.apify.org](https://demo-webstore.apify.org)'s on-sale page, then makes a request to each product page and scrapes data about each one:
 
 ```js
 // crawlee.js

--- a/sources/academy/webscraping/puppeteer_playwright/index.md
+++ b/sources/academy/webscraping/puppeteer_playwright/index.md
@@ -63,7 +63,7 @@ npm install puppeteer
 </TabItem>
 </Tabs>
 
-> For a more in-depth guide on how to set up the basic environment we'll be using in this tutorial, check out the [**Computer preparation**](../scraping_basics_javascript/data_extraction/computer_preparation.md) lesson in the **Web scraping for beginners** course
+> For a more in-depth guide on how to set up the basic environment we'll be using in this tutorial, check out the [**Computer preparation**](../scraping_basics_javascript/data_extraction/computer_preparation.md) lesson in the **Web scraping basics for JavaScript devs** course
 
 ## Course overview {#course-overview}
 

--- a/sources/academy/webscraping/puppeteer_playwright/page/interacting_with_a_page.md
+++ b/sources/academy/webscraping/puppeteer_playwright/page/interacting_with_a_page.md
@@ -55,7 +55,7 @@ With `page.click()`, Puppeteer and Playwright actually drag the mouse and click,
 
 Notice that in the Playwright example, we are using a different selector than in the Puppeteer example. This is because Playwright supports [many custom CSS selectors](https://playwright.dev/docs/other-locators#css-elements-matching-one-of-the-conditions), such as the **has-text** pseudo class. As a rule of thumb, using text selectors is much more preferable to using regular selectors, as they are much less likely to break. If Google makes the sibling above the **Accept all** button a `<div>` element instead of a `<button>` element, our `button + button` selector will break. However, the button will always have the text **Accept all**; therefore, `button:has-text("Accept all")` is more reliable.
 
-> If you're not already familiar with CSS selectors and how to find them, we recommend referring to [this lesson](../../scraping_basics_javascript/data_extraction/using_devtools.md) in the **Web scraping for beginners** course.
+> If you're not already familiar with CSS selectors and how to find them, we recommend referring to [this lesson](../../scraping_basics_javascript/data_extraction/using_devtools.md) in the **Web scraping basics for JavaScript devs** course.
 
 Then, we can type some text into an input field `<textarea>` with `page.type()`; passing a CSS selector as the first, and the string to input as the second parameter:
 

--- a/sources/academy/webscraping/scraping_basics_javascript/challenge/modularity.md
+++ b/sources/academy/webscraping/scraping_basics_javascript/challenge/modularity.md
@@ -123,7 +123,7 @@ Then, the labels can be used by importing `labels` and accessing `labels.START`,
 
 This is not necessary, but it is best practice, as it can prevent dumb typos that can cause nasty bugs 🐞 For the rest of this lesson, all of the examples using labels will be using the imported versions.
 
-> If you haven't already read the **Best practices** lesson in the **Web scraping for beginners** course, please [give it a read](../best_practices.md).
+> If you haven't already read the **Best practices** lesson in the **Web scraping basics for JavaScript devs** course, please [give it a read](../best_practices.md).
 
 ## Next up {#next}
 

--- a/sources/academy/webscraping/scraping_basics_javascript/challenge/scraping_amazon.md
+++ b/sources/academy/webscraping/scraping_basics_javascript/challenge/scraping_amazon.md
@@ -214,4 +214,4 @@ log.info('Crawl finished.');
 
 Nice work! You've officially built your first scraper with Crawlee! You're now ready to take on the rest of the Apify Academy with confidence.
 
-For now, this is the last section of the **Web scraping for beginners** course. If you want to learn more about web scraping, we recommend checking venturing out and following the other lessons in the Academy. We will keep updating the Academy with more content regularly until we cover all the advanced and expert topics we promised at the beginning.
+For now, this is the last section of the **Web scraping basics for JavaScript devs** course. If you want to learn more about web scraping, we recommend checking venturing out and following the other lessons in the Academy. We will keep updating the Academy with more content regularly until we cover all the advanced and expert topics we promised at the beginning.

--- a/sources/academy/webscraping/scraping_basics_javascript/crawling/exporting_data.md
+++ b/sources/academy/webscraping/scraping_basics_javascript/crawling/exporting_data.md
@@ -109,4 +109,4 @@ await Dataset.exportToCSV('results');
 
 ## Next up {#next}
 
-And this is it for the [**Basics of crawling**](./index.md) section of the [**Web scraping for beginners**](../index.md) course. If you want to learn more, test your knowledge of the methods and concepts you learned in this course by moving forward with the [**challenge**](../challenge/index.md).
+And this is it for the [**Basics of crawling**](./index.md) section of the [**Web scraping basics for JavaScript devs**](../index.md) course. If you want to learn more, test your knowledge of the methods and concepts you learned in this course by moving forward with the [**challenge**](../challenge/index.md).

--- a/sources/academy/webscraping/scraping_basics_javascript/crawling/index.md
+++ b/sources/academy/webscraping/scraping_basics_javascript/crawling/index.md
@@ -12,7 +12,7 @@ slug: /web-scraping-for-beginners/crawling
 
 ---
 
-Welcome to the second section of our **Web scraping for beginners** course. In the [Basics of data extraction](../data_extraction/index.md) section, we learned how to extract data from a web page. Specifically, a template Shopify site called [Warehouse store](https://warehouse-theme-metal.myshopify.com/).
+Welcome to the second section of our **Web scraping basics for JavaScript devs** course. In the [Basics of data extraction](../data_extraction/index.md) section, we learned how to extract data from a web page. Specifically, a template Shopify site called [Warehouse store](https://warehouse-theme-metal.myshopify.com/).
 
 ![on-sale category of Warehouse store](./images/warehouse-store.png)
 

--- a/sources/academy/webscraping/scraping_basics_javascript/crawling/recap_extraction_basics.md
+++ b/sources/academy/webscraping/scraping_basics_javascript/crawling/recap_extraction_basics.md
@@ -11,7 +11,7 @@ slug: /web-scraping-for-beginners/crawling/recap-extraction-basics
 
 ---
 
-We finished off the [first section](../data_extraction/index.md) of the _Web Scraping for Beginners_ course by creating a web scraper in Node.js. The scraper collected all the on-sale products from [Warehouse store](https://warehouse-theme-metal.myshopify.com/collections/sales). Let's see the code with some comments added.
+We finished off the [first section](../data_extraction/index.md) of the _Web scraping basics for JavaScript devs_ course by creating a web scraper in Node.js. The scraper collected all the on-sale products from [Warehouse store](https://warehouse-theme-metal.myshopify.com/collections/sales). Let's see the code with some comments added.
 
 ```js
 // First, we imported all the libraries we needed to

--- a/sources/academy/webscraping/scraping_basics_javascript/data_extraction/node_continued.md
+++ b/sources/academy/webscraping/scraping_basics_javascript/data_extraction/node_continued.md
@@ -164,7 +164,7 @@ After running the code, you will see this output in your terminal:
 ];
 ```
 
-Congratulations! You completed the **Basics of data extraction** section of the Web scraping for beginners course. A quick recap of what you learned:
+Congratulations! You completed the **Basics of data extraction** section of the Web scraping basics for JavaScript devs course. A quick recap of what you learned:
 
 1. The basic terminology around web scraping, crawling, HTML, CSS and JavaScript.
 2. How to use browser DevTools and Console to inspect web pages and manipulate them using CSS and JavaScript.

--- a/sources/academy/webscraping/scraping_basics_javascript/data_extraction/save_to_csv.md
+++ b/sources/academy/webscraping/scraping_basics_javascript/data_extraction/save_to_csv.md
@@ -136,7 +136,7 @@ Finally, run it with `node main.js` in your terminal. After running it, you will
 
 ![Displaying CSV data in Google Sheets](./images/csv-data-in-sheets.png)
 
-This marks the end of the **Basics of data extraction** section of Web scraping for beginners. If you enjoyed the course, give us a thumbs up down below and if you're eager to learn more...
+This marks the end of the **Basics of data extraction** section of Web scraping basics for JavaScript devs. If you enjoyed the course, give us a thumbs up down below and if you're eager to learn more...
 
 ## Next up {#next}
 

--- a/sources/academy/webscraping/scraping_basics_javascript/index.md
+++ b/sources/academy/webscraping/scraping_basics_javascript/index.md
@@ -1,18 +1,18 @@
 ---
-title: Web scraping for beginners
+title: Web scraping basics for JavaScript devs
 description: Learn how to develop web scrapers with this comprehensive and practical course. Go from beginner to expert, all in one place.
 sidebar_position: 1
 category: web scraping & automation
 slug: /web-scraping-for-beginners
 ---
 
-# Web scraping for beginners {#welcome}
+# Web scraping basics for JavaScript devs {#welcome}
 
 **Learn how to develop web scrapers with this comprehensive and practical course. Go from beginner to expert, all in one place.**
 
 ---
 
-Welcome to **Web scraping for beginners**, a comprehensive, practical and long form web scraping course that will take you from an absolute beginner to a successful web scraper developer. If you're looking for a quick start, we recommend trying [this tutorial](https://blog.apify.com/web-scraping-javascript-nodejs/) instead.
+Welcome to **Web scraping basics for JavaScript devs**, a comprehensive, practical and long form web scraping course that will take you from an absolute beginner to a successful web scraper developer. If you're looking for a quick start, we recommend trying [this tutorial](https://blog.apify.com/web-scraping-javascript-nodejs/) instead.
 
 This course is made by [Apify](https://apify.com), the web scraping and automation platform, but we will use only open-source technologies throughout all academy lessons. This means that the skills you learn will be applicable to any scraping project, and you'll be able to run your scrapers on any computer. No Apify account needed.
 
@@ -30,9 +30,9 @@ Scraper development is a fun and challenging way to learn web development, web t
 
 When we set out to create the Academy, we wanted to build a complete guide to web scraping - a course that a beginner could use to create their first scraper, as well as a resource that professionals will continuously use to learn about advanced and niche web scraping techniques and technologies. All lessons include code examples and code-along exercises that you can use to immediately put your scraping skills into action.
 
-This is what you'll learn in the **Web scraping for beginners** course:
+This is what you'll learn in the **Web scraping basics for JavaScript devs** course:
 
-* [Web scraping for beginners](./index.md)
+* [Web scraping basics for JavaScript devs](./index.md)
   * [Basics of data extraction](./data_extraction/index.md)
   * [Basics of crawling](./crawling/index.md)
   * [Best practices](./best_practices.md)

--- a/sources/academy/webscraping/typescript/enums.md
+++ b/sources/academy/webscraping/typescript/enums.md
@@ -15,7 +15,7 @@ Enums are a nice feature offered by TypeScript that can be used to create automa
 
 ## Let's talk about constants {#lets-talk-about-constants}
 
-If you've followed along with any of the more advanced courses in the Apify academy, or at least read the [Best practices](../scraping_basics_javascript/best_practices.md) lesson in the **Web scraping for beginners** course, you'll definitely be familiar with the idea of constant variables. In a nutshell, we create constant variables for values that will never change, and will likely used in multiple places. The naming convention for constants is **ALL_CAPS_AND_UNDERSCORED**.
+If you've followed along with any of the more advanced courses in the Apify academy, or at least read the [Best practices](../scraping_basics_javascript/best_practices.md) lesson in the **Web scraping basics for JavaScript devs** course, you'll definitely be familiar with the idea of constant variables. In a nutshell, we create constant variables for values that will never change, and will likely used in multiple places. The naming convention for constants is **ALL_CAPS_AND_UNDERSCORED**.
 
 Here's an object of constant values that we've prepared for use within our project.
 


### PR DESCRIPTION
Rename the JS course from "Web scraping for beginners" to "Web scraping basics for JavaScript devs", so that it is aligned with the Python course and the design described in https://github.com/apify/apify-docs/issues/1015

This change attempts to isolate the change to the course name only. The name appears at many places which could be improved or which are questionable, but this change is not intended to be a complete overhaul of the course.