### PR TITLE
feat: use `docusaurus-plugin-image-zoom` to add zoomable images

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -127,6 +127,7 @@ module.exports = {
         ],
     ]),
     plugins: [
+        'docusaurus-plugin-image-zoom',
         [
             '@docusaurus/plugin-content-docs',
             {
@@ -306,6 +307,9 @@ module.exports = {
                 ...config.themeConfig.prism.additionalLanguages,
                 'http', 'bash', 'ruby', 'java', 'scala', 'go', 'csharp', 'powershell', 'dart', 'objectivec', 'ocaml', 'r',
             ],
+        },
+        zoom: {
+            selector: '.markdown img',
         },
         languageTabs: [
             {

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
                 "@redocly/cli": "^1.27.1",
                 "ajv": "^8.17.1",
                 "clsx": "^2.0.0",
+                "docusaurus-plugin-image-zoom": "^3.0.1",
                 "docusaurus-plugin-openapi-docs": "^4.3.7",
                 "docusaurus-theme-openapi-docs": "^4.3.7",
                 "form-data": "^4.0.0",
@@ -11391,6 +11392,19 @@
             "resolved": "https://registry.npmjs.org/docusaurus-gtm-plugin/-/docusaurus-gtm-plugin-0.0.2.tgz",
             "integrity": "sha512-Xx/df0Ppd5SultlzUj9qlQk2lX9mNVfTb41juyBUPZ1Nc/5dNx+uN0VuLyF4JEObkDRrUY1EFo9fEUDo8I6QOQ=="
         },
+        "node_modules/docusaurus-plugin-image-zoom": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/docusaurus-plugin-image-zoom/-/docusaurus-plugin-image-zoom-3.0.1.tgz",
+            "integrity": "sha512-mQrqA99VpoMQJNbi02qkWAMVNC4+kwc6zLLMNzraHAJlwn+HrlUmZSEDcTwgn+H4herYNxHKxveE2WsYy73eGw==",
+            "license": "MIT",
+            "dependencies": {
+                "medium-zoom": "^1.1.0",
+                "validate-peer-dependencies": "^2.2.0"
+            },
+            "peerDependencies": {
+                "@docusaurus/theme-classic": ">=3.0.0"
+            }
+        },
         "node_modules/docusaurus-plugin-openapi-docs": {
             "version": "4.5.1",
             "resolved": "https://registry.npmjs.org/docusaurus-plugin-openapi-docs/-/docusaurus-plugin-openapi-docs-4.5.1.tgz",
@@ -18821,6 +18835,12 @@
                 "node": ">= 0.6"
             }
         },
+        "node_modules/medium-zoom": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/medium-zoom/-/medium-zoom-1.1.0.tgz",
+            "integrity": "sha512-ewyDsp7k4InCUp3jRmwHBRFGyjBimKps/AJLjRSox+2q/2H4p/PNpQf+pwONWlJiOudkBXtbdmVbFjqyybfTmQ==",
+            "license": "MIT"
+        },
         "node_modules/memfs": {
             "version": "3.5.3",
             "resolved": "https://registry.npmjs.org/memfs/-/memfs-3.5.3.tgz",
@@ -22402,6 +22422,27 @@
             "version": "1.0.7",
             "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
             "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
+        },
+        "node_modules/path-root": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/path-root/-/path-root-0.1.1.tgz",
+            "integrity": "sha512-QLcPegTHF11axjfojBIoDygmS2E3Lf+8+jI6wOVmNVenrKSo3mFdSGiIgdSHenczw3wPtlVMQaFVwGmM7BJdtg==",
+            "license": "MIT",
+            "dependencies": {
+                "path-root-regex": "^0.1.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/path-root-regex": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/path-root-regex/-/path-root-regex-0.1.2.tgz",
+            "integrity": "sha512-4GlJ6rZDhQZFE0DPVKh0e9jmZ5egZfxTkp7bcRDuPlJXbAwhxcl2dINPUAsjLdejqaLsCeg8axcLjIbvBjN4pQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
         },
         "node_modules/path-scurry": {
             "version": "2.0.0",
@@ -26439,6 +26480,18 @@
                 "node": ">=4"
             }
         },
+        "node_modules/resolve-package-path": {
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/resolve-package-path/-/resolve-package-path-4.0.3.tgz",
+            "integrity": "sha512-SRpNAPW4kewOaNUt8VPqhJ0UMxawMwzJD8V7m1cJfdSTK9ieZwS6K7Dabsm4bmLFM96Z5Y/UznrpG5kt1im8yA==",
+            "license": "MIT",
+            "dependencies": {
+                "path-root": "^0.1.1"
+            },
+            "engines": {
+                "node": ">= 12"
+            }
+        },
         "node_modules/resolve-pathname": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/resolve-pathname/-/resolve-pathname-3.0.0.tgz",
@@ -29166,6 +29219,19 @@
             "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
             "engines": {
                 "node": ">=6"
+            }
+        },
+        "node_modules/validate-peer-dependencies": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/validate-peer-dependencies/-/validate-peer-dependencies-2.2.0.tgz",
+            "integrity": "sha512-8X1OWlERjiUY6P6tdeU9E0EwO8RA3bahoOVG7ulOZT5MqgNDUO/BQoVjYiHPcNe+v8glsboZRIw9iToMAA2zAA==",
+            "license": "MIT",
+            "dependencies": {
+                "resolve-package-path": "^4.0.3",
+                "semver": "^7.3.8"
+            },
+            "engines": {
+                "node": ">= 12"
             }
         },
         "node_modules/validate.io-array": {

--- a/package.json
+++ b/package.json
@@ -59,8 +59,8 @@
         "globby": "^14.0.0",
         "markdownlint": "^0.38.0",
         "markdownlint-cli": "^0.45.0",
-        "path-browserify": "^1.0.1",
         "patch-package": "^8.0.0",
+        "path-browserify": "^1.0.1",
         "rimraf": "^6.0.0",
         "typescript": "5.8.3",
         "typescript-eslint": "^8.29.1"
@@ -80,6 +80,7 @@
         "@redocly/cli": "^1.27.1",
         "ajv": "^8.17.1",
         "clsx": "^2.0.0",
+        "docusaurus-plugin-image-zoom": "^3.0.1",
         "docusaurus-plugin-openapi-docs": "^4.3.7",
         "docusaurus-theme-openapi-docs": "^4.3.7",
         "form-data": "^4.0.0",


### PR DESCRIPTION
Utilizes `docusaurus-plugin-image-zoom` to add a simple zoom feature on all post images.

<img width="1450" height="1226" alt="image" src="https://github.com/user-attachments/assets/7f8ce0c7-9c52-4875-a6c6-c10d8a4c698a" />

<img width="1450" height="1226" alt="image" src="https://github.com/user-attachments/assets/60eed570-53ed-4e24-b2f6-b2a342b1bee6" />
