### PR TITLE
style: use sample numbers in the package installations

### DIFF
--- a/sources/academy/webscraping/scraping_basics_javascript2/05_parsing_html.md
+++ b/sources/academy/webscraping/scraping_basics_javascript2/05_parsing_html.md
@@ -38,7 +38,7 @@ We'll choose [Cheerio](https://cheerio.js.org/) as our parser, as it's a popular
 ```text
 $ npm install cheerio --save
 
-added 23 packages, and audited 24 packages in 1s
+added 123 packages, and audited 123 packages in 0s
 ...
 ```
 

--- a/sources/academy/webscraping/scraping_basics_javascript2/08_saving_data.md
+++ b/sources/academy/webscraping/scraping_basics_javascript2/08_saving_data.md
@@ -154,7 +154,7 @@ Neither JavaScript itself nor Node.js offers anything built-in to read and write
 ```text
 $ npm install @json2csv/node --save
 
-added 4 packages, and audited 28 packages in 1s
+added 123 packages, and audited 123 packages in 0s
 ...
 ```
 

--- a/sources/academy/webscraping/scraping_basics_javascript2/12_framework.md
+++ b/sources/academy/webscraping/scraping_basics_javascript2/12_framework.md
@@ -31,7 +31,7 @@ First let's install the Crawlee package. The framework has a lot of dependencies
 ```text
 $ npm install crawlee --save
 
-added 275 packages, and audited 303 packages in 14s
+added 123 packages, and audited 123 packages in 0s
 ...
 ```
 


### PR DESCRIPTION
I think it's better to use sample numbers than actual numbers. Readers won't be confused if something's not exactly the same. If they notice these are sample numbers, they'll understand these are insignificant in the context of the lesson.