### PR TITLE
fix: bubble integration doc

### DIFF
--- a/sources/platform/integrations/workflows-and-notifications/bubble.md
+++ b/sources/platform/integrations/workflows-and-notifications/bubble.md
@@ -107,6 +107,7 @@ Dynamic values are available across Apify plugin fields. Use Bubble's **Insert d
 {
   "url": "Input URL's value"
 }
+```
 
 :::tip Inserting dynamic data
 


### PR DESCRIPTION
Fixed missing code block closure in Bubble integration documentation

This PR fixes a formatting issue in the Bubble integration documentation where a JSON code block was not properly closed. The missing closing code block marker (```) has been added after line 109, ensuring the proper rendering of the documentation and preventing subsequent content from being incorrectly formatted as code.

This minor adjustment makes the rest of the doc more readable and follows the Markdown format.