### PR TITLE
fix: exercises using the F1 website got outdated

### DIFF
--- a/sources/academy/webscraping/scraping_basics_python/05_parsing_html.md
+++ b/sources/academy/webscraping/scraping_basics_python/05_parsing_html.md
@@ -132,7 +132,7 @@ https://www.formula1.com/en/teams
 
   html_code = response.text
   soup = BeautifulSoup(html_code, "html.parser")
-  print(len(soup.select(".outline")))
+  print(len(soup.select(".group")))
   ```
 
 </details>
@@ -154,7 +154,7 @@ Use the same URL as in the previous exercise, but this time print a total count 
 
   html_code = response.text
   soup = BeautifulSoup(html_code, "html.parser")
-  print(len(soup.select(".f1-grid")))
+  print(len(soup.select(".f1-team-driver-name")))
   ```
 
 </details>


### PR DESCRIPTION
Thanks @rizkil for reporting the issue! In the future this should be prevented by https://github.com/apify/apify-docs/issues/1243. I checked other exercises and I couldn't find any other which are based on the formula1.com website, so this is hopefully the only one which got broken.