### PR TITLE
docs: fix warning block styling

### DIFF
--- a/sources/academy/webscraping/api_scraping/graphql_scraping/introspection.md
+++ b/sources/academy/webscraping/api_scraping/graphql_scraping/introspection.md
@@ -19,7 +19,11 @@ Not only does becoming comfortable with and understanding the ins and outs of us
 
 ## Making the query {#making-the-query}
 
-! Cheddar website was changed and the below example no longer works there. Nonetheless, the general approach is still viable on some websites even though introspection is disabled on most.
+:::warning
+
+Cheddar website was changed and the below example no longer works there. Nonetheless, the general approach is still viable on some websites even though introspection is disabled on most.
+
+:::
 
 In order to perform introspection on our [target website](https://www.cheddar.com), we need to make a request to their GraphQL API with this introspection query using [Insomnia](../../../glossary/tools/insomnia.md) or another HTTP client that supports GraphQL:
 


### PR DESCRIPTION
### Before:

<img width="801" height="309" alt="Screenshot 2025-08-18 at 13 06 08" src="https://github.com/user-attachments/assets/49bdef3f-7618-44c0-825d-4a074ff8afca" />

### After:

<img width="801" height="362" alt="Screenshot 2025-08-18 at 13 06 40" src="https://github.com/user-attachments/assets/a96a1e2b-5c3f-45b2-b12e-525628888396" />
