### PR TITLE
docs: add get-actor-output tool

### DIFF
--- a/sources/platform/integrations/ai/mcp.md
+++ b/sources/platform/integrations/ai/mcp.md
@@ -282,9 +282,9 @@ This dynamic discovery means your AI can adapt to new tasks without manual confi
 | `add-actor` | experimental |  | Add an Actor as a new tool for the user to call |
 | `get-actor-output`* | - | Retrieve the output from an Actor call which is not included in the output preview of the Actor tool. | ✅ |
 
-:::note
+:::note Retrieving full output
 
-The `get-actor-output` tool is automatically included with any Actor-related tool, such as `call-actor`, `add-actor`, or any specific Actor tool like `apify-slash-rag-web-browser`. When you call an Actor - either through the `call-actor` tool or directly via an Actor tool (e.g., `apify-slash-rag-web-browser`) - you receive a preview of the output. The preview depends on the Actor's output format and length; for some Actors and runs, it may include the entire output, while for others, only a limited version is returned to avoid overwhelming the LLM. To retrieve the full output of an Actor run, use the `get-actor-output` tool (supports limit, offset, and field filtering) with the `datasetId` provided by the Actor call.
+The `get-actor-output` tool is automatically included with any Actor-related tool, such as `call-actor`, `add-actor`, or specific Actor tools like `apify-slash-rag-web-browser`. When you call an Actor, you receive an output preview. Depending on the output format and length, the preview may contain the complete output or only a limited version to avoid overwhelming the LLM. To retrieve the full output, use the `get-actor-output` tool with the `datasetId` from the Actor call. This tool supports limit, offset, and field filtering.
 
 :::
 


### PR DESCRIPTION
Add `get-actor-output` tools info and merge into the https://github.com/apify/apify-docs/pull/1927

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Documents a new `get-actor-output` tool for retrieving full Actor outputs, with a note on automatic inclusion, datasetId usage, and pagination/field filtering.
> 
> - **Docs (MCP server)**:
>   - **New tool**: Add `get-actor-output` entry to the Available tools table.
>   - **Usage note**: Explain that it’s auto-included with Actor tools (e.g., `call-actor`, `add-actor`), used to fetch full output via `datasetId`, and supports limit/offset/field filtering.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a46162bf86e47e0730e07a24c839ce160d983288. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->