### PR TITLE
docs: Add link to API for PPE event names

### DIFF
--- a/sources/platform/actors/publishing/monetize.mdx
+++ b/sources/platform/actors/publishing/monetize.mdx
@@ -139,6 +139,10 @@ You can also choose not to use it, but then you must handle API integration and 
 
 :::
 
+#### PPE event names
+
+To implement pay-per-event pricing, you need to define specific events in your Actor code. You can retrieve the list of available pricing event names using the [Get Actor](https://apify.com/docs/api/v2/act-get) API endpoint.
+
 ### How to attract larger customers of PPE and PPR Actors
 
 Each user running your PPE or PPR Actor belongs to a discount tier:


### PR DESCRIPTION
The PR adds a link to the API docs to get PPE event names. It is a follow-up from [the discussion in Slack](https://apify.slack.com/archives/C010Q0FBYG3/p1756045327790319).

One of the suggested solutions was to also provide the full JSON, but I decided not to do it. The main reason is that if the API payload changes, we might forget to update the JSON in the pricing page. This could lead to more confusion. Therefore, I would just keep the link to the API page as the single source of truth.