### PR TITLE
docs: add `APIFY_USER_IS_PAYING` env var documentation

### DIFF
--- a/sources/platform/actors/development/programming_interface/environment_variables.md
+++ b/sources/platform/actors/development/programming_interface/environment_variables.md
@@ -62,7 +62,7 @@ Here's a table of key system environment variables:
 | `ACTOR_TIMEOUT_AT` | Date when the Actor will time out. |
 | `APIFY_TOKEN` | API token of the user who started the Actor. |
 | `APIFY_USER_ID` | ID of the user who started the Actor. May differ from the Actor owner. |
-| `APIFY_USER_IS_PAYING` | If **1**, the user calling the Actor is paying user |
+| `APIFY_USER_IS_PAYING` | If **1**, the user calling the Actor is paying user. |
 | `ACTOR_WEB_SERVER_PORT` | TCP port for the Actor to start an HTTP server on. This server can be used to receive external messages or expose monitoring and control interfaces. The server also receives messages from the [Actor Standby](/platform/actors/development/programming-interface/standby) mode. |
 | `ACTOR_WEB_SERVER_URL` | Unique public URL for accessing the Actor run web server from the outside world. |
 | `APIFY_API_PUBLIC_BASE_URL` | Public URL of the Apify API. May be used to interact with the platform programmatically. Typically set to `api.apify.com`. |

--- a/sources/platform/actors/development/programming_interface/environment_variables.md
+++ b/sources/platform/actors/development/programming_interface/environment_variables.md
@@ -62,7 +62,7 @@ Here's a table of key system environment variables:
 | `ACTOR_TIMEOUT_AT` | Date when the Actor will time out. |
 | `APIFY_TOKEN` | API token of the user who started the Actor. |
 | `APIFY_USER_ID` | ID of the user who started the Actor. May differ from the Actor owner. |
-| `APIFY_USER_IS_PAYING` | If set to `1`, the user calling the Actor is paying user. |
+| `APIFY_USER_IS_PAYING` | If set to `1`, the user calling the Actor is a paying user. |
 | `ACTOR_WEB_SERVER_PORT` | TCP port for the Actor to start an HTTP server on. This server can be used to receive external messages or expose monitoring and control interfaces. The server also receives messages from the [Actor Standby](/platform/actors/development/programming-interface/standby) mode. |
 | `ACTOR_WEB_SERVER_URL` | Unique public URL for accessing the Actor run web server from the outside world. |
 | `APIFY_API_PUBLIC_BASE_URL` | Public URL of the Apify API. May be used to interact with the platform programmatically. Typically set to `api.apify.com`. |

--- a/sources/platform/actors/development/programming_interface/environment_variables.md
+++ b/sources/platform/actors/development/programming_interface/environment_variables.md
@@ -62,6 +62,7 @@ Here's a table of key system environment variables:
 | `ACTOR_TIMEOUT_AT` | Date when the Actor will time out. |
 | `APIFY_TOKEN` | API token of the user who started the Actor. |
 | `APIFY_USER_ID` | ID of the user who started the Actor. May differ from the Actor owner. |
+| `APIFY_USER_IS_PAYING` | If **1**, the user calling the Actor is paying user |
 | `ACTOR_WEB_SERVER_PORT` | TCP port for the Actor to start an HTTP server on. This server can be used to receive external messages or expose monitoring and control interfaces. The server also receives messages from the [Actor Standby](/platform/actors/development/programming-interface/standby) mode. |
 | `ACTOR_WEB_SERVER_URL` | Unique public URL for accessing the Actor run web server from the outside world. |
 | `APIFY_API_PUBLIC_BASE_URL` | Public URL of the Apify API. May be used to interact with the platform programmatically. Typically set to `api.apify.com`. |

--- a/sources/platform/actors/development/programming_interface/environment_variables.md
+++ b/sources/platform/actors/development/programming_interface/environment_variables.md
@@ -62,7 +62,7 @@ Here's a table of key system environment variables:
 | `ACTOR_TIMEOUT_AT` | Date when the Actor will time out. |
 | `APIFY_TOKEN` | API token of the user who started the Actor. |
 | `APIFY_USER_ID` | ID of the user who started the Actor. May differ from the Actor owner. |
-| `APIFY_USER_IS_PAYING` | If set to `1`, the user calling the Actor is a paying user. |
+| `APIFY_USER_IS_PAYING` | If it is `1`, it means that the user who started the Actor is a paying user. |
 | `ACTOR_WEB_SERVER_PORT` | TCP port for the Actor to start an HTTP server on. This server can be used to receive external messages or expose monitoring and control interfaces. The server also receives messages from the [Actor Standby](/platform/actors/development/programming-interface/standby) mode. |
 | `ACTOR_WEB_SERVER_URL` | Unique public URL for accessing the Actor run web server from the outside world. |
 | `APIFY_API_PUBLIC_BASE_URL` | Public URL of the Apify API. May be used to interact with the platform programmatically. Typically set to `api.apify.com`. |

--- a/sources/platform/actors/development/programming_interface/environment_variables.md
+++ b/sources/platform/actors/development/programming_interface/environment_variables.md
@@ -62,7 +62,7 @@ Here's a table of key system environment variables:
 | `ACTOR_TIMEOUT_AT` | Date when the Actor will time out. |
 | `APIFY_TOKEN` | API token of the user who started the Actor. |
 | `APIFY_USER_ID` | ID of the user who started the Actor. May differ from the Actor owner. |
-| `APIFY_USER_IS_PAYING` | If **1**, the user calling the Actor is paying user. |
+| `APIFY_USER_IS_PAYING` | If set to `1`, the user calling the Actor is paying user. |
 | `ACTOR_WEB_SERVER_PORT` | TCP port for the Actor to start an HTTP server on. This server can be used to receive external messages or expose monitoring and control interfaces. The server also receives messages from the [Actor Standby](/platform/actors/development/programming-interface/standby) mode. |
 | `ACTOR_WEB_SERVER_URL` | Unique public URL for accessing the Actor run web server from the outside world. |
 | `APIFY_API_PUBLIC_BASE_URL` | Public URL of the Apify API. May be used to interact with the platform programmatically. Typically set to `api.apify.com`. |


### PR DESCRIPTION
Add documentation for `APIFY_USER_IS_PAYING` environmental variable.
- This is followup of these changes:
  - https://github.com/apify/apify-sdk-js/pull/415
  - https://github.com/apify/apify-shared-python/pull/40
  - https://github.com/apify/apify-sdk-python/pull/507