### PR TITLE
fix: Always clear cache when on MCP page to help with redirect issue

### DIFF
--- a/apify-docs-theme/src/theme/Layout/index.jsx
+++ b/apify-docs-theme/src/theme/Layout/index.jsx
@@ -4,12 +4,28 @@ import { useLocation } from '@docusaurus/router';
 import Layout from '@docusaurus/theme-classic/lib/theme/Layout/index';
 import useBaseUrl from '@docusaurus/useBaseUrl';
 import { usePluginData } from '@docusaurus/useGlobalData';
-import React from 'react';
+import React, { useEffect } from 'react';
 
 export default function LayoutWrapper(props) {
     const { options: { subNavbar } } = usePluginData('@apify/docs-theme');
     const baseUrl = useBaseUrl('/');
     const currentPath = useLocation().pathname.replace(new RegExp(`^${baseUrl}`), '');
+
+    // Silent cache busting for mcp.apify.com redirects
+    useEffect(() => {
+        // Only run on the MCP documentation page
+        if (currentPath.includes('integrations/mcp')) {
+            // Always clear cache when on MCP page to help with redirect issues.
+            // Background: Previously, mcp.apify.com had a 301 redirect to this docs page, which was wrong.
+            // Many users have this redirect cached in their browsers, so they can't access the new MCP UI.
+            // This helps with their cached redirect, allowing them to access mcp.apify.com
+            fetch('https://mcp.apify.com/', { method: 'get', cache: 'reload' }).then(() => {
+                console.log('MCP cache cleared successfully');
+            }).catch((error) => {
+                console.warn('Failed to clear MCP cache:', error);
+            });
+        }
+    }, [currentPath]);
 
     return (
         <>

--- a/apify-docs-theme/src/theme/Layout/index.jsx
+++ b/apify-docs-theme/src/theme/Layout/index.jsx
@@ -4,28 +4,12 @@ import { useLocation } from '@docusaurus/router';
 import Layout from '@docusaurus/theme-classic/lib/theme/Layout/index';
 import useBaseUrl from '@docusaurus/useBaseUrl';
 import { usePluginData } from '@docusaurus/useGlobalData';
-import React, { useEffect } from 'react';
+import React from 'react';
 
 export default function LayoutWrapper(props) {
     const { options: { subNavbar } } = usePluginData('@apify/docs-theme');
     const baseUrl = useBaseUrl('/');
     const currentPath = useLocation().pathname.replace(new RegExp(`^${baseUrl}`), '');
-
-    // Silent cache busting for mcp.apify.com redirects
-    useEffect(() => {
-        // Only run on the MCP documentation page
-        if (currentPath.includes('integrations/mcp')) {
-            // Always clear cache when on MCP page to help with redirect issues.
-            // Background: Previously, mcp.apify.com had a 301 redirect to this docs page, which was wrong.
-            // Many users have this redirect cached in their browsers, so they can't access the new MCP UI.
-            // This helps with their cached redirect, allowing them to access mcp.apify.com
-            fetch('https://mcp.apify.com/', { method: 'get', cache: 'reload' }).then(() => {
-                console.log('MCP cache cleared successfully');
-            }).catch((error) => {
-                console.warn('Failed to clear MCP cache:', error);
-            });
-        }
-    }, [currentPath]);
 
     return (
         <>

--- a/apify-docs-theme/static/js/custom.js
+++ b/apify-docs-theme/static/js/custom.js
@@ -125,9 +125,30 @@ window.addEventListener('load', () => {
 
     // docusaurus-openapi-docs plugin: scroll sidebar into viewport, no need for a large timeout here
     setTimeout(() => scrollOpenApiSidebarItemIntoView(), 200);
+
+    // MCP cache clearing - run after page is fully loaded
+    setTimeout(() => clearMcpRedirectCache(), 200);
 });
 
 window.addEventListener('popstate', () => {
     setTimeout(() => redirectOpenApiDocs(), 50);
     setTimeout(() => scrollOpenApiSidebarItemIntoView(), 50);
 });
+
+// MCP redirect cache-busting
+// Background: Previously, mcp.apify.com had a 301 redirect to the docs page
+// This clears cached redirects so users can access the new MCP configuration interface
+function clearMcpRedirectCache() {
+    // Only run on the MCP documentation page
+    if (window.location.pathname.includes('integrations/mcp')) {
+        // Clear cached redirects to mcp.apify.com
+        fetch('https://mcp.apify.com/', {
+            method: 'get',
+            cache: 'reload',
+        }).then(() => {
+            // Cache cleared successfully
+        }).catch(() => {
+            // Failed to clear cache - silent fail
+        });
+    }
+}

--- a/sources/platform/integrations/ai/mcp.md
+++ b/sources/platform/integrations/ai/mcp.md
@@ -9,7 +9,6 @@ slug: /integrations/mcp
 <!-- markdownlint-disable MD024 -->
 
 
-
 The _Apify Model Context Protocol (MCP) Server_ allows AI applications to connect to Apify's extensive library of Actors as tools to perform web scraping, data extraction, or other automation tasks in real time.
 
 :::tip Configure MCP Server

--- a/sources/platform/integrations/ai/mcp.md
+++ b/sources/platform/integrations/ai/mcp.md
@@ -10,7 +10,9 @@ slug: /integrations/mcp
 
 The _Apify Model Context Protocol (MCP) Server_ allows AI applications to connect to Apify's extensive library of Actors as tools to perform web scraping, data extraction, or other automation tasks in real time.
 
-**Open source**—You can [raise issues](https://github.com/apify/actors-mcp-server/issues) or [suggest new features](https://github.com/apify/actors-mcp-server/issues/new). If you find this useful, please [star us on GitHub](https://github.com/apify/actors-mcp-server) to show your support!
+## Support and contribution
+
+The Apify MCP Server is an open-source project. You can report bugs, suggest new features, or ask questions in the [GitHub issues](https://github.com/apify/actors-mcp-server/issues). If you find this project useful, please [star it on GitHub](https://github.com/apify/actors-mcp-server) to show your support!
 
 :::tip Configure MCP Server
 

--- a/sources/platform/integrations/ai/mcp.md
+++ b/sources/platform/integrations/ai/mcp.md
@@ -10,16 +10,6 @@ slug: /integrations/mcp
 
 The _Apify Model Context Protocol (MCP) Server_ allows AI applications to connect to Apify's extensive library of Actors as tools to perform web scraping, data extraction, or other automation tasks in real time.
 
-## Support and contribution
-
-The Apify MCP Server is an open-source project. You can report bugs, suggest new features, or ask questions in the [GitHub issues](https://github.com/apify/actors-mcp-server/issues). If you find this project useful, please [star it on GitHub](https://github.com/apify/actors-mcp-server) to show your support!
-
-:::tip Configure MCP Server
-
-Configure Apify MCP server at [mcp.apify.com](https://mcp.apify.com), select Actors and tools and copy configuration to your MCP client.
-
-:::
-
 ![Apify MCP Server](../../images/apify_mcp_server.png)
 
 ## Quickstart
@@ -27,15 +17,15 @@ Configure Apify MCP server at [mcp.apify.com](https://mcp.apify.com), select Act
 You can use the Apify MCP Server in two ways:
 
 - _HTTPS Endpoint_ `mcp.apify.com`: Connect your MCP client through OAuth or by including `Authorization: Bearer <APIFY_TOKEN>` header in your requests.
-  - `https://mcp.apify.com` for streamable transport (recommended)
-  - `https://mcp.apify.com/sse` for SSE transport (legacy)
+  - `https://mcp.apify.com` for streamable transport
 - _Standard Input/Output (stdio)_: Ideal for local integrations and command-line tools such as the Claude for Desktop client.
   - Set MCP client server command to `npx @apify/actors-mcp-server` and environment variable `APIFY_TOKEN` to your Apify API token
   - See `npx @apify/actors-mcp-server --help` for more options
 
-:::tip Run instantly ⚡
+:::tip Quick setup options
+MCP server configuration for other clients: Use https://mcp.apify.com to select Actors and tools, then copy the configuration to your client.
 
-To install the Apify MCP Server in [Claude for Desktop](https://claude.ai/download) with one click, download and run the latest [Apify MCP Server DXT file](https://github.com/apify/actors-mcp-server/releases/latest/download/actors-mcp-server.dxt)
+Claude Desktop: Download and run the [Apify MCP Server DXT file](https://github.com/apify/actors-mcp-server/releases/latest/download/actors-mcp-server.dxt) for one-click installation.
 
 :::
 
@@ -218,7 +208,11 @@ Check your client’s documentation or settings to confirm this feature is avail
 
 The Apify MCP server has a rate limit of _30 requests per second_ per user. If you exceed this limit, you will receive a `429 Too Many Requests` response.
 
-## Troubleshooting
+## Support and contribution
+
+The Apify MCP Server is an open-source project.
+You can report bugs, suggest new features, or ask questions in the [GitHub issues](https://github.com/apify/actors-mcp-server/issues).
+If you find this project useful, please [star it on GitHub](https://github.com/apify/actors-mcp-server) to show your support!
 
 - _Authorization (API Token):_ If the MCP server isn’t executing Actors, ensure you provided a correct Apify API token. Without a valid `APIFY_TOKEN`, the server cannot start Actor runs. Always set the `APIFY_TOKEN` environment variable when running locally.
 - _Ensure latest version:_ If running via NPM, always use the latest version of `@apify/actors-mcp-server` for the newest features and fixes. You can append `@latest` when installing or in your config args to ensure this.

--- a/sources/platform/integrations/ai/mcp.md
+++ b/sources/platform/integrations/ai/mcp.md
@@ -8,8 +8,9 @@ slug: /integrations/mcp
 
 <!-- markdownlint-disable MD024 -->
 
-
 The _Apify Model Context Protocol (MCP) Server_ allows AI applications to connect to Apify's extensive library of Actors as tools to perform web scraping, data extraction, or other automation tasks in real time.
+
+**Open source**—You can [raise issues](https://github.com/apify/actors-mcp-server/issues) or [suggest new features](https://github.com/apify/actors-mcp-server/issues/new). If you find this useful, please [star us on GitHub](https://github.com/apify/actors-mcp-server) to show your support!
 
 :::tip Configure MCP Server
 
@@ -30,14 +31,11 @@ You can use the Apify MCP Server in two ways:
   - Set MCP client server command to `npx @apify/actors-mcp-server` and environment variable `APIFY_TOKEN` to your Apify API token
   - See `npx @apify/actors-mcp-server --help` for more options
 
-You could also use legacy option by running [Apify Actors MCP Server](https://apify.com/apify/actors-mcp-server) as an Actor.
-
 :::tip Run instantly ⚡
 
 To install the Apify MCP Server in [Claude for Desktop](https://claude.ai/download) with one click, download and run the latest [Apify MCP Server DXT file](https://github.com/apify/actors-mcp-server/releases/latest/download/actors-mcp-server.dxt)
 
 :::
-
 
 ## Prerequisites
 
@@ -228,7 +226,7 @@ The Apify MCP server has a rate limit of _30 requests per second_ per user. If y
 ## Learn more
 
 - [Model Context Protocol (MCP)](https://modelcontextprotocol.io/introduction): Learn about the open standard on the official MCP website – understanding the protocol can help you build custom agents.
-- [Apify Actors MCP Server](https://apify.com/apify/actors-mcp-server): The README for the Apify MCP Server actor (available on Apify Store as `apify/actors-mcp-server`) provides technical details on implementation and advanced usage.
+- [Actors MCP Server GitHub](https://github.com/apify/actors-mcp-server): The README for the Apify MCP Server actor (available on Apify Store as `apify/actors-mcp-server`) provides technical details on implementation and advanced usage.
 - [Apify Tester MCP Client](https://apify.com/jiri.spilka/tester-mcp-client): A specialized client actor (`jiri.spilka/tester-mcp-client`) that you can run to simulate an AI agent in your browser. Useful for testing your setup with a chat UI.
 - [How to use MCP with Apify Actors](https://blog.apify.com/how-to-use-mcp/): Learn how to expose over 5,000 Apify Actors to AI agents with Claude and LangGraph, and configure MCP clients and servers.
 - [Apify MCP Server Tutorial](https://www.youtube.com/watch?v=BKu8H91uCTg): Integrate thousands of Apify Actors and Agents with Claude.

--- a/sources/platform/integrations/ai/mcp.md
+++ b/sources/platform/integrations/ai/mcp.md
@@ -8,7 +8,15 @@ slug: /integrations/mcp
 
 <!-- markdownlint-disable MD024 -->
 
-The _Apify Model Context Protocol (MCP) Server_ allows AI applications to connect to Apify’s extensive library of Actors as tools to perform web scraping, data extraction, or other automation tasks in real time.
+
+
+The _Apify Model Context Protocol (MCP) Server_ allows AI applications to connect to Apify's extensive library of Actors as tools to perform web scraping, data extraction, or other automation tasks in real time.
+
+:::tip Configure MCP Server
+
+Configure Apify MCP server at [mcp.apify.com](https://mcp.apify.com), select Actors and tools and copy configuration to your MCP client.
+
+:::
 
 ![Apify MCP Server](../../images/apify_mcp_server.png)
 


### PR DESCRIPTION
Always clear cache when on MCP page to help with redirect issues.
Previously, mcp.apify.com had a 301 redirect to this docs page, which was wrong.
Many users have this redirect cached in their browsers, so they can't access the new MCP UI.
This helps with their cached redirect, allowing them to access mcp.apify.com

@B4nan is there is a better place to put the code than in the src/theme/layout? 

Kudos to @JJetmar 

FYI @MQ37 

close https://github.com/apify/apify-mcp-server/issues/129
close https://github.com/apify/ai-team/issues/33

EDIT: Remove this fix after some time: https://github.com/apify/apify-docs/issues/1802