### PR TITLE
fix(docs): Correct param name for PPE charge endpoint

### DIFF
--- a/apify-api/openapi/components/schemas/actor-runs/ChargeRunRequest.yaml
+++ b/apify-api/openapi/components/schemas/actor-runs/ChargeRunRequest.yaml
@@ -1,12 +1,12 @@
 title: ChargeRunRequest
 required:
   - eventName
-  - eventCount
+  - count
 type: object
 properties:
   eventName:
     type: string
     example: ANALYZE_PAGE
-  eventCount:
+  count:
     type: number
     example: 1


### PR DESCRIPTION
Reported in [slack](https://apify.slack.com/archives/C0L33UM7Z/p1759326413985069)

Correcting the name of the param.