### PR TITLE
chore: skip fragment link checks with lychee

### DIFF
--- a/.github/workflows/lychee.yml
+++ b/.github/workflows/lychee.yml
@@ -40,14 +40,12 @@ jobs:
                     GITHUB_TOKEN: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}
                 with:
                     fail: true
-                    lycheeVersion: 'v0.18.1'
                     args: >
                         --base https://docs.apify.com
                         --exclude-path 'build/versions.html'
                         --max-retries 6
                         --verbose
                         --no-progress
-                        --include-fragments
                         --accept '100..=103,200..=299,403..=403,429'
                         --format markdown
                         './build/**/*.html'

--- a/.github/workflows/lychee.yml
+++ b/.github/workflows/lychee.yml
@@ -40,6 +40,7 @@ jobs:
                     GITHUB_TOKEN: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}
                 with:
                     fail: true
+                    lycheeVersion: 'v0.18.1'
                     args: >
                         --base https://docs.apify.com
                         --exclude-path 'build/versions.html'


### PR DESCRIPTION
Recent `lychee` updates (`0.19.0` and above) improve Lychee and align it more with the HTML spec. This, however, also means that Lychee now finds 2000+ "broken" links due to incorrect setup in this repo. 

Since fragment links inside of docs.apify.com are checked internally with Docusaurus anyway, this PR disables the fragment link checker in Lychee.