### PR TITLE
feat: Add configurable search engine indexing behavior [internal]

### DIFF
--- a/apify-docs-theme/src/config.js
+++ b/apify-docs-theme/src/config.js
@@ -10,7 +10,7 @@ if (process.env.LOCALHOST) {
     absoluteUrl = process.env.APIFY_DOCS_ABSOLUTE_URL;
 }
 
-const noIndex = ['true', '1'].includes(process.env.NO_INDEX ?? '')
+const noIndex = ['true', '1'].includes(process.env.NO_INDEX ?? '');
 
 const themeConfig = {
     docs: {

--- a/apify-docs-theme/src/config.js
+++ b/apify-docs-theme/src/config.js
@@ -10,10 +10,7 @@ if (process.env.LOCALHOST) {
     absoluteUrl = process.env.APIFY_DOCS_ABSOLUTE_URL;
 }
 
-let noIndex = false;
-if (process.env.NO_INDEX) {
-    noIndex = [true, 'true', 1, '1'].includes(process.env.NO_INDEX);
-}
+const noIndex = ['true', '1'].includes(process.env.NO_INDEX ?? '')
 
 const themeConfig = {
     docs: {

--- a/apify-docs-theme/src/config.js
+++ b/apify-docs-theme/src/config.js
@@ -10,6 +10,11 @@ if (process.env.LOCALHOST) {
     absoluteUrl = process.env.APIFY_DOCS_ABSOLUTE_URL;
 }
 
+let noIndex = false;
+if (process.env.NO_INDEX) {
+    noIndex = [true, 'true', 1, '1'].includes(process.env.NO_INDEX);
+}
+
 const themeConfig = {
     docs: {
         versionPersistence: 'localStorage',
@@ -313,4 +318,5 @@ module.exports = {
     themeConfig,
     plugins,
     absoluteUrl,
+    noIndex,
 };

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -12,6 +12,7 @@ module.exports = {
     title: 'Apify Documentation',
     tagline: 'Apify Documentation',
     url: config.absoluteUrl,
+    noIndex: config.noIndex,
     baseUrl: '/',
     trailingSlash: false,
     organizationName: 'apify',


### PR DESCRIPTION
If the `NO_INDEX` environment variable is used during build, the [`noIndex` Docusaurus config](https://docusaurus.io/docs/api/docusaurus-config#noIndex) will be used and the docs will be built so that they're not indexable by search engines.