### PR TITLE
fix: re-order JSON and CSV in Python lessons

### DIFF
--- a/sources/academy/webscraping/scraping_basics_javascript2/09_getting_links.md
+++ b/sources/academy/webscraping/scraping_basics_javascript2/09_getting_links.md
@@ -35,8 +35,8 @@ Over the course of the previous lessons, the code of our program grew to almost 
 import httpx
 from bs4 import BeautifulSoup
 from decimal import Decimal
-import csv
 import json
+import csv
 
 url = "https://warehouse-theme-metal.myshopify.com/collections/sales"
 response = httpx.get(url)
@@ -153,8 +153,8 @@ Now let's put it all together:
 import httpx
 from bs4 import BeautifulSoup
 from decimal import Decimal
-import csv
 import json
+import csv
 
 def download(url):
     response = httpx.get(url)
@@ -279,8 +279,8 @@ Browsers reading the HTML know the base address and automatically resolve such l
 import httpx
 from bs4 import BeautifulSoup
 from decimal import Decimal
-import csv
 import json
+import csv
 # highlight-next-line
 from urllib.parse import urljoin
 ```

--- a/sources/academy/webscraping/scraping_basics_javascript2/10_crawling.md
+++ b/sources/academy/webscraping/scraping_basics_javascript2/10_crawling.md
@@ -20,8 +20,8 @@ Thanks to the refactoring, we have functions ready for each of the tasks, so we 
 import httpx
 from bs4 import BeautifulSoup
 from decimal import Decimal
-import csv
 import json
+import csv
 from urllib.parse import urljoin
 
 def download(url):

--- a/sources/academy/webscraping/scraping_basics_javascript2/11_scraping_variants.md
+++ b/sources/academy/webscraping/scraping_basics_javascript2/11_scraping_variants.md
@@ -193,8 +193,8 @@ Now, if we use our new function, we should finally get a program that can scrape
 import httpx
 from bs4 import BeautifulSoup
 from decimal import Decimal
-import csv
 import json
+import csv
 from urllib.parse import urljoin
 
 def download(url):

--- a/sources/academy/webscraping/scraping_basics_python/08_saving_data.md
+++ b/sources/academy/webscraping/scraping_basics_python/08_saving_data.md
@@ -93,7 +93,7 @@ import csv
 import json
 ```
 
-Next, instead of printing the data, we'll finish the program by exporting it to JSON. Replace `print(data)` with the following:
+Next, instead of printing the data, we'll finish the program by exporting it to JSON. Let's replace the line `print(data)` with the following:
 
 ```py
 with open("products.json", "w") as file:
@@ -167,9 +167,9 @@ Alice,24,"kickbox, Python"
 Bob,42,"reading, TypeScript"
 ```
 
-In the CSV format, if values contain commas, we should enclose them in quotes. You can see that the writer automatically handled this.
+In the CSV format, if a value contains commas, we should enclose it in quotes. When we open the file in a text editor of our choice, we can see that the writer automatically handled this.
 
-When browsing the directory on macOS, we can see a nice preview of the file's contents, which proves that the file is correct and that other programs can read it as well. If you're using a different operating system, try opening the file with any spreadsheet program you have.
+When browsing the directory on macOS, we can see a nice preview of the file's contents, which proves that the file is correct and that other programs can read it. If you're using a different operating system, try opening the file with any spreadsheet program you have.
 
 ![CSV example preview](images/csv-example.png)
 
@@ -183,7 +183,7 @@ from decimal import Decimal
 import csv
 ```
 
-Next, let’s append one more export to end of the source code of our scraper:
+Next, let's add one more data export to end of the source code of our scraper:
 
 ```py
 with open("products.csv", "w") as file:
@@ -193,7 +193,7 @@ with open("products.csv", "w") as file:
         writer.writerow(row)
 ```
 
-Now the program should work as expected, producing a CSV file with the following content:
+The program should now also produce a CSV file with the following content:
 
 ![CSV preview](images/csv.png)
 
@@ -203,7 +203,7 @@ We've built a Python application that downloads a product listing, parses the da
 
 ## Exercises
 
-In this lesson, you learned how to create export files in two formats. The following challenges are designed to help you empathize with the people who'd be working with them.
+In this lesson, we created export files in two formats. The following challenges are designed to help you empathize with the people who'd be working with them.
 
 ### Process your JSON
 

--- a/sources/academy/webscraping/scraping_basics_python/08_saving_data.md
+++ b/sources/academy/webscraping/scraping_basics_python/08_saving_data.md
@@ -88,7 +88,6 @@ In Python, we can read and write JSON using the [`json`](https://docs.python.org
 import httpx
 from bs4 import BeautifulSoup
 from decimal import Decimal
-import csv
 # highlight-next-line
 import json
 ```
@@ -179,6 +178,7 @@ Now that's nice, but we didn't want Alice, Bob, kickbox, or TypeScript. What we 
 import httpx
 from bs4 import BeautifulSoup
 from decimal import Decimal
+import json
 # highlight-next-line
 import csv
 ```
@@ -186,6 +186,14 @@ import csv
 Next, let's add one more data export to end of the source code of our scraper:
 
 ```py
+def serialize(obj):
+    if isinstance(obj, Decimal):
+        return str(obj)
+    raise TypeError("Object not JSON serializable")
+
+with open("products.json", "w") as file:
+    json.dump(data, file, default=serialize)
+
 with open("products.csv", "w") as file:
     writer = csv.DictWriter(file, fieldnames=["title", "min_price", "price"])
     writer.writeheader()

--- a/sources/academy/webscraping/scraping_basics_python/08_saving_data.md
+++ b/sources/academy/webscraping/scraping_basics_python/08_saving_data.md
@@ -78,11 +78,76 @@ If you find the complex data structures printed by `print()` difficult to read, 
 
 :::
 
+## Saving data as JSON
+
+The JSON format is popular primarily among developers. We use it for storing data, configuration files, or as a way to transfer data between programs (e.g., APIs). Its origin stems from the syntax of objects in the JavaScript programming language, which is similar to the syntax of Python dictionaries.
+
+In Python, we can read and write JSON using the [`json`](https://docs.python.org/3/library/json.html) standard library module. We'll begin with imports:
+
+```py
+import httpx
+from bs4 import BeautifulSoup
+from decimal import Decimal
+import csv
+# highlight-next-line
+import json
+```
+
+Next, instead of printing the data, we'll finish the program by exporting it to JSON. Replace `print(data)` with the following:
+
+```py
+with open("products.json", "w") as file:
+    json.dump(data, file)
+```
+
+That's it! If we run the program now, it should also create a `products.json` file in the current working directory:
+
+```text
+$ python main.py
+Traceback (most recent call last):
+  ...
+    raise TypeError(f'Object of type {o.__class__.__name__} '
+TypeError: Object of type Decimal is not JSON serializable
+```
+
+Ouch! JSON supports integers and floating-point numbers, but there's no guidance on how to handle `Decimal`. To maintain precision, it's common to store monetary values as strings in JSON files. But this is a convention, not a standard, so we need to handle it manually. We'll pass a custom function to `json.dump()` to serialize objects that it can't handle directly:
+
+```py
+def serialize(obj):
+    if isinstance(obj, Decimal):
+        return str(obj)
+    raise TypeError("Object not JSON serializable")
+
+with open("products.json", "w") as file:
+    json.dump(data, file, default=serialize)
+```
+
+If we run our scraper now, it won't display any output, but it will create a `products.json` file in the current working directory, which contains all the data about the listed products:
+
+<!-- eslint-skip -->
+```json title=products.json
+[{"title": "JBL Flip 4 Waterproof Portable Bluetooth Speaker", "min_price": "74.95", "price": "74.95"}, {"title": "Sony XBR-950G BRAVIA 4K HDR Ultra HD TV", "min_price": "1398.00", "price": null}, ...]
+```
+
+If you skim through the data, you'll notice that the `json.dump()` function handled some potential issues, such as escaping double quotes found in one of the titles by adding a backslash:
+
+```json
+{"title": "Sony SACS9 10\" Active Subwoofer", "min_price": "158.00", "price": "158.00"}
+```
+
+:::tip Pretty JSON
+
+While a compact JSON file without any whitespace is efficient for computers, it can be difficult for humans to read. You can pass `indent=2` to `json.dump()` for prettier output.
+
+Also, if your data contains non-English characters, set `ensure_ascii=False`. By default, Python encodes everything except [ASCII](https://en.wikipedia.org/wiki/ASCII), which means it would save [Bún bò Nam Bô](https://vi.wikipedia.org/wiki/B%C3%BAn_b%C3%B2_Nam_B%E1%BB%99) as `B\\u00fan b\\u00f2 Nam B\\u00f4`.
+
+:::
+
 ## Saving data as CSV
 
 The CSV format is popular among data analysts because a wide range of tools can import it, including spreadsheets apps like LibreOffice Calc, Microsoft Excel, Apple Numbers, and Google Sheets.
 
-In Python, it's convenient to read and write CSV files, thanks to the [`csv`](https://docs.python.org/3/library/csv.html) standard library module. First let's try something small in the Python's interactive REPL to familiarize ourselves with the basic usage:
+In Python, we can read and write CSV using the [`csv`](https://docs.python.org/3/library/csv.html) standard library module. First let's try something small in the Python's interactive REPL to familiarize ourselves with the basic usage:
 
 ```py
 >>> import csv
@@ -118,7 +183,7 @@ from decimal import Decimal
 import csv
 ```
 
-Next, instead of printing the data, we'll finish the program by exporting it to CSV. Replace `print(data)` with the following:
+Next, let’s append one more export to end of the source code of our scraper:
 
 ```py
 with open("products.csv", "w") as file:
@@ -128,74 +193,9 @@ with open("products.csv", "w") as file:
         writer.writerow(row)
 ```
 
-If we run our scraper now, it won't display any output, but it will create a `products.csv` file in the current working directory, which contains all the data about the listed products.
+Now the program should work as expected, producing a CSV file with the following content:
 
 ![CSV preview](images/csv.png)
-
-## Saving data as JSON
-
-The JSON format is popular primarily among developers. We use it for storing data, configuration files, or as a way to transfer data between programs (e.g., APIs). Its origin stems from the syntax of objects in the JavaScript programming language, which is similar to the syntax of Python dictionaries.
-
-In Python, there's a [`json`](https://docs.python.org/3/library/json.html) standard library module, which is so straightforward that we can start using it in our code right away. We'll need to begin with imports:
-
-```py
-import httpx
-from bs4 import BeautifulSoup
-from decimal import Decimal
-import csv
-# highlight-next-line
-import json
-```
-
-Next, let’s append one more export to end of the source code of our scraper:
-
-```py
-with open("products.json", "w") as file:
-    json.dump(data, file)
-```
-
-That’s it! If we run the program now, it should also create a `products.json` file in the current working directory:
-
-```text
-$ python main.py
-Traceback (most recent call last):
-  ...
-    raise TypeError(f'Object of type {o.__class__.__name__} '
-TypeError: Object of type Decimal is not JSON serializable
-```
-
-Ouch! JSON supports integers and floating-point numbers, but there's no guidance on how to handle `Decimal`. To maintain precision, it's common to store monetary values as strings in JSON files. But this is a convention, not a standard, so we need to handle it manually. We'll pass a custom function to `json.dump()` to serialize objects that it can't handle directly:
-
-```py
-def serialize(obj):
-    if isinstance(obj, Decimal):
-        return str(obj)
-    raise TypeError("Object not JSON serializable")
-
-with open("products.json", "w") as file:
-    json.dump(data, file, default=serialize)
-```
-
-Now the program should work as expected, producing a JSON file with the following content:
-
-<!-- eslint-skip -->
-```json title=products.json
-[{"title": "JBL Flip 4 Waterproof Portable Bluetooth Speaker", "min_price": "74.95", "price": "74.95"}, {"title": "Sony XBR-950G BRAVIA 4K HDR Ultra HD TV", "min_price": "1398.00", "price": null}, ...]
-```
-
-If you skim through the data, you'll notice that the `json.dump()` function handled some potential issues, such as escaping double quotes found in one of the titles by adding a backslash:
-
-```json
-{"title": "Sony SACS9 10\" Active Subwoofer", "min_price": "158.00", "price": "158.00"}
-```
-
-:::tip Pretty JSON
-
-While a compact JSON file without any whitespace is efficient for computers, it can be difficult for humans to read. You can pass `indent=2` to `json.dump()` for prettier output.
-
-Also, if your data contains non-English characters, set `ensure_ascii=False`. By default, Python encodes everything except [ASCII](https://en.wikipedia.org/wiki/ASCII), which means it would save [Bún bò Nam Bô](https://vi.wikipedia.org/wiki/B%C3%BAn_b%C3%B2_Nam_B%E1%BB%99) as `B\\u00fan b\\u00f2 Nam B\\u00f4`.
-
-:::
 
 We've built a Python application that downloads a product listing, parses the data, and saves it in a structured format for further use. But the data still has gaps: for some products, we only have the min price, not the actual prices. In the next lesson, we'll attempt to scrape more details from all the product pages.
 
@@ -204,23 +204,6 @@ We've built a Python application that downloads a product listing, parses the da
 ## Exercises
 
 In this lesson, you learned how to create export files in two formats. The following challenges are designed to help you empathize with the people who'd be working with them.
-
-### Process your CSV
-
-Open the `products.csv` file in a spreadsheet app. Use the app to find all products with a min price greater than $500.
-
-<details>
-  <summary>Solution</summary>
-
-  Let's use [Google Sheets](https://www.google.com/sheets/about/), which is free to use. After logging in with a Google account:
-
-  1. Go to **File > Import**, choose **Upload**, and select the file. Import the data using the default settings. You should see a table with all the data.
-  2. Select the header row. Go to **Data > Create filter**.
-  3. Use the filter icon that appears next to `min_price`. Choose **Filter by condition**, select **Greater than**, and enter **500** in the text field. Confirm the dialog. You should see only the filtered data.
-
-  ![CSV in Google Sheets](images/csv-sheets.png)
-
-</details>
 
 ### Process your JSON
 
@@ -241,5 +224,22 @@ Write a new Python program that reads `products.json`, finds all products with a
       if Decimal(product["min_price"]) > 500:
           pp(product)
   ```
+
+</details>
+
+### Process your CSV
+
+Open the `products.csv` file we created in the lesson using a spreadsheet application. Then, in the app, find all products with a min price greater than $500.
+
+<details>
+  <summary>Solution</summary>
+
+  Let's use [Google Sheets](https://www.google.com/sheets/about/), which is free to use. After logging in with a Google account:
+
+  1. Go to **File > Import**, choose **Upload**, and select the file. Import the data using the default settings. You should see a table with all the data.
+  2. Select the header row. Go to **Data > Create filter**.
+  3. Use the filter icon that appears next to `min_price`. Choose **Filter by condition**, select **Greater than**, and enter **500** in the text field. Confirm the dialog. You should see only the filtered data.
+
+  ![CSV in Google Sheets](images/csv-sheets.png)
 
 </details>

--- a/sources/academy/webscraping/scraping_basics_python/09_getting_links.md
+++ b/sources/academy/webscraping/scraping_basics_python/09_getting_links.md
@@ -34,8 +34,8 @@ Over the course of the previous lessons, the code of our program grew to almost 
 import httpx
 from bs4 import BeautifulSoup
 from decimal import Decimal
-import csv
 import json
+import csv
 
 url = "https://warehouse-theme-metal.myshopify.com/collections/sales"
 response = httpx.get(url)
@@ -65,12 +65,6 @@ for product in soup.select(".product-item"):
 
     data.append({"title": title, "min_price": min_price, "price": price})
 
-with open("products.csv", "w") as file:
-    writer = csv.DictWriter(file, fieldnames=["title", "min_price", "price"])
-    writer.writeheader()
-    for row in data:
-        writer.writerow(row)
-
 def serialize(obj):
     if isinstance(obj, Decimal):
         return str(obj)
@@ -78,6 +72,12 @@ def serialize(obj):
 
 with open("products.json", "w") as file:
     json.dump(data, file, default=serialize)
+
+with open("products.csv", "w") as file:
+    writer = csv.DictWriter(file, fieldnames=["title", "min_price", "price"])
+    writer.writeheader()
+    for row in data:
+        writer.writerow(row)
 ```
 
 Let's introduce several functions to make the whole thing easier to digest. First, we can turn the beginning of our program into this `download()` function, which takes a URL and returns a `BeautifulSoup` instance:
@@ -152,8 +152,8 @@ Now let's put it all together:
 import httpx
 from bs4 import BeautifulSoup
 from decimal import Decimal
-import csv
 import json
+import csv
 
 def download(url):
     response = httpx.get(url)
@@ -182,13 +182,6 @@ def parse_product(product):
 
     return {"title": title, "min_price": min_price, "price": price}
 
-def export_csv(file, data):
-    fieldnames = list(data[0].keys())
-    writer = csv.DictWriter(file, fieldnames=fieldnames)
-    writer.writeheader()
-    for row in data:
-        writer.writerow(row)
-
 def export_json(file, data):
     def serialize(obj):
         if isinstance(obj, Decimal):
@@ -196,6 +189,13 @@ def export_json(file, data):
         raise TypeError("Object not JSON serializable")
 
     json.dump(data, file, default=serialize, indent=2)
+
+def export_csv(file, data):
+    fieldnames = list(data[0].keys())
+    writer = csv.DictWriter(file, fieldnames=fieldnames)
+    writer.writeheader()
+    for row in data:
+        writer.writerow(row)
 
 listing_url = "https://warehouse-theme-metal.myshopify.com/collections/sales"
 listing_soup = download(listing_url)
@@ -205,11 +205,11 @@ for product in listing_soup.select(".product-item"):
     item = parse_product(product)
     data.append(item)
 
-with open("products.csv", "w") as file:
-    export_csv(file, data)
-
 with open("products.json", "w") as file:
     export_json(file, data)
+
+with open("products.csv", "w") as file:
+    export_csv(file, data)
 ```
 
 The program is much easier to read now. With the `parse_product()` function handy, we could also replace the convoluted loop with one that only takes up four lines of code.
@@ -278,8 +278,8 @@ Browsers reading the HTML know the base address and automatically resolve such l
 import httpx
 from bs4 import BeautifulSoup
 from decimal import Decimal
-import csv
 import json
+import csv
 # highlight-next-line
 from urllib.parse import urljoin
 ```

--- a/sources/academy/webscraping/scraping_basics_python/09_getting_links.md
+++ b/sources/academy/webscraping/scraping_basics_python/09_getting_links.md
@@ -115,7 +115,20 @@ def parse_product(product):
     return {"title": title, "min_price": min_price, "price": price}
 ```
 
-Now the CSV export. We'll make a small change here. Having to specify the field names is not ideal. What if we add more field names in the parsing function? We'd always have to remember to go and edit the export function as well. If we could figure out the field names in place, we'd remove this dependency. One way would be to infer the field names from the dictionary keys of the first row:
+Now the JSON export. For better readability of it, let's make a small change here and set the indentation level to two spaces:
+
+```py
+def export_json(file, data):
+    def serialize(obj):
+        if isinstance(obj, Decimal):
+            return str(obj)
+        raise TypeError("Object not JSON serializable")
+
+    # highlight-next-line
+    json.dump(data, file, default=serialize, indent=2)
+```
+
+The last function we'll add will take care of the CSV export. We'll make a small change here as well. Having to specify the field names is not ideal. What if we add more field names in the parsing function? We'd always have to remember to go and edit the export function as well. If we could figure out the field names in place, we'd remove this dependency. One way would be to infer the field names from the dictionary keys of the first row:
 
 ```py
 def export_csv(file, data):
@@ -132,19 +145,6 @@ def export_csv(file, data):
 The code above assumes the `data` variable contains at least one item, and that all the items have the same keys. This isn't robust and could break, but in our program, this isn't a problem, and omitting these corner cases allows us to keep the code examples more succinct.
 
 :::
-
-The last function we'll add will take care of the JSON export. For better readability of the JSON export, let's make a small change here too and set the indentation level to two spaces:
-
-```py
-def export_json(file, data):
-    def serialize(obj):
-        if isinstance(obj, Decimal):
-            return str(obj)
-        raise TypeError("Object not JSON serializable")
-
-    # highlight-next-line
-    json.dump(data, file, default=serialize, indent=2)
-```
 
 Now let's put it all together:
 
@@ -406,8 +406,8 @@ https://www.theguardian.com/sport/article/2024/sep/02/max-verstappen-damns-his-u
   from bs4 import BeautifulSoup
   from urllib.parse import urljoin
 
-  url = "https://www.theguardian.com/sport/formulaone"
-  response = httpx.get(url)
+  listing_url = "https://www.theguardian.com/sport/formulaone"
+  response = httpx.get(listing_url)
   response.raise_for_status()
 
   html_code = response.text
@@ -415,7 +415,7 @@ https://www.theguardian.com/sport/article/2024/sep/02/max-verstappen-damns-his-u
 
   for item in soup.select("#maincontent ul li"):
       link = item.select_one("a")
-      url = urljoin(url, link["href"])
+      url = urljoin(listing_url, link["href"])
       print(url)
   ```
 

--- a/sources/academy/webscraping/scraping_basics_python/10_crawling.md
+++ b/sources/academy/webscraping/scraping_basics_python/10_crawling.md
@@ -19,8 +19,8 @@ Thanks to the refactoring, we have functions ready for each of the tasks, so we 
 import httpx
 from bs4 import BeautifulSoup
 from decimal import Decimal
-import csv
 import json
+import csv
 from urllib.parse import urljoin
 
 def download(url):
@@ -52,13 +52,6 @@ def parse_product(product, base_url):
 
     return {"title": title, "min_price": min_price, "price": price, "url": url}
 
-def export_csv(file, data):
-    fieldnames = list(data[0].keys())
-    writer = csv.DictWriter(file, fieldnames=fieldnames)
-    writer.writeheader()
-    for row in data:
-        writer.writerow(row)
-
 def export_json(file, data):
     def serialize(obj):
         if isinstance(obj, Decimal):
@@ -66,6 +59,13 @@ def export_json(file, data):
         raise TypeError("Object not JSON serializable")
 
     json.dump(data, file, default=serialize, indent=2)
+
+def export_csv(file, data):
+    fieldnames = list(data[0].keys())
+    writer = csv.DictWriter(file, fieldnames=fieldnames)
+    writer.writeheader()
+    for row in data:
+        writer.writerow(row)
 
 listing_url = "https://warehouse-theme-metal.myshopify.com/collections/sales"
 listing_soup = download(listing_url)
@@ -75,11 +75,11 @@ for product in listing_soup.select(".product-item"):
     item = parse_product(product, listing_url)
     data.append(item)
 
-with open("products.csv", "w") as file:
-    export_csv(file, data)
-
 with open("products.json", "w") as file:
     export_json(file, data)
+
+with open("products.csv", "w") as file:
+    export_csv(file, data)
 ```
 
 ## Extracting vendor name

--- a/sources/academy/webscraping/scraping_basics_python/11_scraping_variants.md
+++ b/sources/academy/webscraping/scraping_basics_python/11_scraping_variants.md
@@ -192,8 +192,8 @@ Now, if we use our new function, we should finally get a program that can scrape
 import httpx
 from bs4 import BeautifulSoup
 from decimal import Decimal
-import csv
 import json
+import csv
 from urllib.parse import urljoin
 
 def download(url):
@@ -235,13 +235,6 @@ def parse_variant(variant):
     )
     return {"variant_name": name, "price": price}
 
-def export_csv(file, data):
-    fieldnames = list(data[0].keys())
-    writer = csv.DictWriter(file, fieldnames=fieldnames)
-    writer.writeheader()
-    for row in data:
-        writer.writerow(row)
-
 def export_json(file, data):
     def serialize(obj):
         if isinstance(obj, Decimal):
@@ -249,6 +242,13 @@ def export_json(file, data):
         raise TypeError("Object not JSON serializable")
 
     json.dump(data, file, default=serialize, indent=2)
+
+def export_csv(file, data):
+    fieldnames = list(data[0].keys())
+    writer = csv.DictWriter(file, fieldnames=fieldnames)
+    writer.writeheader()
+    for row in data:
+        writer.writerow(row)
 
 listing_url = "https://warehouse-theme-metal.myshopify.com/collections/sales"
 listing_soup = download(listing_url)
@@ -267,11 +267,11 @@ for product in listing_soup.select(".product-item"):
         item["variant_name"] = None
         data.append(item)
 
-with open("products.csv", "w") as file:
-    export_csv(file, data)
-
 with open("products.json", "w") as file:
     export_json(file, data)
+
+with open("products.csv", "w") as file:
+    export_csv(file, data)
 ```
 
 Let's run the scraper and see if all the items in the data contain prices:


### PR DESCRIPTION
When working on https://github.com/apify/apify-docs/pull/1584 I realized it'd be better if the lesson started with JSON and continued with CSV, not the other way.

In Python it doesn't matter and in JavaScript it's easier to start with JSON, which is built-in, and only then move to CSV, which requires an additional library. So for the sake of having both lessons aligned, I want to change the order in the Python lesson, too.

So most of the diff is just the two sections reversed, and the two exercises reversed. I made only a few additional changes to the wording.