### PR TITLE
fix: config of ignored contexts and patterns

### DIFF
--- a/.vale.ini
+++ b/.vale.ini
@@ -1,6 +1,6 @@
 StylesPath = .github/styles
 MinAlertLevel = warning
-IgnoredScopes = code, tt, table, tr, td, frontmatter
+IgnoredScopes = code, tt, table, tr, td, frontmatter, link, alt
 
 Vocab = Docs
 
@@ -11,8 +11,8 @@ mdx = md
 
 [*.md]
 BasedOnStyles = Vale, Apify, write-good, Microsoft
-# Ignore URLs, HTML/XML tags, lines with =, Markdown links, emails, curly braces, inline code
-TokenIgnores = (<\/?[A-Z][^>]*>), ([^\n]+=[^\n]*), (\[[^\]]+\]\([^\)]+\)), ([^\n]+@[^\n]+\.[^\n]), ({[^}]*}), `[^`]+`
+# Ignore URLs, HTML/XML tags, lines with =, emails, curly braces, inline code
+TokenIgnores = (<\/?[A-Z][^>]*>), ([^\n]+=[^\n]*), ([^\n]+@[^\n]+\.[^\n]), ({[^}]*}), `[^`]+`
 # Ignore HTML comments and Markdown code blocks
 BlockIgnores = (?s) (<!--.*?-->)|(```.*?```)
 Vale.Spelling = YES


### PR DESCRIPTION
According to my tests, this fixes Vale checking.
Current vale.ini disables checking in most
of the files, one of the regexes probably being
too greedy. Exctracted from https://github.com/apify/apify-docs/pull/1890/

I couldn't confirm that enabling specific Apify rules like

```ini
Apify.H1 = YES
Apify.Apify = YES
Apify.Capitalization = YES
Apify.Languages = YES
```

is necessary, Vale seems to pick them up correctly on my machine.