### PR TITLE
fix(docs): Actor quality cleanup after limited permissions hidden 

### DIFF
--- a/sources/platform/actors/publishing/quality_score.mdx
+++ b/sources/platform/actors/publishing/quality_score.mdx
@@ -29,14 +29,13 @@ The Actor quality score recalculates several times per day. Changes you make to 
 
 Your quality score may change even without you modifying your Actor. This happens for two reasons: First, your score is influenced by how well your Actor performs relative to other Actors on the platform. As other Actors improve or decline, your relative position may shift. Second, the quality score algorithm continues to evolve with new properties being added and adjustments to existing calculations.
 
-There are eight quality categories:
+There are seven quality categories:
 
 - Reliability
 - Popularity
 - Feedback and community
 - Ease of use
 - Pricing transparency
-- Trustworthiness
 - History of success
 - Congruency of texts
 


### PR DESCRIPTION
Category for limited permission was not deleted together with removal of limited permission (aka trustworthiness) section.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates the Actor quality score docs to reflect seven categories by removing the Trustworthiness (limited permissions) category.
> 
> - **Docs (Actor quality score)**:
>   - Update category count from eight to seven in `sources/platform/actors/publishing/quality_score.mdx`.
>   - Remove `Trustworthiness` (limited permissions) from the category list.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7c368e5efcf9add48f3af77d7b0fd3b5764cb2a3. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->