### PR TITLE
docs: fix client links rendering in dark mode

### DIFF
--- a/apify-api/openapi/paths/datasets/datasets@{datasetId}.yaml
+++ b/apify-api/openapi/paths/datasets/datasets@{datasetId}.yaml
@@ -5,6 +5,9 @@ get:
   description: |
     Returns dataset object for given dataset ID.
 
+    This does not return dataset items, only information about the storage itself.
+    To retrieve dataset items, use the [List dataset items](/api/v2/dataset-items-get) endpoint.
+
     :::note
 
     Keep in mind that attributes `itemCount` and `cleanItemCount` are not propagated right away after data are pushed into a dataset.

--- a/apify-api/plugins/decorators/client-references-links-decorator.js
+++ b/apify-api/plugins/decorators/client-references-links-decorator.js
@@ -34,8 +34,8 @@ function ClientReferencesLinksDecorator(target) {
     const pyLink = target[X_PY_DOC_URLS_PROPERTY];
     const jsLink = target[X_JS_DOC_URLS_PROPERTY];
 
-    const jsImgUrl = 'https://raw.githubusercontent.com/apify/openapi/b1206ac2adf8f39b05e5a09bf32c2802af58d851/assets/javascript.svg';
-    const pyImgUrl = 'https://raw.githubusercontent.com/apify/openapi/b1206ac2adf8f39b05e5a09bf32c2802af58d851/assets/python.svg';
+    const jsImgUrl = '/img/javascript-40x40.svg';
+    const pyImgUrl = '/img/python-40x40.svg';
 
     const jsAlt = 'Apify API JavaScript Client Reference';
     const pyAlt = 'Apify API Python Client Reference';
@@ -49,11 +49,13 @@ function ClientReferencesLinksDecorator(target) {
     }
 
     if (pyLink) {
-        prepend += `<a href="${pyLink}" target="_blank"><img src="${pyImgUrl}" class="openapi-clients-box-icon" alt="${pyAlt}"/></a>`;
+        prepend += `<a href="${pyLink}" target="_blank" class="client-docs-link">
+            <img src="${pyImgUrl}" class="openapi-clients-box-icon" width="24px" height="24px" alt="${pyAlt}"/>Python</a>`;
     }
 
     if (jsLink) {
-        prepend += `<a href="${jsLink}" target="_blank"><img src="${jsImgUrl}" class="openapi-clients-box-icon" alt="${jsAlt}" /></a>`;
+        prepend += `<a href="${jsLink}" target="_blank" class="client-docs-link">
+            <img src="${jsImgUrl}" class="openapi-clients-box-icon" width="24px" height="24px" alt="${jsAlt}" />JavaScript</a>`;
     }
 
     prepend += `</span>`;

--- a/apify-docs-theme/src/theme/custom.css
+++ b/apify-docs-theme/src/theme/custom.css
@@ -1740,18 +1740,6 @@ html[data-theme='dark'] .runnable-code-block svg .apify-logo {
 
 }
 
-.redocusaurus table code {
-    word-break: normal;
-}
-
-.redocusaurus .menu-content div:nth-child(2) ul {
-    padding-bottom: 0;
-}
-
-.redocusaurus .menu-content div:nth-child(2) div {
-    display: none;
-}
-
 .apiPage .tsd-panel-header .tsd-anchor-id {
     top: -13rem;
 }
@@ -1763,44 +1751,40 @@ iframe[src*="youtube"] {
     margin-bottom: 1.6rem;
 }
 
-.redocusaurus div[data-section-id] span[id] {
-    margin-top: -130px;
-    position: absolute;
-}
-
-.redocusaurus .openapi-clients-box {
-    display: block;
-    float: right;
-    padding-left: 6px;
-}
-
-.redocusaurus .openapi-clients-box-heading {
-    display: inline-block;
-    font-family: 'San Francisco', Helvetica, Arial, sans-serif;
-    color: #6C7590;
-    font-style: normal;
-    font-weight: 700;
-    font-size: 14px;
-    line-height: 20px;
-    text-transform: uppercase;
-    padding-bottom: 6px;
-}
-
-.redocusaurus .openapi-clients-box-icon {
-    display: block;
-    padding-bottom: 6px;
-}
-
 .theme-api-markdown .openapi-clients-box {
     display: block;
     float: right;
-    padding-left: 6px;
+    padding-left: 12px;
+    padding-right: 6px;
+}
+
+.client-docs-link img {
+    border: 1px solid var(--color-neutral-action-secondary);
+    border-radius: 8px;
+}
+
+.client-docs-link {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    justify-content: left;
+    gap: 8px;
+    padding: 4px 8px 8px 0px;
+}
+
+a.client-docs-link {
+    font-weight: 500;
+    color: var(--color-neutral-text-muted);
+}
+
+.theme-admonition {
+    clear: right;
 }
 
 .theme-api-markdown .openapi-clients-box-heading {
     display: inline-block;
     font-family: 'San Francisco', Helvetica, Arial, sans-serif;
-    color: #6C7590;
+    color: var(--color-neutral-text-muted);
     font-style: normal;
     font-weight: 700;
     font-size: 14px;
@@ -1811,7 +1795,7 @@ iframe[src*="youtube"] {
 
 .theme-api-markdown .openapi-clients-box-icon {
     display: block;
-    padding-bottom: 6px;
+    padding: 2px;
     margin: 0 !important;
 }
 


### PR DESCRIPTION
Improves contrast for the Client buttons in dark mode. Replaces the original SVG buttons with a logo and a text node. 

Removes unused `.redocusaurus` styles to improve CSS readability.

Expands documentation on the Get Dataset endpoint so that the admonition clears the `float: right` client box.

Closes #1949 