### PR TITLE
fix: Get absoluteUrl from docusaurus context

### DIFF
--- a/apify-docs-theme/src/theme/Layout/index.jsx
+++ b/apify-docs-theme/src/theme/Layout/index.jsx
@@ -12,12 +12,14 @@ export default function LayoutWrapper(props) {
     const currentPath = useLocation().pathname.replace(new RegExp(`^${baseUrl}`), '').trim();
     const shouldRenderAlternateLink = currentPath && currentPath !== '404';
 
+    const alternateMarkdownLink = useBaseUrl(`/${currentPath}.md`, { absolute: true });
+
     return (
         <>
             <Head>
                 {
                     shouldRenderAlternateLink
-                        ? <link rel="alternate" type="text/markdown" href={`${baseUrl}/${currentPath}.md`}/>
+                        ? <link rel="alternate" type="text/markdown" href={alternateMarkdownLink}/>
                         : null
                 }
             </Head>


### PR DESCRIPTION
Closes #2030

Won't work on staging unfortunately, but managed to run with production build. See comments below.
