### PR TITLE
feat: allow LLMs dropdown in academy pages

### DIFF
--- a/apify-docs-theme/src/theme/DocItemContent/index.js
+++ b/apify-docs-theme/src/theme/DocItemContent/index.js
@@ -54,6 +54,7 @@ export default function DocItemContent({ children }) {
     '/platform',
     '/sdk',
     '/cli',
+    '/academy',
   ];
 
   // Define paths that should not show LLMButtons (e.g., changelog pages)


### PR DESCRIPTION
This PR enables the LLM's dropdown on all academy pages.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `/academy` to the LLMButtons allowed paths so the dropdown appears on academy pages.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5385014803a7500f9e1fc9b4121eb60d13b180ec. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->