### PR TITLE
chore(docs-theme): enable OIDC-based publishing to npm

### DIFF
--- a/.github/workflows/publish-to-npm.yaml
+++ b/.github/workflows/publish-to-npm.yaml
@@ -75,10 +75,7 @@ jobs:
             -   name: Deploy theme to npm
                 run: |
                     cd $GITHUB_WORKSPACE/apify-docs-theme
-                    npm publish --provenance
-                env:
-                    GIT_USER: "barjin:${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}"
-                    GH_TOKEN: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}
+                    npm publish
 
             -   name: Wait until the new theme version is available on npm
                 run: |


### PR DESCRIPTION
Closes #2083

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Modernizes the publish workflow to Node 24 and OIDC-based npm auth, replacing manual .npmrc and switching to `npm publish --provenance`.
> 
> - **CI/CD (GitHub Actions)** in `.github/workflows/publish-to-npm.yaml`:
>   - **Node setup**: Rename step and standardize to `node-version: 24` using `actions/setup-node@v6` in both jobs.
>   - **NPM auth via OIDC**: Configure `registry-url` and `always-auth` with `setup-node`; remove manual `.npmrc` token writes.
>   - **Publish command**: Replace `npx publish-if-not-exists` with `npm publish --provenance`.
>   - Other: Minor step name cleanups; keep corepack enable and version bump flow unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fc8fe238284f954b7900b5e0312efa6f88037a37. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->