### PR TITLE
feat(api): add collection and prefix query params to get list of kv store keys

### DIFF
--- a/apify-api/openapi/paths/key-value-stores/key-value-stores@{storeId}@keys.yaml
+++ b/apify-api/openapi/paths/key-value-stores/key-value-stores@{storeId}@keys.yaml
@@ -38,6 +38,19 @@ get:
         type: number
         format: double
         example: 100
+    - name: collection
+      in: query
+      description: Limit the results to keys that belong to a specific collection from the key-value store schema.
+        The key-value store need to have a schema defined for this parameter to work.
+      schema:
+        type: string
+        example: postImages
+    - name: prefix
+      in: query
+      description: Limit the results to keys that start with a specific prefix.
+      schema:
+        type: string
+        example: post-images-
   responses:
     '200':
       description: ''


### PR DESCRIPTION
Document new query params for `GET: https://api.apify.com/v2/key-value-stores/storeId/keys`: https://github.com/apify/apify-core/pull/20726

Based on https://github.com/apify/actor-whitepaper/blob/master/pages/KEY_VALUE_STORE_SCHEMA.md#api-implications