### PR TITLE
docs: document `raw` query param in `logs`

### DIFF
--- a/apify-api/openapi/paths/logs/logs@{buildOrRunId}.yaml
+++ b/apify-api/openapi/paths/logs/logs@{buildOrRunId}.yaml
@@ -40,6 +40,17 @@ get:
       schema:
         type: boolean
         example: false
+    - name: raw
+      in: query
+      description: |
+        If `true` or `1`, the logs will be kept verbatim. By default, the API removes 
+        ANSI escape codes from the logs, keeping only printable characters.
+      required: false
+      style: form
+      explode: true
+      schema:
+        type: boolean
+        example: false
   responses:
     '200':
       description: ''


### PR DESCRIPTION
Documents the `raw` query param from the API's [log](https://github.com/apify/apify-core/blob/94b7ce60a0850fa4d9bd62343bebec86bea5a796/src/api/src/routes/logs/log.js#L30) function.