### PR TITLE
style: do not use three dots in incomplete examples

### DIFF
--- a/sources/academy/webscraping/scraping_basics_javascript2/11_scraping_variants.md
+++ b/sources/academy/webscraping/scraping_basics_javascript2/11_scraping_variants.md
@@ -72,8 +72,6 @@ These elements aren't visible to regular visitors. They're there just in case Ja
 Using our knowledge of Beautiful Soup, we can locate the options and extract the data we need:
 
 ```py
-...
-
 listing_url = "https://warehouse-theme-metal.myshopify.com/collections/sales"
 listing_soup = download(listing_url)
 
@@ -89,8 +87,6 @@ for product in listing_soup.select(".product-item"):
     else:
         item["variant_name"] = None
         data.append(item)
-
-...
 ```
 
 The CSS selector `.product-form__option.no-js` matches elements with both `product-form__option` and `no-js` classes. Then we're using the [descendant combinator](https://developer.mozilla.org/en-US/docs/Web/CSS/Descendant_combinator) to match all `option` elements somewhere inside the `.product-form__option.no-js` wrapper.

--- a/sources/academy/webscraping/scraping_basics_javascript2/12_framework.md
+++ b/sources/academy/webscraping/scraping_basics_javascript2/12_framework.md
@@ -534,7 +534,6 @@ If you export the dataset as JSON, it should look something like this:
 To scrape IMDb data, you'll need to construct a `Request` object with the appropriate search URL for each movie title. The following code snippet gives you an idea of how to do this:
 
 ```py
-...
 from urllib.parse import quote_plus
 
 async def main():
@@ -550,7 +549,6 @@ async def main():
         await context.add_requests(requests)
 
     ...
-...
 ```
 
 When navigating to the first search result, you might find it helpful to know that `context.enqueue_links()` accepts a `limit` keyword argument, letting you specify the max number of HTTP requests to enqueue.

--- a/sources/academy/webscraping/scraping_basics_python/11_scraping_variants.md
+++ b/sources/academy/webscraping/scraping_basics_python/11_scraping_variants.md
@@ -71,8 +71,6 @@ These elements aren't visible to regular visitors. They're there just in case Ja
 Using our knowledge of Beautiful Soup, we can locate the options and extract the data we need:
 
 ```py
-...
-
 listing_url = "https://warehouse-theme-metal.myshopify.com/collections/sales"
 listing_soup = download(listing_url)
 
@@ -88,8 +86,6 @@ for product in listing_soup.select(".product-item"):
     else:
         item["variant_name"] = None
         data.append(item)
-
-...
 ```
 
 The CSS selector `.product-form__option.no-js` matches elements with both `product-form__option` and `no-js` classes. Then we're using the [descendant combinator](https://developer.mozilla.org/en-US/docs/Web/CSS/Descendant_combinator) to match all `option` elements somewhere inside the `.product-form__option.no-js` wrapper.

--- a/sources/academy/webscraping/scraping_basics_python/12_framework.md
+++ b/sources/academy/webscraping/scraping_basics_python/12_framework.md
@@ -533,7 +533,6 @@ If you export the dataset as JSON, it should look something like this:
 To scrape IMDb data, you'll need to construct a `Request` object with the appropriate search URL for each movie title. The following code snippet gives you an idea of how to do this:
 
 ```py
-...
 from urllib.parse import quote_plus
 
 async def main():
@@ -549,7 +548,6 @@ async def main():
         await context.add_requests(requests)
 
     ...
-...
 ```
 
 When navigating to the first search result, you might find it helpful to know that `context.enqueue_links()` accepts a `limit` keyword argument, letting you specify the max number of HTTP requests to enqueue.


### PR DESCRIPTION
There are many places with incomplete code examples, but nowhere I used these three dots at the start and end of the code block, except of these two (four) occurrences. This PR removes them to achieve consistency with the rest of examples in the course(s).