### PR TITLE
docs: add additionalProperties to input schema specification

### DIFF
--- a/sources/platform/actors/development/actor_definition/input_schema/specification.md
+++ b/sources/platform/actors/development/actor_definition/input_schema/specification.md
@@ -106,6 +106,7 @@ If you switch the input to the **JSON** display using the toggle, then you will 
 | `schemaVersion` | Integer | Yes | The version of the input schema <br/>specification against which <br/>your schema is written. <br/>Currently, only version `1` is out. |
 | `properties` | Object | Yes | This is an object mapping each field key <br/>to its specification. |
 | `required` | String | No | An array of field keys that are required. |
+| `additionalProperties` | Boolean | No | Controls handling of extra properties whose names are not listed in the `properties` field. By default any additional properties are allowed. Setting this to `false` means no additional properties will be allowed |
 
 :::note Input schema differences
 

--- a/sources/platform/actors/development/actor_definition/input_schema/specification.md
+++ b/sources/platform/actors/development/actor_definition/input_schema/specification.md
@@ -106,7 +106,7 @@ If you switch the input to the **JSON** display using the toggle, then you will 
 | `schemaVersion` | Integer | Yes | The version of the input schema <br/>specification against which <br/>your schema is written. <br/>Currently, only version `1` is out. |
 | `properties` | Object | Yes | This is an object mapping each field key <br/>to its specification. |
 | `required` | String | No | An array of field keys that are required. |
-| `additionalProperties` | Boolean | No | Controls handling of extra properties whose names are not listed in the `properties` field. By default any additional properties are allowed. Setting this to `false` means no additional properties will be allowed |
+| `additionalProperties` | Boolean | No | Controls if properties not listed in `properties` are allowed. Defaults to `true`. <br/>Set to `false` to make requests with extra properties fail. |
 
 :::note Input schema differences
 


### PR DESCRIPTION
The `additionalProperties` is completely missing in the input schema specification.
![Screenshot 2025-06-11 at 14 28 46](https://github.com/user-attachments/assets/e2ef9a46-d621-4690-8114-6d563987d6c2)
