### PR TITLE
fix: don't overwrite frontmatter `description` field where present

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -401,7 +401,7 @@ module.exports = {
 
                 const sentenceMatch = contentText.match(/^(.*?[.!?])\s/);
 
-                result.frontMatter.description = sentenceMatch ? sentenceMatch[1].trim() : contentText;
+                result.frontMatter.description ??= sentenceMatch ? sentenceMatch[1].trim() : contentText;
             }
 
             return result;


### PR DESCRIPTION
Makes sure the custom `docusaurus.config.js` script doesn't replace the custom `description` from frontmatter, where it's present. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Avoid overwriting existing frontmatter descriptions by only generating a description when none is provided.
> 
> - **Markdown processing (`docusaurus.config.js`)**:
>   - Use nullish assignment for `result.frontMatter.description` to only set an auto-generated summary when the frontmatter `description` is missing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 04d507520b70f69d851144dfb33c2e5a87ce0711. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->