### PR TITLE
fix: correctly stretch Actor template cards

### DIFF
--- a/src/components/ActorTemplates/ActorTemplates.tsx
+++ b/src/components/ActorTemplates/ActorTemplates.tsx
@@ -36,6 +36,10 @@ const ActorTemplatesWrapper = styled.div`
     margin: 0 auto;
     gap: ${theme.space.space24};
 
+    > a {
+        display: flex;
+    }
+
     @media (min-width: ${theme.layout.tablet}) {
         grid-template-columns: repeat(2, 1fr);
     }


### PR DESCRIPTION
This PR fixes the stretching for Actor template cards.
Before:
<img width="1271" height="386" alt="image" src="https://github.com/user-attachments/assets/ca44f09e-0f31-4098-b6c7-dd59187b5a41" />
After:
<img width="1390" height="386" alt="image" src="https://github.com/user-attachments/assets/f38203c9-8788-4228-9175-d360f58d2953" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Set direct child anchors in `ActorTemplatesWrapper` to `display: flex` so `ActorTemplateCard` tiles stretch uniformly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 46eba8b5d1c53cec6fb950822e4dffd8697e7c3d. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->