### PR TITLE
docs: add new signed URL fields to dataset & key-value store

### DIFF
--- a/apify-api/openapi/components/schemas/datasets/Dataset.yaml
+++ b/apify-api/openapi/components/schemas/datasets/Dataset.yaml
@@ -69,5 +69,11 @@ properties:
   consoleUrl:
     type: string
     example: 'https://console.apify.com/storage/datasets/27TmTznX9YPeAYhkC'
+  itemsPublicUrl:
+    type: string
+    example: 'https://api.apify.com/v2/datasets/WkzbQMuFYuamGv3YF/items?signature=abc123'
+  urlSigningSecretKey:
+    type: string
+    nullable: true
   stats:
     $ref: ./DatasetStats.yaml

--- a/apify-api/openapi/components/schemas/datasets/Dataset.yaml
+++ b/apify-api/openapi/components/schemas/datasets/Dataset.yaml
@@ -71,9 +71,11 @@ properties:
     example: 'https://console.apify.com/storage/datasets/27TmTznX9YPeAYhkC'
   itemsPublicUrl:
     type: string
+    description: "A public link to access the dataset items directly."
     example: 'https://api.apify.com/v2/datasets/WkzbQMuFYuamGv3YF/items?signature=abc123'
   urlSigningSecretKey:
     type: string
+    description: "A secret key for generating signed public URLs. It is only provided to clients with WRITE permission for the dataset."
     nullable: true
   stats:
     $ref: ./DatasetStats.yaml

--- a/apify-api/openapi/components/schemas/key-value-stores/KeyValueStore.yaml
+++ b/apify-api/openapi/components/schemas/key-value-stores/KeyValueStore.yaml
@@ -6,6 +6,7 @@ required:
   - modifiedAt
   - accessedAt
   - consoleUrl
+  - keysPublicUrl
 type: object
 properties:
   id:
@@ -42,5 +43,11 @@ properties:
   consoleUrl:
     type: string
     example: 'https://console.apify.com/storage/key-value-stores/27TmTznX9YPeAYhkC'  
+  keysPublicUrl:
+    type: string
+    example: 'https://api.apify.com/v2/key-value-stores/WkzbQMuFYuamGv3YF/keys?signature=abc123'
+  urlSigningSecretKey:
+    type: string
+    nullable: true
   stats:
     $ref: ./KeyValueStoreStats.yaml

--- a/apify-api/openapi/components/schemas/key-value-stores/KeyValueStore.yaml
+++ b/apify-api/openapi/components/schemas/key-value-stores/KeyValueStore.yaml
@@ -45,9 +45,11 @@ properties:
     example: 'https://console.apify.com/storage/key-value-stores/27TmTznX9YPeAYhkC'  
   keysPublicUrl:
     type: string
+    description: "A public link to access keys of the key-value store directly."
     example: 'https://api.apify.com/v2/key-value-stores/WkzbQMuFYuamGv3YF/keys?signature=abc123'
   urlSigningSecretKey:
     type: string
+    description: "A secret key for generating signed public URLs. It is only provided to clients with WRITE permission for the key-value store."
     nullable: true
   stats:
     $ref: ./KeyValueStoreStats.yaml

--- a/apify-api/openapi/components/schemas/key-value-stores/ListOfKeysResponse.yaml
+++ b/apify-api/openapi/components/schemas/key-value-stores/ListOfKeysResponse.yaml
@@ -14,6 +14,7 @@ properties:
       required:
         - key
         - size
+        - recordPublicUrl
       properties:
         key:
           type: string
@@ -21,6 +22,9 @@ properties:
         size:
           type: number
           example: 36
+        recordPublicUrl:
+          type: string
+          example: 'https://api.apify.com/v2/key-value-stores/WkzbQMuFYuamGv3YF/records/some-key?signature=abc123'
     description: ''
   count:
     type: number

--- a/apify-api/openapi/components/schemas/key-value-stores/ListOfKeysResponse.yaml
+++ b/apify-api/openapi/components/schemas/key-value-stores/ListOfKeysResponse.yaml
@@ -24,6 +24,7 @@ properties:
           example: 36
         recordPublicUrl:
           type: string
+          description: "A public link to access this record directly."
           example: 'https://api.apify.com/v2/key-value-stores/WkzbQMuFYuamGv3YF/records/some-key?signature=abc123'
     description: ''
   count:


### PR DESCRIPTION
This PR updates updates storage responses:
- GET dataset has `itemsPublicUrl` and `urlSigningSecretKey`
- GET KV store has `keysPublicUrl` and `urlSigningSecretKey`
- Get KV store keys, item has `recordPublicUrl`