### PR TITLE
docs: redirect SDK JS `versions` page to changelog

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -218,6 +218,7 @@ server {
   rewrite ^/sdk/js/docs/2\.\d+\.\d+(.*)$ /sdk/js/docs/2.3$1 redirect;
   rewrite ^/sdk/js/docs/api(.*)$ /sdk/js/docs/2.3/api$1 redirect;
   rewrite ^/sdk/js/docs/typedefs(.*)$ /sdk/js/docs/2.3/typedefs$1 redirect;
+  rewrite ^/sdk/js/versions/?$ /sdk/js/docs/changelog redirect;
 
   # old integrated docs -> new docs in GH pages
   rewrite ^/apify-client-js/?$ /api/client/js/ redirect;

--- a/nginx.conf
+++ b/nginx.conf
@@ -218,7 +218,6 @@ server {
   rewrite ^/sdk/js/docs/2\.\d+\.\d+(.*)$ /sdk/js/docs/2.3$1 redirect;
   rewrite ^/sdk/js/docs/api(.*)$ /sdk/js/docs/2.3/api$1 redirect;
   rewrite ^/sdk/js/docs/typedefs(.*)$ /sdk/js/docs/2.3/typedefs$1 redirect;
-  rewrite ^/sdk/js/versions/?$ /sdk/js/docs/changelog redirect;
 
   # old integrated docs -> new docs in GH pages
   rewrite ^/apify-client-js/?$ /api/client/js/ redirect;
@@ -231,6 +230,12 @@ server {
   rewrite ^/sdk/js$ /sdk/js/ redirect;
   rewrite ^/sdk/python$ /sdk/python/ redirect;
   rewrite ^/cli$ /cli/ redirect;
+
+  # versions page redirects
+  rewrite ^/versions/?$ / permanent; # no docs-wide changelog, redirect to the root
+  rewrite ^/cli/versions/?$ /cli/docs/changelog permanent;
+  rewrite ^/sdk/js/versions/?$ /sdk/js/docs/changelog permanent;
+  rewrite ^/api/client/js/versions/?$ /api/client/js/docs/changelog permanent;
 
   # legacy links in some Actor READMEs
   rewrite ^/scraping/tutorial/introduction$ /academy/apify-scrapers/getting-started permanent;
@@ -447,6 +452,8 @@ server {
 
   # Redirect rule so that /python/docs actually leads somewhere
   rewrite ^/python/docs/?$ /python/docs/quick-start;
+
+  rewrite ^/versions/?$ /js/api/core/changelog permanent;
 }
 
 server {


### PR DESCRIPTION
Redirects the traffic from `/sdk/js/versions` to `/sdk/js/docs/changelog`

Connected to https://github.com/apify/apify-sdk-js/pull/416

Alternatively, we don't have to merge this (to keep the `nginx` conf clean), the `versions` page had likely 0 traffic (only linked from the sitemap).