### PR TITLE
chore(docs): Add ui dependencies to the docs theme

### DIFF
--- a/apify-docs-theme/package.json
+++ b/apify-docs-theme/package.json
@@ -20,6 +20,8 @@
     },
     "dependencies": {
         "@apify/docs-search-modal": "^1.2.2",
+        "@apify/ui-library": "^1.97.2",
+        "@apify/ui-icons": "^1.19.0",
         "@docusaurus/theme-common": "^3.7.0",
         "@stackql/docusaurus-plugin-hubspot": "^1.1.0",
         "algoliasearch": "^5.19.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -67,6 +67,8 @@
             "license": "ISC",
             "dependencies": {
                 "@apify/docs-search-modal": "^1.2.2",
+                "@apify/ui-icons": "^1.19.0",
+                "@apify/ui-library": "^1.97.2",
                 "@docusaurus/theme-common": "^3.7.0",
                 "@stackql/docusaurus-plugin-hubspot": "^1.1.0",
                 "algoliasearch": "^5.19.0",


### PR DESCRIPTION
The dependencies on `@apify/ui-library` and `@apify/ui-icons` were not listed in `apify-docs-theme/package.json`, causing the newly added `@apify/ui-icons` library to be missing when updating the theme in other docs.

Issue introduced here: https://github.com/apify/apify-docs/pull/1956
See this error: https://github.com/apify/apify-client-js/actions/runs/18216304167/job/51866166008
