### PR TITLE
chore: redirect old Crawlee JS versions to the latest one

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -437,6 +437,10 @@ server {
   rewrite ^/docs(.*)$ /js/docs$1 permanent;
   rewrite ^/api(.*)$ /js/api$1 permanent;
 
+  # Remove version numbers from /js/api/3.[0-9]/* and /js/docs/3.[0-9]/*
+  rewrite ^/js/api/3\.\d(/.*)?$ /js/api$1 permanent;
+  rewrite ^/js/docs/3\.\d(/.*)?$ /js/docs$1 permanent;
+
   # Redirect rule for "upgrading-to-v03" to "upgrading-to-v0x"
   rewrite ^/python/docs/upgrading/upgrading-to-v03$ /python/docs/upgrading/upgrading-to-v0x permanent;
 


### PR DESCRIPTION
We're planning to remove some of the Crawlee versions from the documentation, as this worsens the DX and leads to longer build times.

<img width="733" height="811" alt="image" src="https://github.com/user-attachments/assets/8c5bb5c4-ca75-4e85-8713-d2744adfdeb8" />

This PR adds permanent `nginx`  redirects for _all single-digit minor 3.x versions_ to the `latest` documentation.
