### PR TITLE
docs: fix typo in actor_json.md

### DIFF
--- a/sources/platform/actors/development/actor_definition/actor_json.md
+++ b/sources/platform/actors/development/actor_definition/actor_json.md
@@ -9,7 +9,7 @@ sidebar_position: 1
 
 ---
 
-Your main Actor configuration is in the `actor/actor.json` file at the root of your Actor's directory. This file links your local development project to an Actor on the Apify platform. It should include details like the Actor's name, version, build tag, and environment variables. Make sure to commit this file to your Git repository.
+Your main Actor configuration is in the `.actor/actor.json` file at the root of your Actor's directory. This file links your local development project to an Actor on the Apify platform. It should include details like the Actor's name, version, build tag, and environment variables. Make sure to commit this file to your Git repository.
 
 For example, the `.actor/actor.json` file can look like this:
 


### PR DESCRIPTION
### Summary

Add a missing dot prefix to indicate the hidden `.actor` folder containing `actor.json`.