### PR TITLE
docs: Update changing monetization setting

### DIFF
--- a/sources/academy/platform/get_most_of_actors/monetizing_your_actor.md
+++ b/sources/academy/platform/get_most_of_actors/monetizing_your_actor.md
@@ -101,14 +101,23 @@ Follow the monetization wizard to configure. Follow the monetization wizard to c
 
 ### Changing monetization
 
-You can change the monetization setting of your Actor by using the same wixard as for the setup in the **Monetization** section of your Actor's **Publication** tab. Any changes made to an already published Actor will take _14 days_ to come in effect, so that the users of your Actor have time to prepare.
+You can change the monetization setting of your Actor by using the same wizard as for the setup in the **Monetization** section of your Actor's **Publication** tab.
 
-:::important Frequency of monetization adjustments
+Most changes take effect **immediately**. However, **major changes** require a 14-day notice period and are limited to once per month to protect users.
 
-Be aware that you can change monetization setting of each Actor only once per month. For further information & guidelines please refer to our [Terms & Conditions](https://apify.com/store-terms-and-conditions)
+**Major changes** that require 14-day notice include:
+
+- Changing the pricing model (e.g., from rental to pay-per-result)
+- Increasing prices
+- Adding new pay-per-event charges
+
+All other changes (such as decreasing prices, adjusting descriptions, or removing pay-per-event charges) take effect immediately.
+
+:::important Frequency of major monetization adjustments
+
+You can make major monetization changes to each Actor only **once per month**. After making a major change, you must wait until it takes effect (14 days) plus an additional period before making another major change. For further information & guidelines, please refer to our [Terms & Conditions](https://apify.com/store-terms-and-conditions)
 
 :::
-
 
 ## Payouts & analytics
 

--- a/sources/platform/actors/publishing/monetize/index.mdx
+++ b/sources/platform/actors/publishing/monetize/index.mdx
@@ -61,13 +61,23 @@ Follow the monetization wizard to configure your pricing model.
 </TabItem>
 </Tabs>
 
-## Changing monetization
+### Changing monetization
 
-You can change the monetization setting of your Actor by using the same wizard as for the setup in the **Monetization** section of your Actor's **Publication** tab. Any changes made to an already published Actor will take _14 days_ to come into effect, so that the users of your Actor have time to prepare.
+You can change the monetization setting of your Actor by using the same wizard as for the setup in the **Monetization** section of your Actor's **Publication** tab.
 
-:::important Frequency of monetization adjustments
+Most changes take effect **immediately**. However, **major changes** require a 14-day notice period and are limited to once per month to protect users.
 
-Be aware that you can change the monetization setting of each Actor only once per month. For further information and guidelines, please refer to our [Terms & Conditions](https://apify.com/store-terms-and-conditions)
+**Major changes** that require 14-day notice include:
+
+- Changing the pricing model (e.g., from rental to pay-per-result)
+- Increasing prices
+- Adding new pay-per-event charges
+
+All other changes (such as decreasing prices, adjusting descriptions, or removing pay-per-event charges) take effect immediately.
+
+:::important Frequency of major monetization adjustments
+
+You can make major monetization changes to each Actor only **once per month**. After making a major change, you must wait until it takes effect (14 days) plus an additional period before making another major change. For further information & guidelines, please refer to our [Terms & Conditions](https://apify.com/store-terms-and-conditions)
 
 :::
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Clarifies monetization change behavior: most changes apply immediately; major changes (e.g., model switch, price increases, new pay-per-event charges) require 14-day notice and are limited to once per month.
> 
> - **Docs: Monetization policy updates**
>   - Clarify change behavior in `sources/academy/platform/get_most_of_actors/monetizing_your_actor.md` and `sources/platform/actors/publishing/monetize/index.mdx`:
>     - Most changes take effect immediately.
>     - Define “major changes” requiring 14-day notice (pricing model changes, price increases, adding pay-per-event charges).
>     - Limit major changes to once per month; add dedicated important note block.
>   - Minor adjustments:
>     - Fix typo “wixard” → “wizard”.
>     - Adjust heading level for "Changing monetization".
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 839671d65cde630bd8acdfd53f66599c9197e7b4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->