### PR TITLE
Use realistic numbers in PPE examples

### DIFF
--- a/sources/platform/actors/publishing/monetize/pay_per_event.mdx
+++ b/sources/platform/actors/publishing/monetize/pay_per_event.mdx
@@ -311,27 +311,27 @@ If you're not using the Apify SDKs (JS/Python), you need to handle idempotency (
 
 You make your Actor PPE and set the following pricing:
 
-- _`actor-start` event_: $0.10 per start
-- _`scraped-product` event_: $0.01 per product
-- _`scraped-product-detail` event_: $0.05 per detail
+- _`apify-actor-start` event_: $0.00001 per start
+- _`scraped-product` event_: $0.001 per product
+- _`scraped-product-review` event_: $0.005 per review
 - _`ai-analysis` event_: $0.15 per analysis
 
 During the first month, three users use your Actor:
 
-- _User 1 (paid plan)_: Starts Actor 5 times, scrapes 1,000 products, makes 50 product details, runs 30 AI analyses
-  - Charges: 5 × $0.10 + 1,000 × $0.01 + 50 × $0.05 + 30 × $0.15 = $0.50 + $10.00 + $2.50 + $4.50 = $17.50
-- _User 2 (paid plan)_: Starts Actor 2 times, scrapes 500 products, makes 20 product details, runs 10 AI analyses
-  - Charges: 2 × $0.10 + 500 × $0.01 + 20 × $0.05 + 10 × $0.15 = $0.20 + $5.00 + $1.00 + $1.50 = $7.70
-- _User 3 (free plan)_: Starts Actor 1 time, scrapes 100 products, makes 5 product details, runs 3 AI analyses
-  - Charges: 1 × $0.10 + 100 × $0.01 + 5 × $0.05 + 3 × $0.15 = $0.10 + $1.00 + $0.25 + $0.45 = $1.80
+- _User 1 (paid plan)_: Starts Actor 5 times, scrapes 10,000 products, 500 product reviews, and runs 30 AI analyses
+  - Charges: 5 × $0.00001 + 10,000 × $0.001 + 500 × $0.005 + 30 × $0.15 = $0.00005 + $10.00 + $2.50 + $4.50 = ~$17
+- _User 2 (paid plan)_: Starts Actor 2 times, scrapes 500 products, 200 product reviews, and runs 10 AI analyses
+  - Charges: 2 × $0.00001 + 500 × $0.001 + 200 × $0.005 + 10 × $0.15 = $0.00002 + $0.50 + $1.00 + $1.50 = ~$3
+- _User 3 (free plan)_: Starts Actor 1 time, scrapes 100 products, 5 product reviews, and runs 3 AI analyses
+  - Charges: 1 × $0.00001 + 100 × $0.001 + 5 × $0.005 + 3 × $0.15 = $0.00001 + $0.10 + $0.025 + $0.45 = ~$0.575
 
 Let's say the underlying platform usage for the first user is $3.20, for the second $1.50, and for the third $0.40.
 
 Your profit is computed only from the first two users, since they are on Apify paid plans. The revenue breakdown is:
 
-- _Total revenue_: $17.50 + $7.70 = $25.20
+- _Total revenue_: $17 + $3 = $20
 - _Total underlying cost_: $3.20 + $1.50 = $4.70
-- _Your profit_: 80% of revenue minus costs = 0.8 × $25.20 - $4.70 = $15.46
+- _Your profit_: 80% of revenue minus costs = 0.8 × $20 - $4.70 = $11.3
 
 ## Event names
 


### PR DESCRIPTION
I was reading through the docs and noticed this small nit, that the prices and names we used didn't really reflect real pricing, so I updated it.