### PR TITLE
feat: publish the Python course on the Academy homepage

### DIFF
--- a/sources/academy/homepage_content.json
+++ b/sources/academy/homepage_content.json
@@ -3,7 +3,13 @@
         {
             "title": "Web scraping basics for JavaScript devs",
             "link": "academy/web-scraping-for-beginners",
-            "description": "Learn how to develop web scrapers on your own computer with open-source tools. This web scraping course teaches you all the basics a scraper developer needs to know.",
+            "description": "Learn how to use JavaScript to extract information from websites in this practical course, starting from the absolute basics.",
+            "imageUrl": "/img/academy/intro.svg"
+        },
+        {
+            "title": "Web scraping basics for Python devs",
+            "link": "academy/scraping-basics-python",
+            "description": "Learn how to use Python to extract information from websites in this practical course, starting from the absolute basics.",
             "imageUrl": "/img/academy/intro.svg"
         },
         {

--- a/sources/academy/webscraping/anti_scraping/index.md
+++ b/sources/academy/webscraping/anti_scraping/index.md
@@ -1,7 +1,7 @@
 ---
 title: Anti-scraping protections
 description: Understand the various anti-scraping measures different sites use to prevent bots from accessing them, and how to appear more human to fix these issues.
-sidebar_position: 4
+sidebar_position: 5
 category: web scraping & automation
 slug: /anti-scraping
 ---

--- a/sources/academy/webscraping/api_scraping/index.md
+++ b/sources/academy/webscraping/api_scraping/index.md
@@ -1,7 +1,7 @@
 ---
 title: API scraping
 description: Learn all about how the professionals scrape various types of APIs with various configurations, parameters, and requirements.
-sidebar_position: 3
+sidebar_position: 5
 category: web scraping & automation
 slug: /api-scraping
 ---

--- a/sources/academy/webscraping/api_scraping/index.md
+++ b/sources/academy/webscraping/api_scraping/index.md
@@ -1,7 +1,7 @@
 ---
 title: API scraping
 description: Learn all about how the professionals scrape various types of APIs with various configurations, parameters, and requirements.
-sidebar_position: 5
+sidebar_position: 4
 category: web scraping & automation
 slug: /api-scraping
 ---

--- a/sources/academy/webscraping/puppeteer_playwright/index.md
+++ b/sources/academy/webscraping/puppeteer_playwright/index.md
@@ -1,7 +1,7 @@
 ---
 title: Puppeteer & Playwright
 description: Learn in-depth how to use two of the most popular Node.js libraries for controlling a headless browser - Puppeteer and Playwright.
-sidebar_position: 2
+sidebar_position: 3
 category: web scraping & automation
 slug: /puppeteer-playwright
 ---

--- a/sources/academy/webscraping/scraping_basics_python/index.md
+++ b/sources/academy/webscraping/scraping_basics_python/index.md
@@ -1,7 +1,7 @@
 ---
 title: Web scraping basics for Python devs
 description: Learn how to use Python to extract information from websites in this practical course, starting from the absolute basics.
-sidebar_position: 10
+sidebar_position: 2
 category: web scraping & automation
 slug: /scraping-basics-python
 ---


### PR DESCRIPTION
Fixes https://github.com/apify/apify-docs/issues/1319! 🎉 Known issues:

- The homepage image for the course card is the same as for the JS course. I think later on we should ask a designer to provide new images which would distinguish the JS and Py course.
- https://github.com/apify/apify-docs/pull/1568 - TBD in parallel with this PR
- https://github.com/apify/apify-docs/issues/1570 - not essential, can be simply added later on
- https://github.com/apify/apify-docs/issues/1243 - not a priority right now

### Preview

![Screenshot 2025-05-07 at 16-56-59 Web Scraping Academy Academy Apify Documentation](https://github.com/user-attachments/assets/af290235-8a40-42f8-9790-bb3729c1a951)

