### PR TITLE
fix: Broken markdown in builds and runs section

### DIFF
--- a/sources/platform/actors/development/builds_and_runs/index.md
+++ b/sources/platform/actors/development/builds_and_runs/index.md
@@ -33,7 +33,7 @@ To create a _run_, you take your _build_ and start it with some input:
 
 ```mermaid
 flowchart LR
-    subgraph AD [+]
+    subgraph AD [Run Definition]
         direction LR
         Build
         Input


### PR DESCRIPTION
Noticed https://docs.apify.com/platform/actors/development/builds-and-runs#running-an-actor has broken md

<img width="558" height="386" alt="image" src="https://github.com/user-attachments/assets/1112d705-219f-441c-9fe7-2c9420eeff15" />
