### PR TITLE
chore: deploy nginx workflow

### DIFF
--- a/.github/workflows/deploy-nginx.yml
+++ b/.github/workflows/deploy-nginx.yml
@@ -3,11 +3,11 @@
 name: Deploy Nginx Configuration
 
 on:
-  push:
-    branches:
-      - master
-    paths:
-      - 'nginx.conf'
+  # push:
+  #   branches:
+  #     - master
+  #   paths:
+  #     - 'nginx.conf'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
New workflow for apify-docs nginx deployment to be tested while also keeping the current solution working

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds a GitHub Actions workflow to trigger Nginx config deployment in apify/apify-docs-private on nginx.conf changes or manual dispatch.
> 
> - **CI/CD**:
>   - **New workflow** `/.github/workflows/deploy-nginx.yml`:
>     - Triggers on `push` to `master` when `nginx.conf` changes and via `workflow_dispatch`.
>     - Executes `gh workflow run deploy-nginx.yaml` against `apify/apify-docs-private` with `deployment=apify-docs`.
>     - Uses `GITHUB_TOKEN` from `secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3ed86df375cabdd60f4bf7b59e8f1d7a62bcd24c. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->