### PR TITLE
fix: navbar subtitle width

### DIFF
--- a/apify-docs-theme/src/theme/custom.css
+++ b/apify-docs-theme/src/theme/custom.css
@@ -561,7 +561,7 @@ aside .icon svg[class*=iconExternalLink] {
 .navbar__sub--title {
     display: flex;
     align-items: center;
-    width: 200px;
+    width: 220px;
     margin-right: 1.6rem;
     padding-right: 2rem;
     position: relative;


### PR DESCRIPTION
fixes navbar subtitle width that wouldn't fit for JS/Python client subpages due to bigger paddings in new design uplift