### PR TITLE
fix: make "Copy for LLMs" button work with query parameters in the URL

### DIFF
--- a/apify-docs-theme/src/theme/LLMButtons/index.jsx
+++ b/apify-docs-theme/src/theme/LLMButtons/index.jsx
@@ -55,7 +55,11 @@ const DROPDOWN_OPTIONS = [
 ];
 
 const getPrompt = (currentUrl) => `Read from ${currentUrl} so I can ask questions about it.`;
-const getMarkdownUrl = (currentUrl) => `${currentUrl}.md`;
+const getMarkdownUrl = (currentUrl) => {
+    const url = new URL(currentUrl);
+    url.pathname = `${url.pathname.replace(/\/$/, '')}.md`;
+    return url.toString();
+};
 
 const onOpenInChatGPTClick = () => {
     if (window.analytics) {


### PR DESCRIPTION
Parses the current location as a URL before appending the `.md` suffix to route to the correct `md` URL.

E.g. Hubspot adds those tracking query parameters, old code would add the `.md` suffix to the end of the query params.

<img width="1286" height="229" alt="image" src="https://github.com/user-attachments/assets/95ed685a-09e2-4924-a0c8-62578cdef866" />
