### PR TITLE
fix: allow builds without the segment API key

### DIFF
--- a/src/plugins/docusaurus-plugin-segment/index.js
+++ b/src/plugins/docusaurus-plugin-segment/index.js
@@ -16,9 +16,8 @@ module.exports = function (context, options) {
             }
 
             if (!writeKey) {
-                throw new Error(
-                    'You need to specify a Segment writeKey in the plugin options',
-                );
+                console.warn('You need to specify a Segment writeKey in the plugin options');
+                return {};
             }
 
             return {


### PR DESCRIPTION
convert the error to a warning, to allow local development without the key