### PR TITLE
fix: standardize nullable refs and correct array items syntax

### DIFF
--- a/apify-api/openapi/components/schemas/actor-builds/Build.yaml
+++ b/apify-api/openapi/components/schemas/actor-builds/Build.yaml
@@ -72,9 +72,9 @@ properties:
     type: string
     example: 0.1.1
   actorDefinition:
-      oneOf:
+      allOf:
         - $ref: "../actors/ActorDefinition.yaml"
-        - type: "null"
+      nullable: true
 example:
   id: HG7ML7M8z78YcAPEB
   actId: janedoe~my-actor

--- a/apify-api/openapi/components/schemas/users/Proxy.yaml
+++ b/apify-api/openapi/components/schemas/users/Proxy.yaml
@@ -10,4 +10,4 @@ properties:
   groups:
     type: array
     items:
-      - $ref: ./ProxyGroup.yaml
+      $ref: ./ProxyGroup.yaml


### PR DESCRIPTION
This PR fix two places where docs used non-standard (according to OpenAPI 3.0) spec.

Why? I was playing with `oapi-codeget` tool for generation Go client from `openapi.yaml`. Without these changes I wasn't able to generate it.

I got these errors:
1. Caused by incorrect ProxyGroup ref
    ```
    $ go tool oapi-codegen openapi.yaml
    error loading swagger spec in openapi.yaml
    : failed to load OpenAPI specification: failed to unmarshal data: json error: invalid character 'o' looking for beginning of value, yaml error: error unmarshaling JSON: while decoding JSON: json: cannot unmarshal array into field Schema.items of type openapi3.Schema
    ```

2. Caused by incorrect nullable ActorDefinition
    ```
    $ go tool oapi-codegen openapi.yaml
    error generating code: error generating type definitions: error generating Go types for component schemas: error converting Schema Build to Go type: error generating Go schema for property 'actorDefinition': error generating type for oneOf: error resolving primitive type: unhandled Schema type: &[null]
    ```

Details about oapi-codegen:
```
go tool oapi-codegen -version
github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen
v2.5.0
```

Places for verification:
- https://docs.apify.com/api/v2/actor-build-get -> https://pr-1996.preview.docs.apify.com/api/v2/actor-build-get (added `nullable` label to `ActorDefinition` in schema)
- https://docs.apify.com/api/v2/users-me-get -> https://pr-1996.preview.docs.apify.com/api/v2/users-me-get (added object schema for `Proxy` instead of `undefined`)