### PR TITLE
docs: Improve Quick Start section in the platform docs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -82,7 +82,7 @@
                 "@stackql/docusaurus-plugin-hubspot": "^1.1.0",
                 "algoliasearch": "^5.19.0",
                 "algoliasearch-helper": "^3.22.6",
-                "axios": "^1.11.0",
+                "axios": "^1.7.9",
                 "babel-loader": "^10.0.0",
                 "docusaurus-gtm-plugin": "^0.0.2",
                 "postcss-preset-env": "^10.1.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -82,7 +82,7 @@
                 "@stackql/docusaurus-plugin-hubspot": "^1.1.0",
                 "algoliasearch": "^5.19.0",
                 "algoliasearch-helper": "^3.22.6",
-                "axios": "^1.7.9",
+                "axios": "^1.11.0",
                 "babel-loader": "^10.0.0",
                 "docusaurus-gtm-plugin": "^0.0.2",
                 "postcss-preset-env": "^10.1.3",

--- a/sources/platform/actors/development/quick_start/index.mdx
+++ b/sources/platform/actors/development/quick_start/index.mdx
@@ -40,7 +40,7 @@ You can develop Actor in two ways:
 
 Develop your Actor locally in your IDE and only deploy to the Apify platform when it is production ready.
 
-This way, you benefit from your local setup for a better development and debugging experience. After you are done with the development, you can easily [deploy](./deployment) your Actor to Apify platform.
+This way, you benefit from your local setup for a better development and debugging experience. After you are done with the development, you can [deploy](./deployment) your Actor to the Apify platform.
 
 <CardGrid>
     <Card

--- a/sources/platform/actors/development/quick_start/index.mdx
+++ b/sources/platform/actors/development/quick_start/index.mdx
@@ -36,7 +36,7 @@ For these languages, you can also [choose from many code templates](https://apif
 
 You can develop Actor in two ways:
 
-### Option 1: Local Development
+### Local development
 
 Develop your Actor locally in your IDE and only deploy to the Apify platform when it is production ready.
 

--- a/sources/platform/actors/development/quick_start/index.mdx
+++ b/sources/platform/actors/development/quick_start/index.mdx
@@ -36,7 +36,7 @@ For these languages, you can also [choose from many code templates](https://apif
 
 You can develop Actor in two ways:
 
-### Option 1: local Development
+### Option 1: Local Development
 
 Develop your Actor locally in your IDE and only deploy to the Apify platform when it is production ready. 
 

--- a/sources/platform/actors/development/quick_start/index.mdx
+++ b/sources/platform/actors/development/quick_start/index.mdx
@@ -1,53 +1,63 @@
 ---
 title: Quick start
 sidebar_position: 1
-description: Create your first Actor using the Apify Console IDE or locally.
+description: Create your first Actor using the Apify Web IDE or locally in your IDE.
 slug: /actors/development/quick-start
 ---
 
+import Card from "@site/src/components/Card";
+import CardGrid from "@site/src/components/CardGrid";
+
 # Development: Quick start
 
-**Create your first Actor using the Apify Console IDE or locally.**
+**Create your first Actor using the Apify Web IDE or locally in your IDE.**
 
 ---
 
-:::note
+:::info
 
 Before you start building your own Actor, try out a couple of existing Actors from [Apify Store](https://apify.com/store). See the [Running Actors](../../running/index.md) section for more information on running existing Actors.
 
 :::
 
-## Language
+## Technology Stack
 
 Any code that can run inside of a Docker container can be turned into Apify [Actor](../../index.mdx). This gives you freedom in choosing your technical stack, including programming language and technologies.
 
 But to fully benefit from running on top of the Apify platform, we recommend you choose either JavaScript/Node.js or Python, where Apify provides first-level support regarding its SDK, API clients, and learning materials.
 
-For these languages, you can also choose from many code templates that help you to kickstart your project quickly:
+For these languages, you can also [choose from many code templates](https://apify.com/templates) that help you to kickstart your project quickly:
 
 <a href="https://apify.com/templates" target="_blank">
     <img src={require("./images/templates.png").default} width="70%" />
 </a>
 
-## [](#local-development)Local development
+## Development Paths
 
-You can create Actor in two ways:
+You can develop Actor in two ways:
 
-- Using the **Web IDE** in [Apify Console](https://console.apify.com). This is the fastest way to kick-start your Actor development and try out the Apify platform.
-- Develop your Actor **locally** and only deploy to the Apify platform when it is production ready. This way, you benefit from your local setup for a better development and debugging experience. After you are done with the development, you can easily [deploy](./deployment) your Actor to Apify platform.
+### Option 1: local Development
 
-Now, let's start with:
+Develop your Actor locally in your IDE and only deploy to the Apify platform when it is production ready. 
 
-import Card from "@site/src/components/Card";
-import CardGrid from "@site/src/components/CardGrid";
+This way, you benefit from your local setup for a better development and debugging experience. After you are done with the development, you can easily [deploy](./deployment) your Actor to Apify platform.
 
 <CardGrid>
     <Card
-        title="Apify Console web IDE"
-        to="/platform/actors/development/quick-start/web-ide"
-    />
-    <Card
-        title="Locally on your machine"
+        title="Start Locally in Your IDE"
         to="/platform/actors/development/quick-start/locally"
+    />
+</CardGrid>
+
+### Option 2: Web IDE
+
+Using the Web IDE in [Apify Console](https://console.apify.com). 
+
+This is the fastest way to kick-start your Actor development and try out the Apify platform.
+
+<CardGrid>
+    <Card
+        title="Start in Apify Web IDE"
+        to="/platform/actors/development/quick-start/web-ide"
     />
 </CardGrid>

--- a/sources/platform/actors/development/quick_start/index.mdx
+++ b/sources/platform/actors/development/quick_start/index.mdx
@@ -8,8 +8,6 @@ slug: /actors/development/quick-start
 import Card from "@site/src/components/Card";
 import CardGrid from "@site/src/components/CardGrid";
 
-# Development: Quick start
-
 **Create your first Actor using the Apify Web IDE or locally in your IDE.**
 
 ---

--- a/sources/platform/actors/development/quick_start/index.mdx
+++ b/sources/platform/actors/development/quick_start/index.mdx
@@ -20,7 +20,7 @@ Before you start building your own Actor, try out a couple of existing Actors fr
 
 :::
 
-## Technology Stack
+## Technology stack
 
 Any code that can run inside of a Docker container can be turned into Apify [Actor](../../index.mdx). This gives you freedom in choosing your technical stack, including programming language and technologies.
 

--- a/sources/platform/actors/development/quick_start/index.mdx
+++ b/sources/platform/actors/development/quick_start/index.mdx
@@ -38,7 +38,7 @@ You can develop Actor in two ways:
 
 ### Option 1: Local Development
 
-Develop your Actor locally in your IDE and only deploy to the Apify platform when it is production ready. 
+Develop your Actor locally in your IDE and only deploy to the Apify platform when it is production ready.
 
 This way, you benefit from your local setup for a better development and debugging experience. After you are done with the development, you can easily [deploy](./deployment) your Actor to Apify platform.
 
@@ -51,7 +51,7 @@ This way, you benefit from your local setup for a better development and debuggi
 
 ### Option 2: Web IDE
 
-Using the Web IDE in [Apify Console](https://console.apify.com). 
+Using the Web IDE in [Apify Console](https://console.apify.com).
 
 This is the fastest way to kick-start your Actor development and try out the Apify platform.
 

--- a/sources/platform/actors/development/quick_start/index.mdx
+++ b/sources/platform/actors/development/quick_start/index.mdx
@@ -14,7 +14,7 @@ import CardGrid from "@site/src/components/CardGrid";
 
 ---
 
-:::info
+:::info Before you build
 
 Before you start building your own Actor, try out a couple of existing Actors from [Apify Store](https://apify.com/store). See the [Running Actors](../../running/index.md) section for more information on running existing Actors.
 

--- a/sources/platform/actors/development/quick_start/index.mdx
+++ b/sources/platform/actors/development/quick_start/index.mdx
@@ -49,7 +49,7 @@ This way, you benefit from your local setup for a better development and debuggi
     />
 </CardGrid>
 
-### Option 2: Web IDE
+### Web IDE
 
 Using the Web IDE in [Apify Console](https://console.apify.com).
 

--- a/sources/platform/actors/development/quick_start/index.mdx
+++ b/sources/platform/actors/development/quick_start/index.mdx
@@ -28,7 +28,7 @@ For these languages, you can also [choose from many code templates](https://apif
 
 ![Actor Templates](./images/templates.png)
 
-## Development Paths
+## Development paths
 
 You can develop Actor in two ways:
 

--- a/sources/platform/actors/development/quick_start/index.mdx
+++ b/sources/platform/actors/development/quick_start/index.mdx
@@ -26,11 +26,9 @@ Any code that can run inside of a Docker container can be turned into Apify [Act
 
 But to fully benefit from running on top of the Apify platform, we recommend you choose either JavaScript/Node.js or Python, where Apify provides first-level support regarding its SDK, API clients, and learning materials.
 
-For these languages, you can also [choose from many code templates](https://apify.com/templates) that help you to kickstart your project quickly:
+For these languages, you can also [choose from many code templates](https://apify.com/templates) that help you to kickstart your project quickly.
 
-<a href="https://apify.com/templates" target="_blank">
-    <img src={require("./images/templates.png").default} width="70%" />
-</a>
+![Actor Templates](./images/templates.png)
 
 ## Development Paths
 

--- a/sources/platform/actors/development/quick_start/start_locally.md
+++ b/sources/platform/actors/development/quick_start/start_locally.md
@@ -49,7 +49,7 @@ Now, you can navigate to your new Actor directory:
 cd your-actor-name
 ```
 
-## Step 2: Run your Actor
+### Step 2: Run your Actor
 
 Run your Actor with:
 

--- a/sources/platform/actors/development/quick_start/start_locally.md
+++ b/sources/platform/actors/development/quick_start/start_locally.md
@@ -99,7 +99,7 @@ This JSON Schema validates input automatically (no error handling needed), power
 
 Find more info in the [Input schema](/platform/actors/development/actor-definition/input-schema) documentation.
 
-### Actor's `storage`
+#### Actor's `storage`
 
 The Actor system provides two storage types for files and results: [key-value](/platform/actors/development/actor-definition/key-value-store-schema) store and [dataset](/platform/actors/development/actor-definition/dataset-schema).
 

--- a/sources/platform/actors/development/quick_start/start_locally.md
+++ b/sources/platform/actors/development/quick_start/start_locally.md
@@ -32,30 +32,45 @@ apify create
 
 The Apify CLI will prompt you to:
 
-1. _Name your Actor_: Enter a descriptive name for your Actor, such as `your-actor-name`
-1. _Choose a programming language_: Select the language you want to use for your Actor (JavaScript, TypeScript, or Python).
-1. _Select a development template_: Choose a template from the list of available options.
+1. Name your Actor: Enter a descriptive name for your Actor, such as `your-actor-name`.
+1. Choose a programming language: Select the language you want to use for your Actor (JavaScript, TypeScript, or Python).
+1. Select a development template: Choose a template from the list of available options.
+   :::info
 
-:::info
+   If you’re unsure which template to use, browse the [full list of templates](https://apify.com/templates) with descriptions to find the best fit for your Actor.
 
-If you’re unsure which template to use, browse the [full list of templates]((https://apify.com/templates)) with descriptions to find the best fit for your Actor.
+   :::
+1. After selecting the template, the Apify CLI will:
+   - Create a `your-actor-name` directory with the boilerplate code.
+   - Install all project dependencies.
+1. Navigate to your new Actor directory:
+    ```bash
+    cd your-actor-name
+    ```
 
-:::
+## Step 2: Run your Actor
 
-![Creation](./images/actor-create.gif)
+- tbd (see the result as soon as possible)
 
-After selecting the template, the Apify CLI will:
+## Step 3: Explore the Result
 
-- Create a `your-actor-name` directory with the boilerplate code.
-- Install all project dependencies
+- tbd (see the result - AHA moment, I get data)
+- explain the "code"
 
-Now, you can navigate to the newly created Actor directory:
+## Step 4: Deploy your Actor
 
-```bash
-cd your-actor-name
-```
+- tbd
 
-## Explore the source code in your editor
+## Step 5: It's time to build!
+
+- Encourage developers to edit actors, build interesting stuff, etc.
+- Optional...
+
+## Next Steps
+
+- tbd (deploy)
+
+<!-- ## Explore the source code in your editor
 
 After creating your Actor, explore the source code in your preferred code editor, We'll use the `Crawlee + Puppeteer + Chrome` template code as an example, but all Actor templates follow a similar organizational pattern. The important directories and filer are:
 
@@ -121,4 +136,4 @@ Once you are satisfied with your Actor, to deploy it to the Apify platform, foll
 
     :::
 
-By following these steps, you can seamlessly deploy your Actors to the Apify platform, enabling you to leverage its scalability, reliability, and advanced features for your web scraping and data processing projects.
+By following these steps, you can seamlessly deploy your Actors to the Apify platform, enabling you to leverage its scalability, reliability, and advanced features for your web scraping and data processing projects. -->

--- a/sources/platform/actors/development/quick_start/start_locally.md
+++ b/sources/platform/actors/development/quick_start/start_locally.md
@@ -89,7 +89,7 @@ The `.actor` folder contains the Actor configuration. The `actor.json` file defi
 
 Each Actor accepts an `input object` that tells it what to do. The object uses JSON format and lives in `storage/key_value_stores/default/INPUT.json`.
 
-:::info
+:::info Edit the schema to change input
 
 To change the `INPUT.json`, edit the `input_schema.json` in the `.actor` folder first.
 

--- a/sources/platform/actors/development/quick_start/start_locally.md
+++ b/sources/platform/actors/development/quick_start/start_locally.md
@@ -19,39 +19,39 @@ slug: /actors/development/quick-start/locally
 
 - [Node.js](https://nodejs.org/en/) version 16 or higher with `npm` installed on your computer.
 - The [Apify CLI](/cli/docs/installation) installed.
-- Optional: If you want to deploy your Actor to the Apify platform, you need to [sign in](https://console.apify.com/sign-in).
-
----
+- Optional: To deploy your Actor, [sign in](https://console.apify.com/sign-in).
 
 ## Step 1: Create your Actor
 
-Use Apify CLI to create a new Actor using the following command:
+Use Apify CLI to create a new Actor:
 
 ```bash
 apify create
 ```
 
-The Apify CLI will prompt you to:
+The CLI will ask you to:
 
-1. Name your Actor: Enter a descriptive name for your Actor, such as `your-actor-name`.
-1. Choose a programming language: Select the language you want to use for your Actor (JavaScript, TypeScript, or Python).
-1. Select a development template: Choose a template from the list of available options.
+1. Name your Actor (e.g., `your-actor-name`)
+2. Choose a programming language (`JavaScript`, `TypeScript`, or `Python`)
+3. Select a development template
    :::info
 
-   If you’re unsure which template to use, browse the [full list of templates](https://apify.com/templates) with descriptions to find the best fit for your Actor.
+   Browse the [full list of templates](https://apify.com/templates) to find the best fit for your Actor.
 
    :::
-1. After selecting the template, the Apify CLI will:
-   - Create a `your-actor-name` directory with the boilerplate code.
-   - Install all project dependencies.
-1. Navigate to your new Actor directory:
-    ```bash
-    cd your-actor-name
-    ```
+
+The CLI will:
+- Create a `your-actor-name` directory with boilerplate code
+- Install all project dependencies
+
+Now, you can navigate to your new Actor directory:
+```bash
+cd your-actor-name
+```
 
 ## Step 2: Run your Actor
 
-After creating your Actor, you can run it with:
+Run your Actor with:
 
 ```bash
 apify run
@@ -59,11 +59,11 @@ apify run
 
 :::tip
 
-During development, use `apify run --purge`. This command clears all results from previous runs, so it’s as if you’re running the Actor for the first time.
+During development, use `apify run --purge`. This clears all results from previous runs, so it's as if you're running the Actor for the first time.
 
 :::
 
-This command runs your Actor, and you’ll see output similar to the following in your terminal:
+You'll see output similar to this in your terminal:
 
 ```bash
 INFO  System info {"apifyVersion":"3.4.3","apifyClientVersion":"2.12.6","crawleeVersion":"3.13.10","osType":"Darwin","nodeVersion":"v22.17.0"}
@@ -73,85 +73,80 @@ Extracted heading { level: 'h3', text: 'Google Maps Scraper' }
 Extracted heading { level: 'h3', text: 'Instagram Scraper' }
 ```
 
-As you can see in the logs, the Actor extracts text from a web page. All the main logic is defined in `src/main.js`. Depending on the template you chose, this file may also be `src/main.ts` (for TypeScript) or `src/main.py` (for Python).
+As you can see in the logs, the Actor extracts text from a web page. The main logic lives in `src/main.js`. Depending on your template, this file may be `src/main.ts` (TypeScript) or `src/main.py` (Python).
 
 In the next step, we’ll explore the results in more detail.
 
 ## Step 3: Explore the Actor
 
-<!-- TODO: Add more examples -->
-
-The following section will explain the Actor in more details.
+Let's explore the Actor structure.
 
 ### The `.actor` folder
 
-The Actor configuration is in the folder `.actor`. The file `actor.json` defines the Actor's configuration, such as name, description, etc. You can find more info in [actor.json](https://docs.apify.com/platform/actors/development/actor-definition/actor-json) definition.
+The `.actor` folder contains the Actor configuration. The `actor.json` file defines the Actor's name, description, and other settings. Find more info in the [actor.json](https://docs.apify.com/platform/actors/development/actor-definition/actor-json) definition.
 
 ### Actor's `input`
 
-Each Actor accepts an `input object`, which tells it what it should do. The object is passed in JSON format, and you can find it in `storage/key_value_stores/default/INPUT.json`.
+Each Actor accepts an `input object` that tells it what to do. The object uses JSON format and lives in `storage/key_value_stores/default/INPUT.json`.
 
 :::info
 
-To change the `INPUT.json`, edit first the `input_schema.json` in the `.actor` folder. 
+To change the `INPUT.json`, edit the `input_schema.json` in the `.actor` folder first. 
 
-This JSON Schema not only validates input automatically (so you don't need to handle input errors in your code), but also powers the Actor's user interface, generates API docs, and enables smart integration with tools like Zapier or Make by auto-linking input fields.
+This JSON Schema validates input automatically (no error handling needed), powers the Actor's user interface, generates API docs, and enables smart integration with tools like Zapier or Make by auto-linking input fields.
 
 :::
 
-You can find more info in the [Input schema](/platform/actors/development/actor-definition/input-schema) documentation.
+Find more info in the [Input schema](/platform/actors/development/actor-definition/input-schema) documentation.
 
 ### Actor's `storage`
 
-The Actor system provides two specialized storages that can be used by Actors for storing files and results: `key-value` store and `dataset`.
+The Actor system provides two storage types for files and results: `key-value` store and `dataset`.
 
 #### Key-value store
 
-The key-value store is a simple data storage that is used for saving and reading files or data records.
-
-Key-value stores are ideal for saving things like screenshots, PDFs, or to persist the state of Actors e.g. as a JSON file.
+The key-value store saves and reads files or data records. Key-value stores work well for screenshots, PDFs, or persisting Actor state as JSON files.
 
 #### Dataset 
 
-The dataset is an append-only storage that allows you to store a series of data objects such as results from web scraping, crawling, or data processing jobs. You or your users can then export the dataset to formats such as JSON, CSV, XML, RSS, Excel, or HTML.
+The dataset stores a series of data objects from web scraping, crawling, or data processing jobs. You can export datasets to JSON, CSV, XML, RSS, Excel, or HTML formats.
 
 ### Actor's `output`
 
-While the input object provides a standardized way to invoke Actors, Actors can also generate an output object, which is a standardized way to display, consume, and integrate Actors’ results.
+You define the Actor output using the Output schema files:
 
-You can define how the Actor output looks using the Output schema file. The system uses this information to automatically generate an immutable JSON file, which tells users where to find the results produced by the Actor.
+- [Dataset Schema Specification](/platform/actors/development/actor-definition/dataset-schema)
+- [Key-value Store Schema Specification](/platform/actors/development/actor-definition/key-value-store-schema)
+
+The system uses this to generate an immutable JSON file that tells users where to find the Actor's results.
 
 ## Step 4: Deploy your Actor
 
-Let's now deploy your Actor to the Apify platform, where you can for example run the Actor on scheduled basis, or you can make the Actor public for other users.
+Let's now deploy your Actor to the Apify platform, where you can run the Actor on a scheduled basis, or you can make the Actor public for other users.
 
-1. First of all, you need to login:
+1. Login first:
 
     ```bash
     apify login
     ```
 
     :::info
-    After you succesfull login, your Apify token is stored in `~/.apify/auth.json`, or `C:\Users\<name>\.apify` based on your system.
+    After you successfully login, your Apify token is stored in `~/.apify/auth.json`, or `C:\Users\<name>\.apify` based on your system.
     :::
 
-1. Now, you can push your Actor to the Apify platform:
+2. Push your Actor to the Apify platform:
 
     ```bash
     apify push
     ```
 
-## Step 5: It's time to build!
+## Step 5: It's Time to Iterate!
 
-Good job, you have done it! 🎉  From here, you can develop your Actor.
-
-:::tip Actor monetization
-
-If you have successfully completed your first Actor, you may consider [sharing it with other users and monetizing it](../../publishing/index.mdx). The Apify platform provides opportunities to publish and monetize your Actors, allowing you to share your work with the community and potentially generate revenue.
-
-:::
+Good job! 🎉 You're ready to develop your Actor. You can make changes to your Actor and implement your use case.
 
 ## Next Steps
 
-- If you want to understand Actors in more details, read the [Actor Whitepaper](https://whitepaper.actor/).
+- Visit the [Apify Academy](/academy) to access a comprehensive collection of tutorials, documentation, and learning resources.
+- To understand Actors in detail, read the [Actor Whitepaper](https://whitepaper.actor/).
 - Check [Continuous integration](../deployment/continuous_integration.md) documentation to automate your Actor development process.
+- After you finish building your first Actor, you can [share it with other users and even monetize it](../../publishing/index.mdx).

--- a/sources/platform/actors/development/quick_start/start_locally.md
+++ b/sources/platform/actors/development/quick_start/start_locally.md
@@ -101,7 +101,7 @@ Find more info in the [Input schema](/platform/actors/development/actor-definiti
 
 #### Actor's `storage`
 
-The Actor system provides two storage types for files and results: [key-value](/platform/actors/development/actor-definition/key-value-store-schema) store and [dataset](/platform/actors/development/actor-definition/dataset-schema).
+The Actor system provides two storage types for files and results: [key-value](/platform/storage/key-value-store) store and [dataset](/platform/storage/dataset).
 
 ##### Key-value store
 

--- a/sources/platform/actors/development/quick_start/start_locally.md
+++ b/sources/platform/actors/development/quick_start/start_locally.md
@@ -77,7 +77,7 @@ As you can see in the logs, the Actor extracts text from a web page. The main lo
 
 In the next step, we’ll explore the results in more detail.
 
-## Step 3: Explore the Actor
+### Step 3: Explore the Actor
 
 Let's explore the Actor structure.
 

--- a/sources/platform/actors/development/quick_start/start_locally.md
+++ b/sources/platform/actors/development/quick_start/start_locally.md
@@ -107,7 +107,7 @@ The Actor system provides two storage types for files and results: [key-value](/
 
 The key-value store saves and reads files or data records. Key-value stores work well for screenshots, PDFs, or persisting Actor state as JSON files.
 
-#### Dataset
+##### Dataset
 
 The dataset stores a series of data objects from web scraping, crawling, or data processing jobs. You can export datasets to JSON, CSV, XML, RSS, Excel, or HTML formats.
 

--- a/sources/platform/actors/development/quick_start/start_locally.md
+++ b/sources/platform/actors/development/quick_start/start_locally.md
@@ -81,7 +81,7 @@ In the next step, we’ll explore the results in more detail.
 
 Let's explore the Actor structure.
 
-### The `.actor` folder
+#### The `.actor` folder
 
 The `.actor` folder contains the Actor configuration. The `actor.json` file defines the Actor's name, description, and other settings. Find more info in the [actor.json](https://docs.apify.com/platform/actors/development/actor-definition/actor-json) definition.
 

--- a/sources/platform/actors/development/quick_start/start_locally.md
+++ b/sources/platform/actors/development/quick_start/start_locally.md
@@ -11,9 +11,7 @@ slug: /actors/development/quick-start/locally
 
 ## What you'll learn
 
-- How to create and run your first Actor locally using Apify CLI
-- How to understand and configure Actor input, output, and storage
-- How to deploy your Actor to the Apify platform
+This guide walks you through the full lifecycle of an Actor. You'll start by creating and running it locally with the Apify CLI, then learn to configure its input and data storage. Finally, you will deploy the Actor to the Apify platform, making it ready to run in the cloud.
 
 ## Prerequisites
 

--- a/sources/platform/actors/development/quick_start/start_locally.md
+++ b/sources/platform/actors/development/quick_start/start_locally.md
@@ -41,10 +41,12 @@ The CLI will ask you to:
    :::
 
 The CLI will:
+
 - Create a `your-actor-name` directory with boilerplate code
 - Install all project dependencies
 
 Now, you can navigate to your new Actor directory:
+
 ```bash
 cd your-actor-name
 ```
@@ -91,7 +93,7 @@ Each Actor accepts an `input object` that tells it what to do. The object uses J
 
 :::info
 
-To change the `INPUT.json`, edit the `input_schema.json` in the `.actor` folder first. 
+To change the `INPUT.json`, edit the `input_schema.json` in the `.actor` folder first.
 
 This JSON Schema validates input automatically (no error handling needed), powers the Actor's user interface, generates API docs, and enables smart integration with tools like Zapier or Make by auto-linking input fields.
 
@@ -107,7 +109,7 @@ The Actor system provides two storage types for files and results: `key-value` s
 
 The key-value store saves and reads files or data records. Key-value stores work well for screenshots, PDFs, or persisting Actor state as JSON files.
 
-#### Dataset 
+#### Dataset
 
 The dataset stores a series of data objects from web scraping, crawling, or data processing jobs. You can export datasets to JSON, CSV, XML, RSS, Excel, or HTML formats.
 

--- a/sources/platform/actors/development/quick_start/start_locally.md
+++ b/sources/platform/actors/development/quick_start/start_locally.md
@@ -9,54 +9,47 @@ slug: /actors/development/quick-start/locally
 
 ---
 
-:::info Prerequisites
+## What you'll learn
 
-You need to have [Node.js](https://nodejs.org/en/) version 16 or higher with `npm` installed on your computer.
+- tbd
 
-:::
 
-## Install Apify CLI
+## Prerequisites
 
-### MacOS/Linux
+- [Node.js](https://nodejs.org/en/) version 16 or higher with `npm` installed on your computer.
+- The [Apify CLI](/cli/docs/installation) installed.
+- Optional: If you want to deploy your Actor to the Apify platform, you need to [sign in](https://console.apify.com/sign-in).
 
-You can install the Apify CLI via the [Homebrew package manager](https://brew.sh/).
+---
 
-```bash
-brew install apify-cli
-```
+## Step 1: Create your Actor
 
-### Other platforms
-
-Use [NPM](https://www.npmjs.com/) to install the Apify CLI.
-
-```bash
-npm -g install apify-cli
-```
-
-Visit [Apify CLI documentation](https://docs.apify.com/cli/) for more information regarding installation and advanced usage.
-
-## Create your Actor
-
-To create a new Actor, use the following command:
+Use Apify CLI to create a new Actor using the following command:
 
 ```bash
 apify create
 ```
 
-The CLI will prompt you to:
+The Apify CLI will prompt you to:
 
 1. _Name your Actor_: Enter a descriptive name for your Actor, such as `your-actor-name`
 1. _Choose a programming language_: Select the language you want to use for your Actor (JavaScript, TypeScript, or Python).
 1. _Select a development template_: Choose a template from the list of available options.
 
-After selecting the template, the CLI will:
+:::info
+
+If you’re unsure which template to use, browse the [full list of templates]((https://apify.com/templates)) with descriptions to find the best fit for your Actor.
+
+:::
+
+![Creation](./images/actor-create.gif)
+
+After selecting the template, the Apify CLI will:
 
 - Create a `your-actor-name` directory with the boilerplate code.
 - Install all project dependencies
 
-![Creation](./images/actor-create.gif)
-
-Navigate to the newly created Actor directory:
+Now, you can navigate to the newly created Actor directory:
 
 ```bash
 cd your-actor-name

--- a/sources/platform/actors/development/quick_start/start_locally.md
+++ b/sources/platform/actors/development/quick_start/start_locally.md
@@ -146,7 +146,7 @@ Let's now deploy your Actor to the Apify platform, where you can run the Actor o
 
 Good job! 🎉 You're ready to develop your Actor. You can make changes to your Actor and implement your use case.
 
-## Next Steps
+## Next steps
 
 - Visit the [Apify Academy](/academy) to access a comprehensive collection of tutorials, documentation, and learning resources.
 - To understand Actors in detail, read the [Actor Whitepaper](https://whitepaper.actor/).

--- a/sources/platform/actors/development/quick_start/start_locally.md
+++ b/sources/platform/actors/development/quick_start/start_locally.md
@@ -131,9 +131,9 @@ Let's now deploy your Actor to the Apify platform, where you can run the Actor o
     ```
 
     :::info Your Apify token location
-    
+
     After you successfully login, your Apify token is stored in `~/.apify/auth.json`, or `C:\Users\<name>\.apify` based on your system.
-    
+
     :::
 
 2. Push your Actor to the Apify platform:

--- a/sources/platform/actors/development/quick_start/start_locally.md
+++ b/sources/platform/actors/development/quick_start/start_locally.md
@@ -11,8 +11,9 @@ slug: /actors/development/quick-start/locally
 
 ## What you'll learn
 
-- tbd
-
+- How to create and run your first Actor locally using Apify CLI
+- How to understand and configure Actor input, output, and storage
+- How to deploy your Actor to the Apify platform
 
 ## Prerequisites
 
@@ -50,90 +51,107 @@ The Apify CLI will prompt you to:
 
 ## Step 2: Run your Actor
 
-- tbd (see the result as soon as possible)
-
-## Step 3: Explore the Result
-
-- tbd (see the result - AHA moment, I get data)
-- explain the "code"
-
-## Step 4: Deploy your Actor
-
-- tbd
-
-## Step 5: It's time to build!
-
-- Encourage developers to edit actors, build interesting stuff, etc.
-- Optional...
-
-## Next Steps
-
-- tbd (deploy)
-
-<!-- ## Explore the source code in your editor
-
-After creating your Actor, explore the source code in your preferred code editor, We'll use the `Crawlee + Puppeteer + Chrome` template code as an example, but all Actor templates follow a similar organizational pattern. The important directories and filer are:
-
-### `src` Directory
-
-- `src/main.js`: This file contains the actual code of your Actor
-
-### `.actor` Directory
-
-- [`actor.json`](https://docs.apify.com/platform/actors/development/actor-definition/actor-json): This file defines the Actor's configuration, such as input and output specifications.
-- [`Dockerfile`](https://docs.apify.com/platform/actors/development/actor-definition/dockerfile): This file contains instructions for building the Docker image for your Actor.
-
-### `storage` Directory
-
-- This directory emulates the [Apify Storage](../../../storage/index.md)
-  - [Dataset](../../../storage/dataset.md)
-  - [Key-Value Store](../../../storage/key_value_store.md)
-  - [Request Queue](../../../storage/request_queue.md)
-
-![Actor source code](./images/actor-local-code.png)
-
-## Run it locally
-
-To run your Actor locally, use the following command:
+After creating your Actor, you can run it with:
 
 ```bash
 apify run
 ```
 
-After executing this command, you will see the Actor's log output in your terminal. The results of the Actor's execution will be stored in the local dataset located in the `storage/datasets/default` directory.
+:::tip
 
-![Actor source code](./images/actor-local-run.png)
-
-:::note Local testing & debugging
-
-Running the Actor locally allows you to test and debug your code before deploying it to the Apify platform.
+During development, use `apify run --purge`. This command clears all results from previous runs, so it’s as if you’re running the Actor for the first time.
 
 :::
 
-## Deploy it to Apify platform
+This command runs your Actor, and you’ll see output similar to the following in your terminal:
 
-Once you are satisfied with your Actor, to deploy it to the Apify platform, follow these steps:
+```bash
+INFO  System info {"apifyVersion":"3.4.3","apifyClientVersion":"2.12.6","crawleeVersion":"3.13.10","osType":"Darwin","nodeVersion":"v22.17.0"}
+Extracted heading { level: 'h1', text: 'Your full‑stack platform for web scraping' }
+Extracted heading { level: 'h3', text: 'TikTok Scraper' }
+Extracted heading { level: 'h3', text: 'Google Maps Scraper' }
+Extracted heading { level: 'h3', text: 'Instagram Scraper' }
+```
 
-1. _Sign in to Apify with the CLI tool_
+As you can see in the logs, the Actor extracts text from a web page. All the main logic is defined in `src/main.js`. Depending on the template you chose, this file may also be `src/main.ts` (for TypeScript) or `src/main.py` (for Python).
+
+In the next step, we’ll explore the results in more detail.
+
+## Step 3: Explore the Actor
+
+<!-- TODO: Add more examples -->
+
+The following section will explain the Actor in more details.
+
+### The `.actor` folder
+
+The Actor configuration is in the folder `.actor`. The file `actor.json` defines the Actor's configuration, such as name, description, etc. You can find more info in [actor.json](https://docs.apify.com/platform/actors/development/actor-definition/actor-json) definition.
+
+### Actor's `input`
+
+Each Actor accepts an `input object`, which tells it what it should do. The object is passed in JSON format, and you can find it in `storage/key_value_stores/default/INPUT.json`.
+
+:::info
+
+To change the `INPUT.json`, edit first the `input_schema.json` in the `.actor` folder. 
+
+This JSON Schema not only validates input automatically (so you don't need to handle input errors in your code), but also powers the Actor's user interface, generates API docs, and enables smart integration with tools like Zapier or Make by auto-linking input fields.
+
+:::
+
+You can find more info in the [Input schema](/platform/actors/development/actor-definition/input-schema) documentation.
+
+### Actor's `storage`
+
+The Actor system provides two specialized storages that can be used by Actors for storing files and results: `key-value` store and `dataset`.
+
+#### Key-value store
+
+The key-value store is a simple data storage that is used for saving and reading files or data records.
+
+Key-value stores are ideal for saving things like screenshots, PDFs, or to persist the state of Actors e.g. as a JSON file.
+
+#### Dataset 
+
+The dataset is an append-only storage that allows you to store a series of data objects such as results from web scraping, crawling, or data processing jobs. You or your users can then export the dataset to formats such as JSON, CSV, XML, RSS, Excel, or HTML.
+
+### Actor's `output`
+
+While the input object provides a standardized way to invoke Actors, Actors can also generate an output object, which is a standardized way to display, consume, and integrate Actors’ results.
+
+You can define how the Actor output looks using the Output schema file. The system uses this information to automatically generate an immutable JSON file, which tells users where to find the results produced by the Actor.
+
+## Step 4: Deploy your Actor
+
+Let's now deploy your Actor to the Apify platform, where you can for example run the Actor on scheduled basis, or you can make the Actor public for other users.
+
+1. First of all, you need to login:
 
     ```bash
     apify login
     ```
 
-    This command will prompt you to provide your API token that you can find in Console.
+    :::info
+    After you succesfull login, your Apify token is stored in `~/.apify/auth.json`, or `C:\Users\<name>\.apify` based on your system.
+    :::
 
-1. _Push your Actor to the Apify platform_
+1. Now, you can push your Actor to the Apify platform:
 
     ```bash
     apify push
     ```
 
-    This command will upload your Actor's code and configuration to the Apify platform, where it can be executed and managed.
+## Step 5: It's time to build!
 
-    :::note Actor monetization
+Good job, you have done it! 🎉  From here, you can develop your Actor.
 
-    If you have successfully completed your first Actor, you may consider [sharing it with other users and monetizing it](../../publishing/index.mdx). The Apify platform provides opportunities to publish and monetize your Actors, allowing you to share your work with the community and potentially generate revenue.
+:::tip Actor monetization
 
-    :::
+If you have successfully completed your first Actor, you may consider [sharing it with other users and monetizing it](../../publishing/index.mdx). The Apify platform provides opportunities to publish and monetize your Actors, allowing you to share your work with the community and potentially generate revenue.
 
-By following these steps, you can seamlessly deploy your Actors to the Apify platform, enabling you to leverage its scalability, reliability, and advanced features for your web scraping and data processing projects. -->
+:::
+
+## Next Steps
+
+- If you want to understand Actors in more details, read the [Actor Whitepaper](https://whitepaper.actor/).
+- Check [Continuous integration](../deployment/continuous_integration.md) documentation to automate your Actor development process.

--- a/sources/platform/actors/development/quick_start/start_locally.md
+++ b/sources/platform/actors/development/quick_start/start_locally.md
@@ -142,7 +142,7 @@ Let's now deploy your Actor to the Apify platform, where you can run the Actor o
     apify push
     ```
 
-## Step 5: It's Time to Iterate!
+### Step 5: It's Time to Iterate!
 
 Good job! 🎉 You're ready to develop your Actor. You can make changes to your Actor and implement your use case.
 

--- a/sources/platform/actors/development/quick_start/start_locally.md
+++ b/sources/platform/actors/development/quick_start/start_locally.md
@@ -19,7 +19,7 @@ This guide walks you through the full lifecycle of an Actor. You'll start by cre
 - The [Apify CLI](/cli/docs/installation) installed.
 - Optional: To deploy your Actor, [sign in](https://console.apify.com/sign-in).
 
-## Step 1: Create your Actor
+### Step 1: Create your Actor
 
 Use Apify CLI to create a new Actor:
 

--- a/sources/platform/actors/development/quick_start/start_locally.md
+++ b/sources/platform/actors/development/quick_start/start_locally.md
@@ -103,7 +103,7 @@ Find more info in the [Input schema](/platform/actors/development/actor-definiti
 
 The Actor system provides two storage types for files and results: [key-value](/platform/actors/development/actor-definition/key-value-store-schema) store and [dataset](/platform/actors/development/actor-definition/dataset-schema).
 
-#### Key-value store
+##### Key-value store
 
 The key-value store saves and reads files or data records. Key-value stores work well for screenshots, PDFs, or persisting Actor state as JSON files.
 

--- a/sources/platform/actors/development/quick_start/start_locally.md
+++ b/sources/platform/actors/development/quick_start/start_locally.md
@@ -85,7 +85,7 @@ Let's explore the Actor structure.
 
 The `.actor` folder contains the Actor configuration. The `actor.json` file defines the Actor's name, description, and other settings. Find more info in the [actor.json](https://docs.apify.com/platform/actors/development/actor-definition/actor-json) definition.
 
-### Actor's `input`
+#### Actor's `input`
 
 Each Actor accepts an `input object` that tells it what to do. The object uses JSON format and lives in `storage/key_value_stores/default/INPUT.json`.
 

--- a/sources/platform/actors/development/quick_start/start_locally.md
+++ b/sources/platform/actors/development/quick_start/start_locally.md
@@ -59,7 +59,7 @@ Run your Actor with:
 apify run
 ```
 
-:::tip
+:::tip Clear data with --purge
 
 During development, use `apify run --purge`. This clears all results from previous runs, so it's as if you're running the Actor for the first time.
 

--- a/sources/platform/actors/development/quick_start/start_locally.md
+++ b/sources/platform/actors/development/quick_start/start_locally.md
@@ -130,8 +130,10 @@ Let's now deploy your Actor to the Apify platform, where you can run the Actor o
     apify login
     ```
 
-    :::info
+    :::info Your Apify token location
+    
     After you successfully login, your Apify token is stored in `~/.apify/auth.json`, or `C:\Users\<name>\.apify` based on your system.
+    
     :::
 
 2. Push your Actor to the Apify platform:

--- a/sources/platform/actors/development/quick_start/start_locally.md
+++ b/sources/platform/actors/development/quick_start/start_locally.md
@@ -32,7 +32,7 @@ The CLI will ask you to:
 1. Name your Actor (e.g., `your-actor-name`)
 2. Choose a programming language (`JavaScript`, `TypeScript`, or `Python`)
 3. Select a development template
-   :::info
+   :::info Explore Actor templates
 
    Browse the [full list of templates](https://apify.com/templates) to find the best fit for your Actor.
 
@@ -101,7 +101,7 @@ Find more info in the [Input schema](/platform/actors/development/actor-definiti
 
 ### Actor's `storage`
 
-The Actor system provides two storage types for files and results: `key-value` store and `dataset`.
+The Actor system provides two storage types for files and results: [key-value](/platform/actors/development/actor-definition/key-value-store-schema) store and [dataset](/platform/actors/development/actor-definition/dataset-schema).
 
 #### Key-value store
 

--- a/sources/platform/actors/development/quick_start/start_locally.md
+++ b/sources/platform/actors/development/quick_start/start_locally.md
@@ -120,7 +120,7 @@ You define the Actor output using the Output schema files:
 
 The system uses this to generate an immutable JSON file that tells users where to find the Actor's results.
 
-## Step 4: Deploy your Actor
+### Step 4: Deploy your Actor
 
 Let's now deploy your Actor to the Apify platform, where you can run the Actor on a scheduled basis, or you can make the Actor public for other users.
 

--- a/sources/platform/actors/development/quick_start/start_locally.md
+++ b/sources/platform/actors/development/quick_start/start_locally.md
@@ -111,7 +111,7 @@ The key-value store saves and reads files or data records. Key-value stores work
 
 The dataset stores a series of data objects from web scraping, crawling, or data processing jobs. You can export datasets to JSON, CSV, XML, RSS, Excel, or HTML formats.
 
-### Actor's `output`
+#### Actor's `output`
 
 You define the Actor output using the Output schema files:
 

--- a/sources/platform/actors/development/quick_start/start_locally.md
+++ b/sources/platform/actors/development/quick_start/start_locally.md
@@ -13,7 +13,7 @@ slug: /actors/development/quick-start/locally
 
 This guide walks you through the full lifecycle of an Actor. You'll start by creating and running it locally with the Apify CLI, then learn to configure its input and data storage. Finally, you will deploy the Actor to the Apify platform, making it ready to run in the cloud.
 
-## Prerequisites
+### Prerequisites
 
 - [Node.js](https://nodejs.org/en/) version 16 or higher with `npm` installed on your computer.
 - The [Apify CLI](/cli/docs/installation) installed.

--- a/sources/platform/actors/development/quick_start/start_web_ide.md
+++ b/sources/platform/actors/development/quick_start/start_web_ide.md
@@ -149,7 +149,7 @@ After pulling the Actor's source code to your local machine, you can modify and 
 
 Once you've made the desired changes, you can push the updated code back to the Apify platform for deployment & execution, leveraging the platform's scalability and reliability.
 
-## Next Steps
+## Next steps
 
 - Visit the [Apify Academy](/academy) to access a comprehensive collection of tutorials, documentation, and learning resources.
 - To understand Actors in detail, read the [Actor Whitepaper](https://whitepaper.actor/).

--- a/sources/platform/actors/development/quick_start/start_web_ide.md
+++ b/sources/platform/actors/development/quick_start/start_web_ide.md
@@ -40,7 +40,7 @@ Browse the [full list of templates](https://apify.com/templates) to find the bes
 
 After choosing the template, your Actor will be automatically named and you'll be redirected to its page.
 
-## Step 2: Explore the Actor
+### Step 2: Explore the Actor
 
 The provided boilerplate code utilizes the [Apify SDK](https://docs.apify.com/sdk/js/) combined with [Crawlee](https://crawlee.dev/), Apify's popular open-source Node.js web scraping library.
 

--- a/sources/platform/actors/development/quick_start/start_web_ide.md
+++ b/sources/platform/actors/development/quick_start/start_web_ide.md
@@ -32,7 +32,7 @@ You'll see Actor development templates for `JavaScript`, `TypeScript`, and `Pyth
 
 These templates provide boilerplate code and a preconfigured environment. Choose the template that best suits your needs. For the following demo, we'll proceed with **Crawlee + Puppeteer + Chrome**.
 
-:::info
+:::info Explore Actor templates
 
 Browse the [full list of templates](https://apify.com/templates) to find the best fit for your Actor.
 

--- a/sources/platform/actors/development/quick_start/start_web_ide.md
+++ b/sources/platform/actors/development/quick_start/start_web_ide.md
@@ -12,6 +12,12 @@ import TabItem from '@theme/TabItem';
 
 ---
 
+## What you'll learn
+
+- How to create and run your first Actor locally using Apify CLI
+- How to understand and configure Actor input, output, and storage
+- How to deploy your Actor to the Apify platform
+
 ## Prerequisites
 
 - An Apify account. [Sign up for a free account](https://console.apify.com/sign-up) on the Apify website.

--- a/sources/platform/actors/development/quick_start/start_web_ide.md
+++ b/sources/platform/actors/development/quick_start/start_web_ide.md
@@ -8,35 +8,39 @@ slug: /actors/development/quick-start/web-ide
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-# Development in web IDE
-
 **Create your first Actor using the web IDE in Apify Console.**
 
 ---
 
-<!-- TODO: Revisit, make it more like start_locally, but keep the content, only add steps, etc. -->
+## Prerequisites
 
-## Create the Actor
+- An Apify account. [Sign up for a free account](https://console.apify.com/sign-up) on the Apify website.
 
-:::note Prerequisites
+## Step 1: Create your Actor
 
-To use Web IDE, you will need an Apify account. You can [sign-up for a free account](https://console.apify.com/sign-up) on the Apify website.
-
-:::
-
-After you sign in to [Apify Console](https://console.apify.com), navigate to the [**My Actors**](https://console.apify.com/actors/development/my-actors) subsection. Then, click the **Develop new** button at the top right corner of the page.
+Log in to [Apify Console](https://console.apify.com), navigate to [**My Actors**](https://console.apify.com/actors/development/my-actors), then click the **Develop new** button.
 
 ![Create Actor](./images/create-actor.png)
 
-You will be redirected to a page containing various Actor development templates for popular languages such as `JavaScript`, `TypeScript`, and `Python`. These templates provide boilerplate code and a preconfigured environment tailored to specific use cases. You can choose the template that best suits your technology stack. For demonstration purposes, let's choose **Crawlee + Puppeteer + Chrome**.
+You'll see Actor development templates for `JavaScript`, `TypeScript`, and `Python`. 
+
+These templates provide boilerplate code and a preconfigured environment. Choose the template that best suits your needs. For the following demo, we'll proceed with **Crawlee + Puppeteer + Chrome**.
+
+:::info
+
+Browse the [full list of templates](https://apify.com/templates) to find the best fit for your Actor.
+
+:::
 
 ![Templates](./images/actor-templates.png)
 
-After choosing the template your Actor will be automatically named and you will be redirected to its page.
+After choosing the template, your Actor will be automatically named and you'll be redirected to its page.
 
-### Explore the source code
+## Step 2: Explore the Actor
 
-The provided boilerplate code utilizes the [Apify SDK](https://docs.apify.com/sdk/js/) combined with [Crawlee](https://crawlee.dev/), Apify's popular open-source Node.js web scraping library. By default the code performs a recursive crawl of the [apify.com](https://apify.com) website, but you can change it to a website of your choosing.
+The provided boilerplate code utilizes the [Apify SDK](https://docs.apify.com/sdk/js/) combined with [Crawlee](https://crawlee.dev/), Apify's popular open-source Node.js web scraping library. 
+
+By default, the code crawls the [apify.com](https://apify.com) website, but you can change it to any website.
 
 :::info Crawlee
 
@@ -44,14 +48,13 @@ The provided boilerplate code utilizes the [Apify SDK](https://docs.apify.com/sd
 
 :::
 
+## Step 3: Build the Actor
+
+To run your Actor, build it first. Click the **Build** button below the source code.
 
 ![Actor source code](./images/actor-source-code.png)
 
-### Build the Actor
-
-To run your Actor, you need to build it first. Click the **Build** button below the source code to start the build process.
-
-Once the build has been initiated, the UI will transition to the **Last build** tab, displaying the progress of the build and the Docker build log.
+Once the build starts, the UI transitions to the **Last build** tab, showing build progress and Docker build logs.
 
 ![Actor build](./images/actor-build.png)
 
@@ -68,7 +71,7 @@ This represents the Actor creation flow, where you first build the Actor from th
 
 :::
 
-### Run the Actor
+## Step 4: Run the Actor
 
 Once the Actor is built, you can look at its input, which consists of one field - **Start URL**, the URL where the crawling starts. Below the input, you can adjust the **Run options**:
 
@@ -82,9 +85,9 @@ To initiate an Actor run, click the **Start** button at the bottom of the page. 
 
 ![Actor run](./images/actor-run.png)
 
-### Pull the Actor
+## Step 5: Pull the Actor
 
-To continue development locally, you can pull the Actor's source code to your local machine.
+To continue development locally, pull the Actor's source code to your machine.
 
 :::note Prerequisites
 
@@ -109,7 +112,7 @@ Install <code>[apify-cli](https://docs.apify.com/cli/)</code> :
 
 :::
 
-To pull your Actor, you need to:
+To pull your Actor:
 
 1. Log in to the Apify platform
 
@@ -117,7 +120,7 @@ To pull your Actor, you need to:
     apify login
     ```
 
-2. Pull your Actor using the following command:
+2. Pull your Actor:
 
     ```bash
     apify pull your-actor-name
@@ -136,14 +139,15 @@ To pull your Actor, you need to:
 
 You can find both by clicking on the Actor title at the top of the page, which will open a new window containing the Actor's unique name and ID.
 
-## Iterate & customize
+## Step 6: It's Time to Iterate!
 
-After pulling the Actor's source code to your local machine, you can modify and customize it to match your specific requirements.
-Leverage your preferred code editor or development environment to make the necessary changes and enhancements.
+After pulling the Actor's source code to your local machine, you can modify and customize it to match your specific requirements. Leverage your preferred code editor or development environment to make the necessary changes and enhancements.
 
 Once you've made the desired changes, you can push the updated code back to the Apify platform for deployment & execution, leveraging the platform's scalability and reliability.
 
-To learn more about the Apify platform's features and best practices for Actor development:
+## Next Steps
 
-- Continue to the next chapter of this section for in-depth guidance and examples
 - Visit the [Apify Academy](/academy) to access a comprehensive collection of tutorials, documentation, and learning resources.
+- To understand Actors in detail, read the [Actor Whitepaper](https://whitepaper.actor/).
+- Check [Continuous integration](../deployment/continuous_integration.md) documentation to automate your Actor development process.
+- After you finish building your first Actor, you can [share it with other users and even monetize it](../../publishing/index.mdx).

--- a/sources/platform/actors/development/quick_start/start_web_ide.md
+++ b/sources/platform/actors/development/quick_start/start_web_ide.md
@@ -16,7 +16,7 @@ import TabItem from '@theme/TabItem';
 
 This guide walks you through the full lifecycle of an Actor. You'll start by creating and running it locally with the Apify CLI, then learn to configure its input and data storage. Finally, you will deploy the Actor to the Apify platform, making it ready to run in the cloud.
 
-## Prerequisites
+### Prerequisites
 
 - An Apify account. [Sign up for a free account](https://console.apify.com/sign-up) on the Apify website.
 

--- a/sources/platform/actors/development/quick_start/start_web_ide.md
+++ b/sources/platform/actors/development/quick_start/start_web_ide.md
@@ -52,7 +52,7 @@ By default, the code crawls the [apify.com](https://apify.com) website, but you 
 
 :::
 
-## Step 3: Build the Actor
+### Step 3: Build the Actor
 
 To run your Actor, build it first. Click the **Build** button below the source code.
 

--- a/sources/platform/actors/development/quick_start/start_web_ide.md
+++ b/sources/platform/actors/development/quick_start/start_web_ide.md
@@ -28,7 +28,7 @@ Log in to [Apify Console](https://console.apify.com), navigate to [**My Actors**
 
 ![Create Actor](./images/create-actor.png)
 
-You'll see Actor development templates for `JavaScript`, `TypeScript`, and `Python`. 
+You'll see Actor development templates for `JavaScript`, `TypeScript`, and `Python`.
 
 These templates provide boilerplate code and a preconfigured environment. Choose the template that best suits your needs. For the following demo, we'll proceed with **Crawlee + Puppeteer + Chrome**.
 
@@ -44,7 +44,7 @@ After choosing the template, your Actor will be automatically named and you'll b
 
 ## Step 2: Explore the Actor
 
-The provided boilerplate code utilizes the [Apify SDK](https://docs.apify.com/sdk/js/) combined with [Crawlee](https://crawlee.dev/), Apify's popular open-source Node.js web scraping library. 
+The provided boilerplate code utilizes the [Apify SDK](https://docs.apify.com/sdk/js/) combined with [Crawlee](https://crawlee.dev/), Apify's popular open-source Node.js web scraping library.
 
 By default, the code crawls the [apify.com](https://apify.com) website, but you can change it to any website.
 

--- a/sources/platform/actors/development/quick_start/start_web_ide.md
+++ b/sources/platform/actors/development/quick_start/start_web_ide.md
@@ -89,7 +89,7 @@ To initiate an Actor run, click the **Start** button at the bottom of the page. 
 
 ![Actor run](./images/actor-run.png)
 
-## Step 5: Pull the Actor
+### Step 5: Pull the Actor
 
 To continue development locally, pull the Actor's source code to your machine.
 

--- a/sources/platform/actors/development/quick_start/start_web_ide.md
+++ b/sources/platform/actors/development/quick_start/start_web_ide.md
@@ -14,9 +14,7 @@ import TabItem from '@theme/TabItem';
 
 ## What you'll learn
 
-- How to create and run your first Actor locally using Apify CLI
-- How to understand and configure Actor input, output, and storage
-- How to deploy your Actor to the Apify platform
+This guide walks you through the full lifecycle of an Actor. You'll start by creating and running it locally with the Apify CLI, then learn to configure its input and data storage. Finally, you will deploy the Actor to the Apify platform, making it ready to run in the cloud.
 
 ## Prerequisites
 

--- a/sources/platform/actors/development/quick_start/start_web_ide.md
+++ b/sources/platform/actors/development/quick_start/start_web_ide.md
@@ -14,6 +14,8 @@ import TabItem from '@theme/TabItem';
 
 ---
 
+<!-- TODO: Revisit, make it more like start_locally, but keep the content, only add steps, etc. -->
+
 ## Create the Actor
 
 :::note Prerequisites

--- a/sources/platform/actors/development/quick_start/start_web_ide.md
+++ b/sources/platform/actors/development/quick_start/start_web_ide.md
@@ -75,7 +75,7 @@ This represents the Actor creation flow, where you first build the Actor from th
 
 :::
 
-## Step 4: Run the Actor
+### Step 4: Run the Actor
 
 Once the Actor is built, you can look at its input, which consists of one field - **Start URL**, the URL where the crawling starts. Below the input, you can adjust the **Run options**:
 

--- a/sources/platform/actors/development/quick_start/start_web_ide.md
+++ b/sources/platform/actors/development/quick_start/start_web_ide.md
@@ -143,7 +143,7 @@ To pull your Actor:
 
 You can find both by clicking on the Actor title at the top of the page, which will open a new window containing the Actor's unique name and ID.
 
-## Step 6: It's Time to Iterate!
+### Step 6: It's time to iterate!
 
 After pulling the Actor's source code to your local machine, you can modify and customize it to match your specific requirements. Leverage your preferred code editor or development environment to make the necessary changes and enhancements.
 

--- a/sources/platform/actors/development/quick_start/start_web_ide.md
+++ b/sources/platform/actors/development/quick_start/start_web_ide.md
@@ -20,7 +20,7 @@ This guide walks you through the full lifecycle of an Actor. You'll start by cre
 
 - An Apify account. [Sign up for a free account](https://console.apify.com/sign-up) on the Apify website.
 
-## Step 1: Create your Actor
+### Step 1: Create your Actor
 
 Log in to [Apify Console](https://console.apify.com), navigate to [**My Actors**](https://console.apify.com/actors/development/my-actors), then click the **Develop new** button.
 


### PR DESCRIPTION
The PR refactors the Quick Start section of the platform documentation. The main changes involve:

- Adding clear steps on what to do; this is generally a best practice in quick start documentation
- Simplifying the content (the goal should be to show value to new users as quickly as possible)
- Adding missing information and links (templates, etc.)