### PR TITLE
fix: specify unique operationId for get collection (webhook) endpoint

### DIFF
--- a/apify-api/openapi/paths/webhooks/webhooks@{webhookId}@dispatches.yaml
+++ b/apify-api/openapi/paths/webhooks/webhooks@{webhookId}@dispatches.yaml
@@ -3,7 +3,7 @@ get:
     - Webhooks/Webhooks
   summary: Get collection
   description: Gets a given webhook's list of dispatches.
-  operationId: webhook_dispatches_get
+  operationId: webhook_webhookDispatches_get
   parameters:
     - name: webhookId
       in: path


### PR DESCRIPTION
This PR fix OpenAPI docs rendering where due to non-unique `operationId` it shows wrong endpoing documentation for "webhook dispatches" section. Please check attached screenshots for more info.

Also, as positive side effect it should be the last blocker for generating (Go and other languages) clients from our `openapi.yaml` spec.

Close: #2000 

<img width="1912" height="1237" alt="Screenshot 2025-10-31 at 14 35 45" src="https://github.com/user-attachments/assets/e25edc23-dc46-4526-8006-92e620861e38" />
<img width="1912" height="1237" alt="Screenshot 2025-10-31 at 14 43 07" src="https://github.com/user-attachments/assets/04e78501-f9fc-4127-b5bd-bedb1d3c45f3" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Renames the OpenAPI operationId for GET webhook dispatches to a unique identifier.
> 
> - **OpenAPI**:
>   - Update `operationId` for `GET` `webhooks/{webhookId}/dispatches` in `apify-api/openapi/paths/webhooks/webhooks@{webhookId}@dispatches.yaml` from `webhook_dispatches_get` to `webhook_webhookDispatches_get`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e00951ce52238724958092dd0a976f72b09233a9. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->