### PR TITLE
feat: enable comma-separated status filtering across updated endpoints

### DIFF
--- a/apify-api/openapi/paths/actor-runs/actor-runs.yaml
+++ b/apify-api/openapi/paths/actor-runs/actor-runs.yaml
@@ -51,7 +51,7 @@ get:
     - name: status
       in: query
       description: |
-        Comma-separated list of statuses ([available
+        Single status or omma-separated list of statuses ([available
         statuses](https://docs.apify.com/platform/actors/running/runs-and-builds#lifecycle)) used to filter runs by the specified statuses only."
       style: form
       explode: true

--- a/apify-api/openapi/paths/actor-runs/actor-runs.yaml
+++ b/apify-api/openapi/paths/actor-runs/actor-runs.yaml
@@ -51,8 +51,8 @@ get:
     - name: status
       in: query
       description: |
-        Return only runs with the provided status ([available
-        statuses](https://docs.apify.com/platform/actors/running/runs-and-builds#lifecycle))
+        Comma-separated list of statuses ([available
+        statuses](https://docs.apify.com/platform/actors/running/runs-and-builds#lifecycle)) used to filter runs by the specified statuses only."
       style: form
       explode: true
       schema:

--- a/apify-api/openapi/paths/actor-runs/actor-runs.yaml
+++ b/apify-api/openapi/paths/actor-runs/actor-runs.yaml
@@ -51,8 +51,8 @@ get:
     - name: status
       in: query
       description: |
-        Single status or omma-separated list of statuses ([available
-        statuses](https://docs.apify.com/platform/actors/running/runs-and-builds#lifecycle)) used to filter runs by the specified statuses only."
+        Single status or comma-separated list of statuses, see ([available
+        statuses](https://docs.apify.com/platform/actors/running/runs-and-builds#lifecycle)). Used to filter runs by the specified statuses only.
       style: form
       explode: true
       schema:

--- a/apify-api/openapi/paths/actor-tasks/actor-tasks@{actorTaskId}@runs.yaml
+++ b/apify-api/openapi/paths/actor-tasks/actor-tasks@{actorTaskId}@runs.yaml
@@ -57,8 +57,8 @@ get:
     - name: status
       in: query
       description: |
-        Single status oromma-separated list of statuses ([available
-        statuses](https://docs.apify.com/platform/actors/running/runs-and-builds#lifecycle)) used to filter runs by the specified statuses only.
+        Single status or comma-separated list of statuses, see ([available
+        statuses](https://docs.apify.com/platform/actors/running/runs-and-builds#lifecycle)). Used to filter runs by the specified statuses only.
       style: form
       explode: true
       schema:

--- a/apify-api/openapi/paths/actor-tasks/actor-tasks@{actorTaskId}@runs.yaml
+++ b/apify-api/openapi/paths/actor-tasks/actor-tasks@{actorTaskId}@runs.yaml
@@ -57,8 +57,8 @@ get:
     - name: status
       in: query
       description: |
-        Return only runs with the provided status ([available
-        statuses](https://docs.apify.com/platform/actors/running/runs-and-builds#lifecycle))
+        Comma-separated list of statuses ([available
+        statuses](https://docs.apify.com/platform/actors/running/runs-and-builds#lifecycle)) used to filter runs by the specified statuses only.
       style: form
       explode: true
       schema:

--- a/apify-api/openapi/paths/actor-tasks/actor-tasks@{actorTaskId}@runs.yaml
+++ b/apify-api/openapi/paths/actor-tasks/actor-tasks@{actorTaskId}@runs.yaml
@@ -57,7 +57,7 @@ get:
     - name: status
       in: query
       description: |
-        Comma-separated list of statuses ([available
+        Single status oromma-separated list of statuses ([available
         statuses](https://docs.apify.com/platform/actors/running/runs-and-builds#lifecycle)) used to filter runs by the specified statuses only.
       style: form
       explode: true

--- a/apify-api/openapi/paths/actors/acts@{actorId}@runs.yaml
+++ b/apify-api/openapi/paths/actors/acts@{actorId}@runs.yaml
@@ -59,8 +59,8 @@ get:
     - name: status
       in: query
       description: |
-        Return only runs with the provided status ([available
-        statuses](https://docs.apify.com/platform/actors/running/runs-and-builds#lifecycle))
+        Comma-separated list of statuses ([available
+        statuses](https://docs.apify.com/platform/actors/running/runs-and-builds#lifecycle)) used to filter runs by the specified statuses only.
       style: form
       explode: true
       schema:

--- a/apify-api/openapi/paths/actors/acts@{actorId}@runs.yaml
+++ b/apify-api/openapi/paths/actors/acts@{actorId}@runs.yaml
@@ -59,8 +59,8 @@ get:
     - name: status
       in: query
       description: |
-        Single status oromma-separated list of statuses ([available
-        statuses](https://docs.apify.com/platform/actors/running/runs-and-builds#lifecycle)) used to filter runs by the specified statuses only.
+        Single status or comma-separated list of statuses, see ([available
+        statuses](https://docs.apify.com/platform/actors/running/runs-and-builds#lifecycle)). Used to filter runs by the specified statuses only.
       style: form
       explode: true
       schema:

--- a/apify-api/openapi/paths/actors/acts@{actorId}@runs.yaml
+++ b/apify-api/openapi/paths/actors/acts@{actorId}@runs.yaml
@@ -59,7 +59,7 @@ get:
     - name: status
       in: query
       description: |
-        Comma-separated list of statuses ([available
+        Single status oromma-separated list of statuses ([available
         statuses](https://docs.apify.com/platform/actors/running/runs-and-builds#lifecycle)) used to filter runs by the specified statuses only.
       style: form
       explode: true


### PR DESCRIPTION
Following endpoints were updated in [PR #22366](https://github.com/apify/apify-core/pull/22240):

- `/v2/acts/:actorId/runs`
- `/v2/actor-runs`
- `v2/actor-tasks/:actorTaskId/runs`

The change extends the status parameter to support a comma-separated list of multiple statuses, allowing filtering based on the selected values.

This update reflects the changes in the documentation for the status parameter.