### PR TITLE
docs: change security description within API docs

### DIFF
--- a/apify-api/openapi/components/securitySchemes/apiKey.yaml
+++ b/apify-api/openapi/components/securitySchemes/apiKey.yaml
@@ -1,4 +1,20 @@
 type: apiKey
 name: token
 in: query
-description: API authentication token.
+description: |-
+  API token provided as a query parameter (e.g., `?token=your_token`—less secure).
+  
+  Use your API token to authenticate requests. You can find it on the [Integrations page](https://console.apify.com/account#/integrations) in Apify Console.
+  
+  :::danger Security
+  
+  Do not share your API token (or account password) with untrusted parties.
+  
+  :::
+  
+  _When is authentication required?_
+  - _Required_ for private Actors, tasks, or resources (e.g., builds of private Actors).
+  - _Required_ when using named formats for IDs (e.g., `username~store-name` for stores or `username~queue-name` for queues).
+  - _Optional_ for public Actors or resources (e.g., builds of public Actors can be queried without a token).
+  
+  For more information, see our [integrations documentation](https://docs.apify.com/platform/integrations).

--- a/apify-api/openapi/components/securitySchemes/apiKeyActorBuilds.yaml
+++ b/apify-api/openapi/components/securitySchemes/apiKeyActorBuilds.yaml
@@ -1,4 +1,0 @@
-type: apiKey
-name: token
-in: query
-description: API authentication token. It is only required for private Actors. Builds of public Actors can be queried without any token.

--- a/apify-api/openapi/components/securitySchemes/apiKeyQueueId.yaml
+++ b/apify-api/openapi/components/securitySchemes/apiKeyQueueId.yaml
@@ -1,4 +1,0 @@
-type: apiKey
-name: token
-in: query
-description: API authentication token. It is required only when using the `username~queue-name` format for `queueId`.

--- a/apify-api/openapi/components/securitySchemes/apiKeyStoreId.yaml
+++ b/apify-api/openapi/components/securitySchemes/apiKeyStoreId.yaml
@@ -1,4 +1,0 @@
-type: apiKey
-name: token
-in: query
-description: API authentication token. It is required only when using the `username~store-name` format for `storeId`.

--- a/apify-api/openapi/components/securitySchemes/httpBearer.yaml
+++ b/apify-api/openapi/components/securitySchemes/httpBearer.yaml
@@ -1,3 +1,19 @@
 type: http
 scheme: bearer
-description: API authentication token.
+description: |-
+  Bearer token provided in the `Authorization` header (e.g., `Authorization: Bearer your_token`—recommended). [More info](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Authorization).
+  
+  Use your API token to authenticate requests. You can find it on the [Integrations page](https://console.apify.com/account#/integrations) in Apify Console. This method is more secure than query parameters, as headers are not logged in browser history or server logs.
+  
+  :::danger Security
+  
+  Do not share your API token (or account password) with untrusted parties.
+  
+  :::
+
+  _When is authentication required?_
+  - _Required_ for private Actors, tasks, or resources (e.g., builds of private Actors).
+  - _Required_ when using named formats for IDs (e.g., `username~store-name` for stores or `username~queue-name` for queues).
+  - _Optional_ for public Actors or resources (e.g., builds of public Actors can be queried without a token).
+  
+  For more information, see our [integrations documentation](https://docs.apify.com/platform/integrations).

--- a/apify-api/openapi/components/securitySchemes/httpBearerActorBuilds.yaml
+++ b/apify-api/openapi/components/securitySchemes/httpBearerActorBuilds.yaml
@@ -1,3 +1,0 @@
-type: http
-scheme: bearer
-description: API authentication token. It is only required for private Actors. Builds of public Actors can be queried without any token.

--- a/apify-api/openapi/components/securitySchemes/httpBearerQueueId.yaml
+++ b/apify-api/openapi/components/securitySchemes/httpBearerQueueId.yaml
@@ -1,3 +1,0 @@
-type: http
-scheme: bearer
-description: API authentication token. It is required only when using the `username~queue-name` format for `queueId`.

--- a/apify-api/openapi/components/securitySchemes/httpBearerStoreId.yaml
+++ b/apify-api/openapi/components/securitySchemes/httpBearerStoreId.yaml
@@ -1,3 +1,0 @@
-type: http
-scheme: bearer
-description: API authentication token. It is required only when using the `username~store-name` format for `storeId`.

--- a/apify-api/openapi/openapi.yaml
+++ b/apify-api/openapi/openapi.yaml
@@ -14,25 +14,22 @@ info:
     [JSON](http://www.json.org/) format with UTF-8 encoding,
     with a few exceptions that are explicitly described in the reference.
 
-    To access the API using [Node.js](https://nodejs.org/en/), we recommend the
-    [`apify-client`](https://docs.apify.com/api/client/js) [NPM
+    - To access the API using [Node.js](https://nodejs.org/en/), we recommend the [`apify-client`](https://docs.apify.com/api/client/js) [NPM
     package](https://www.npmjs.com/package/apify-client).
-
-    To access the API using [Python](https://www.python.org/), we recommend the
-    [`apify-client`](https://docs.apify.com/api/client/python) [PyPI
+    - To access the API using [Python](https://www.python.org/), we recommend the [`apify-client`](https://docs.apify.com/api/client/python) [PyPI
     package](https://pypi.org/project/apify-client/).
+
     The clients' functions correspond to the API endpoints and have the same
     parameters. This simplifies development of apps that depend on the Apify
     platform.
 
-    **Note:** All requests with JSON payloads need to specify the `Content-Type:
-    application/json` HTTP header!
-    All API endpoints support the `method` query parameter that can override the
-    HTTP method.
-    For example, if you want to call a POST endpoint using a GET request, simply
-    add the query parameter `method=POST` to the URL and send the GET request.
-    This feature is especially useful if you want to call Apify API endpoints
-    from services that can only send GET requests.
+    :::note Important Request Details
+
+    - `Content-Type` header: For requests with a JSON body, you must include the `Content-Type: application/json` header.
+
+    - Method override: You can override the HTTP method using the `method` query parameter. This is useful for clients that can only send `GET` requests. For example, to call a `POST` endpoint, append `?method=POST` to the URL of your `GET` request.
+
+    :::
 
     ## Authentication
     <span id="/introduction/authentication"></span>
@@ -627,20 +624,8 @@ components:
   securitySchemes:
     httpBearer:
       $ref: components/securitySchemes/httpBearer.yaml
-    httpBearerActorBuilds:
-      $ref: components/securitySchemes/httpBearerActorBuilds.yaml
-    httpBearerStoreId:
-      $ref: components/securitySchemes/httpBearerStoreId.yaml
-    httpBearerQueueId:
-      $ref: components/securitySchemes/httpBearerQueueId.yaml
     apiKey:
       $ref: components/securitySchemes/apiKey.yaml
-    apiKeyActorBuilds:
-      $ref: components/securitySchemes/apiKeyActorBuilds.yaml
-    apiKeyStoreId:
-      $ref: components/securitySchemes/apiKeyStoreId.yaml
-    apiKeyQueueId:
-      $ref: components/securitySchemes/apiKeyQueueId.yaml
 security:
   - httpBearer: []
   - apiKey: []

--- a/apify-api/openapi/paths/actor-builds/actor-builds@{buildId}.yaml
+++ b/apify-api/openapi/paths/actor-builds/actor-builds@{buildId}.yaml
@@ -13,6 +13,7 @@ get:
     This endpoint does not require the authentication token. Instead, calls are authenticated using a hard-to-guess ID of the build. However,
     if you access the endpoint without the token, certain attributes, such as `usageUsd` and `usageTotalUsd`, will be hidden.
   operationId: actorBuild_get
+  security: []
   parameters:
     - name: buildId
       in: path

--- a/apify-api/openapi/paths/actor-builds/actor-builds@{buildId}.yaml
+++ b/apify-api/openapi/paths/actor-builds/actor-builds@{buildId}.yaml
@@ -13,9 +13,6 @@ get:
     This endpoint does not require the authentication token. Instead, calls are authenticated using a hard-to-guess ID of the build. However,
     if you access the endpoint without the token, certain attributes, such as `usageUsd` and `usageTotalUsd`, will be hidden.
   operationId: actorBuild_get
-  security:
-    - apiKeyActorBuilds: []
-    - httpBearerActorBuilds: []
   parameters:
     - name: buildId
       in: path

--- a/apify-api/openapi/paths/actor-builds/actor-builds@{buildId}@openapi.json.yaml
+++ b/apify-api/openapi/paths/actor-builds/actor-builds@{buildId}@openapi.json.yaml
@@ -17,6 +17,7 @@ get:
 
     :::
   operationId: actorBuild_openapi_json_get
+  security: []
   parameters:
     - name: buildId
       in: path

--- a/apify-api/openapi/paths/actor-builds/actor-builds@{buildId}@openapi.json.yaml
+++ b/apify-api/openapi/paths/actor-builds/actor-builds@{buildId}@openapi.json.yaml
@@ -17,9 +17,6 @@ get:
 
     :::
   operationId: actorBuild_openapi_json_get
-  security:
-    - apiKeyActorBuilds: []
-    - httpBearerActorBuilds: []
   parameters:
     - name: buildId
       in: path

--- a/apify-api/openapi/paths/actors/acts@{actorId}@builds@default.yaml
+++ b/apify-api/openapi/paths/actors/acts@{actorId}@builds@default.yaml
@@ -11,9 +11,6 @@ get:
     This endpoint does not require an authentication token. Instead, calls are authenticated using the Actor's unique ID.
     However, if you access the endpoint without a token, certain attributes (e.g., `usageUsd` and `usageTotalUsd`) will be hidden.
   operationId: act_build_default_get
-  security:
-    - apiKeyActorBuilds: []
-    - httpBearerActorBuilds: []
   parameters:
     - name: actorId
       in: path

--- a/apify-api/openapi/paths/actors/acts@{actorId}@builds@default.yaml
+++ b/apify-api/openapi/paths/actors/acts@{actorId}@builds@default.yaml
@@ -11,6 +11,7 @@ get:
     This endpoint does not require an authentication token. Instead, calls are authenticated using the Actor's unique ID.
     However, if you access the endpoint without a token, certain attributes (e.g., `usageUsd` and `usageTotalUsd`) will be hidden.
   operationId: act_build_default_get
+  security: []
   parameters:
     - name: actorId
       in: path

--- a/apify-api/openapi/paths/actors/acts@{actorId}@builds@{buildId}.yaml
+++ b/apify-api/openapi/paths/actors/acts@{actorId}@builds@{buildId}.yaml
@@ -11,6 +11,7 @@ get:
     This endpoint does not require the authentication token. Instead, calls are authenticated using a hard-to-guess ID of the build. However,
     if you access the endpoint without the token, certain attributes, such as `usageUsd` and `usageTotalUsd`, will be hidden.
   operationId: act_build_get
+  security: []
   parameters:
     - name: actorId
       in: path

--- a/apify-api/openapi/paths/actors/acts@{actorId}@builds@{buildId}.yaml
+++ b/apify-api/openapi/paths/actors/acts@{actorId}@builds@{buildId}.yaml
@@ -11,9 +11,6 @@ get:
     This endpoint does not require the authentication token. Instead, calls are authenticated using a hard-to-guess ID of the build. However,
     if you access the endpoint without the token, certain attributes, such as `usageUsd` and `usageTotalUsd`, will be hidden.
   operationId: act_build_get
-  security:
-    - apiKeyActorBuilds: []
-    - httpBearerActorBuilds: []
   parameters:
     - name: actorId
       in: path

--- a/apify-api/openapi/paths/actors/acts@{actorId}@builds@{buildId}@openapi.json.yaml
+++ b/apify-api/openapi/paths/actors/acts@{actorId}@builds@{buildId}@openapi.json.yaml
@@ -20,6 +20,7 @@ get:
 
     :::
   operationId: act_openapi_json_get
+  security: []
   parameters:
     - name: actorId
       in: path

--- a/apify-api/openapi/paths/actors/acts@{actorId}@builds@{buildId}@openapi.json.yaml
+++ b/apify-api/openapi/paths/actors/acts@{actorId}@builds@{buildId}@openapi.json.yaml
@@ -20,9 +20,6 @@ get:
 
     :::
   operationId: act_openapi_json_get
-  security:
-    - apiKeyActorBuilds: []
-    - httpBearerActorBuilds: []
   parameters:
     - name: actorId
       in: path

--- a/apify-api/openapi/paths/datasets/datasets@{datasetId}@items.yaml
+++ b/apify-api/openapi/paths/datasets/datasets@{datasetId}@items.yaml
@@ -153,9 +153,6 @@ get:
     If you specify `desc=1` query parameter, the results are returned in the reverse order than they were stored (i.e. from newest to oldest items).
     Note that only the order of **Items** is reversed, but not the order of the `unwind` array elements.
   operationId: dataset_items_get
-  security:
-    - apiKeyStoreId: []
-    - httpBearerStoreId: []
   parameters:
     - name: datasetId
       in: path

--- a/apify-api/openapi/paths/key-value-stores/key-value-stores@{storeId}.yaml
+++ b/apify-api/openapi/paths/key-value-stores/key-value-stores@{storeId}.yaml
@@ -6,9 +6,6 @@ get:
     Gets an object that contains all the details about a specific key-value
     store.
   operationId: keyValueStore_get
-  security:
-    - apiKeyStoreId: []
-    - httpBearerStoreId: []
   parameters:
     - name: storeId
       in: path

--- a/apify-api/openapi/paths/key-value-stores/key-value-stores@{storeId}@keys.yaml
+++ b/apify-api/openapi/paths/key-value-stores/key-value-stores@{storeId}@keys.yaml
@@ -9,9 +9,6 @@ get:
     This endpoint is paginated using `exclusiveStartKey` and `limit` parameters
     - see [Pagination](/api/v2#using-key) for more details.
   operationId: keyValueStore_keys_get
-  security:
-    - apiKeyStoreId: []
-    - httpBearerStoreId: []
   parameters:
     - name: storeId
       in: path

--- a/apify-api/openapi/paths/key-value-stores/key-value-stores@{storeId}@records@{recordKey}.yaml
+++ b/apify-api/openapi/paths/key-value-stores/key-value-stores@{storeId}@records@{recordKey}.yaml
@@ -15,9 +15,6 @@ get:
     client with decompression support, the `Accept-Encoding` header is set by
     the client and body is decompressed automatically.
   operationId: keyValueStore_record_get
-  security:
-    - apiKeyStoreId: []
-    - httpBearerStoreId: []
   parameters:
     - name: storeId
       in: path
@@ -77,9 +74,6 @@ head:
   description: |
     Check if a value is stored in the key-value store under a specific key.
   operationId: keyValueStore_record_head
-  security:
-    - apiKeyStoreId: []
-    - httpBearerStoreId: []
   parameters:
     - name: storeId
       in: path

--- a/apify-api/openapi/paths/request-queues/request-queues@{queueId}.yaml
+++ b/apify-api/openapi/paths/request-queues/request-queues@{queueId}.yaml
@@ -4,9 +4,6 @@ get:
   summary: Get request queue
   description: Returns queue object for given queue ID.
   operationId: requestQueue_get
-  security:
-    - apiKeyQueueId: []
-    - httpBearerQueueId: []
   parameters:
     - name: queueId
       in: path

--- a/apify-api/openapi/paths/request-queues/request-queues@{queueId}@requests@{requestId}.yaml
+++ b/apify-api/openapi/paths/request-queues/request-queues@{queueId}@requests@{requestId}.yaml
@@ -4,9 +4,6 @@ get:
   summary: Get request
   description: Returns request from queue.
   operationId: requestQueue_request_get
-  security:
-    - apiKeyQueueId: []
-    - httpBearerQueueId: []
   parameters:
     - name: queueId
       in: path


### PR DESCRIPTION
merge apiKey & htttpBearer to one per
make sure all endpoints refer to correct security
adjust descriptions
add admonitions