### PR TITLE
fix: wrong output schema field types

### DIFF
--- a/sources/platform/actors/development/actor_definition/dataset_schema/index.md
+++ b/sources/platform/actors/development/actor_definition/dataset_schema/index.md
@@ -218,9 +218,9 @@ The dataset schema structure defines the various components and properties that 
 | Property | Type | Required | Description |
 | --- | --- | --- | --- |
 | `fields` | string[] | true | Selects fields to be presented in the output. <br/>The order of fields matches the order of columns <br/>in visualization UI. If a field value <br/>is missing, it will be presented as **undefined** in the UI. |
-| `unwind` | string | false | Deconstructs nested children into parent object, <br/>For example, with `unwind:["foo"]`, the object `{"foo": {"bar": "hello"}}` <br/> is transformed into `{"bar": "hello"}`. |
+| `unwind` | string[] | false | Deconstructs nested children into parent object, <br/>For example, with `unwind:["foo"]`, the object `{"foo": {"bar": "hello"}}` <br/> is transformed into `{"bar": "hello"}`. |
 | `flatten` | string[] | false | Transforms nested object into flat structure. <br/>For example, with `flatten:["foo"]` the object `{"foo":{"bar": "hello"}}` <br/> is transformed into `{"foo.bar": "hello"}`. |
-| `omit` | string | false | Removes the specified fields from the output. <br/>Nested fields names can be used as well. |
+| `omit` | string[] | false | Removes the specified fields from the output. <br/>Nested fields names can be used as well. |
 | `limit` | integer | false | The maximum number of results returned. <br/>Default is all results. |
 | `desc` | boolean | false | By default, results are sorted in ascending based on the write event into the dataset. <br/> If `desc:true`, the newest writes to the dataset will be returned first. |
 


### PR DESCRIPTION
Fix the type of the output schema fields.

- `transformation.omit` and `transformation.unwind` should be an array of strings, as Worker enforces that.