### PR TITLE
style: use dollar variables (locating elements)

### DIFF
--- a/sources/academy/webscraping/scraping_basics_javascript2/06_locating_elements.md
+++ b/sources/academy/webscraping/scraping_basics_javascript2/06_locating_elements.md
@@ -108,6 +108,12 @@ Sony XBR-950G BRAVIA 4K HDR Ultra HD TV |
 
 There's still some room for improvement, but it's already much better!
 
+:::info Dollar sign variable names
+
+In jQuery and Cheerio, the core idea is a collection that wraps selected objects, usually HTML elements. To tell these wrapped selections apart from plain arrays, strings or other objects, it's common to start variable names with a dollar sign. This is just a naming convention to improve readability. The dollar sign has no special meaning and works like any other character in a variable name.
+
+:::
+
 ## Precisely locating price
 
 In the output we can see that the price isn't located precisely. For each product, our scraper also prints the text `Sale price`. Let's look at the HTML structure again. Each bit containing the price looks like this:


### PR DESCRIPTION
As I progressed with https://github.com/apify/apify-docs/pull/1584/ I felt the code examples were starting to be more and more complex. Then I remembered that when I was young, us jQuery folks used to lean towards a naming convention where variables holding jQuery selections were prefixed with $. I changed the code examples in all lessons to adhere to this as I feel it makes them more readable and less cluttered.

-----

ℹ️ The changes still use `$.map` and `$.each`, because they were made prior to the facb3c00cdd7f292a76317ad613f696d4e8f69b0 commit. It's gonna happen, but not yet.