### PR TITLE
docs: add note on vulnerability disclosure policy rewards

### DIFF
--- a/sources/platform/security.md
+++ b/sources/platform/security.md
@@ -84,7 +84,7 @@ If you notice or suspect a potential security issue, please report it to our sec
 - Impact analysis
 - Affected URL or endpoint
 
-:::note
+:::note Voluntary disclosures
 
 Thank you for helping us keep Apify secure! Please note that we don’t offer financial or other rewards for vulnerability reports. Participation in our VDP is entirely voluntary, and we sincerely appreciate your contribution to the safety of the platform and the community.
 

--- a/sources/platform/security.md
+++ b/sources/platform/security.md
@@ -84,6 +84,12 @@ If you notice or suspect a potential security issue, please report it to our sec
 - Impact analysis
 - Affected URL or endpoint
 
+:::note
+
+Thank you for helping us keep Apify secure! Please note that we don’t offer financial or other rewards for vulnerability reports. Participation in our VDP is entirely voluntary, and we sincerely appreciate your contribution to the safety of the platform and the community.
+
+:::
+
 ### Rules of engagement
 
 - Only target accounts or data you control (test accounts)


### PR DESCRIPTION
We’ve been receiving an increasing number of questions regarding financial compensation for submitted security reports, so adding this to clarify it.