### PR TITLE
chore: rename Algolia search index for easier maintenance

### DIFF
--- a/apify-docs-theme/src/config.js
+++ b/apify-docs-theme/src/config.js
@@ -273,7 +273,7 @@ const themeConfig = {
     algolia: {
         appId: 'N8EOCSBQGH',
         apiKey: 'e97714a64e2b4b8b8fe0b01cd8592870', // search only (public) API key
-        indexName: 'test_test_apify_sdk',
+        indexName: 'apify_sdk_v2',
         algoliaOptions: {
             facetFilters: ['version:VERSION'],
         },

--- a/apify-docs-theme/src/theme/SearchBar/index.js
+++ b/apify-docs-theme/src/theme/SearchBar/index.js
@@ -59,7 +59,7 @@ export default function SearchBar() {
         <BrowserOnly>
             {() => <ApifySearch
                 algoliaAppId={siteConfig.themeConfig.algolia.appId}
-                algoliaIndexName='test_test_apify_sdk'
+                algoliaIndexName='apify_sdk_v2'
                 algoliaKey={siteConfig.themeConfig.algolia.apiKey}
                 filters={`version:${getVersion()}`}
                 navigate={navigate}


### PR DESCRIPTION
Switches the documentation search feature to the new index name. 