### PR TITLE
fix: rename eventCount to count

### DIFF
--- a/apify-api/openapi/paths/actor-runs/actor-runs@{runId}@charge.yaml
+++ b/apify-api/openapi/paths/actor-runs/actor-runs@{runId}@charge.yaml
@@ -31,7 +31,7 @@ post:
           $ref: "../../components/schemas/actor-runs/ChargeRunRequest.yaml"
         example:
           eventName: 'ANALYZE_PAGE'
-          eventCount: 1
+          count: 1
     required: true
   responses:
     '201':


### PR DESCRIPTION
The correct field in the body of the request is called count.