### PR TITLE
docs: missing `url` param on page view [internal]

### DIFF
--- a/src/plugins/docusaurus-plugin-segment/segment.js
+++ b/src/plugins/docusaurus-plugin-segment/segment.js
@@ -30,16 +30,19 @@ function getOneTrustConsentContext() {
 
 export default ExecutionEnvironment.canUseDOM ? {
     onRouteUpdate() {
-        // Don't track page views on development
-        if (process.env.NODE_ENV === 'production' && window.analytics) {
-            window.analytics.page({
-                app: 'docs',
-                page_type: 'DOCS_PAGE',
-                path: window.location.pathname,
-                url: window.location.href,
-                search: window.location.search,
-                ...getOneTrustConsentContext(),
-            });
-        }
+        // this forces deferred execution that ensures `window.location` is in sync
+        setTimeout(() => {
+            // Don't track page views on development
+            if (process.env.NODE_ENV === 'production' && window.analytics) {
+                window.analytics.page({
+                    app: 'docs',
+                    page_type: 'DOCS_PAGE',
+                    path: window.location.pathname,
+                    url: window.location.href,
+                    search: window.location.search,
+                    ...getOneTrustConsentContext(),
+                });
+            }
+        }, 0);
     },
 } : null;


### PR DESCRIPTION
supports https://github.com/apify/apify-web/issues/5377
- turned out that `location` from docusaurus doesn't provide `url` 😂 
- using `window.location` instead does the trick