### PR TITLE
docs: add webServerSchema field in actor definition

### DIFF
--- a/sources/platform/actors/development/actor_definition/actor_json.md
+++ b/sources/platform/actors/development/actor_definition/actor_json.md
@@ -37,7 +37,8 @@ import TabItem from '@theme/TabItem';
     "input": "./input_schema.json",
     "storages": {
         "dataset": "./dataset_schema.json"
-    }
+    },
+    "webServerSchema": "./web_server_openapi.json"
 }
 ```
 
@@ -79,3 +80,4 @@ Actor `name`, `version`, `buildTag`, and `environmentVariables` are currently on
 | `minMemoryMbytes` | Optional | Specifies the minimum amount of memory in megabytes required by the Actor to run. Requires an _integer_ value. If both `minMemoryMbytes` and `maxMemoryMbytes` are set, then `minMemoryMbytes` must be equal or lower than `maxMemoryMbytes`. Refer to the [Usage and resources](https://docs.apify.com/platform/actors/running/usage-and-resources#memory) for more details about memory allocation. |
 | `maxMemoryMbytes` | Optional | Specifies the maximum amount of memory in megabytes required by the Actor to run. It can be used to control the costs of run, especially when developing pay per result Actors. Requires an _integer_ value. Refer to the [Usage and resources](https://docs.apify.com/platform/actors/running/usage-and-resources#memory) for more details about memory allocation. |
 | `usesStandbyMode` | Optional | Boolean specifying whether the Actor will have [Standby mode](../programming_interface/actor_standby.md) enabled. |
+| `webServerSchema` | Optional | Defines an OpenAPI v3 schema for the web server running in the Actor. This can be either an embedded object or a path to a JSON schema file. Use this when your Actor starts its own HTTP server and you want to describe its interface. |


### PR DESCRIPTION
Document the `webServerSchema` field in `actor.json`:

<img width="825" alt="Screenshot 2025-05-16 at 13 14 39" src="https://github.com/user-attachments/assets/ffc3b084-f91a-4889-83bb-97d34164b3f0" />
<img width="808" alt="Screenshot 2025-05-16 at 13 14 53" src="https://github.com/user-attachments/assets/b0c99cf7-4259-4109-bd0b-cf1628a769ba" />
