### PR TITLE
docs: Fix Python Actor configuration property naming

### DIFF
--- a/sources/platform/actors/development/programming_interface/actor_standby.md
+++ b/sources/platform/actors/development/programming_interface/actor_standby.md
@@ -62,7 +62,7 @@ class GetHandler(SimpleHTTPRequestHandler):
 
 async def main() -> None:
     async with Actor:
-        with HTTPServer(('', Actor.config.web_server_port), GetHandler) as http_server:
+        with HTTPServer(('', Actor.configuration.web_server_port), GetHandler) as http_server:
             http_server.serve_forever()
 ```
 
@@ -131,7 +131,7 @@ class GetHandler(SimpleHTTPRequestHandler):
 
 async def main() -> None:
     async with Actor:
-        with HTTPServer(('', Actor.config.standby_port), GetHandler) as http_server:
+        with HTTPServer(('', Actor.configuration.standby_port), GetHandler) as http_server:
             http_server.serve_forever()
 ```
 
@@ -167,7 +167,7 @@ from apify import Actor
 
 async def main() -> None:
     async with Actor:
-        if Actor.config.meta_origin == 'STANDBY':
+        if Actor.configuration.meta_origin == 'STANDBY':
             # Start your Standby server here
         else:
             # Perform the standard Actor operations here

--- a/sources/platform/actors/development/programming_interface/environment_variables.md
+++ b/sources/platform/actors/development/programming_interface/environment_variables.md
@@ -197,13 +197,13 @@ from apify import Actor
 
 async def main():
     async with Actor:
-        old_token = Actor.config.token
+        old_token = Actor.configuration.token
         Actor.log.info(f'old_token = {old_token}')
 
         # use different token
-        Actor.config.token = 's0m3n3wt0k3n'
+        Actor.configuration.token = 's0m3n3wt0k3n'
 
-        new_token = Actor.config.token
+        new_token = Actor.configuration.token
         Actor.log.info(f'new_token = {new_token}')
 ```
 


### PR DESCRIPTION
Updates Python code examples to use the correct `Actor.configuration` property instead of `Actor.config` that got
  removed in the Python SDK v3 (see https://docs.apify.com/sdk/python/docs/upgrading/upgrading-to-v3#removed-actorconfig-property).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates Python code samples to use Actor.configuration (web_server_port, standby_port, meta_origin, token) instead of removed Actor.config across Standby and environment variables docs.
> 
> - **Docs (Python examples)**:
>   - **Standby mode (`sources/platform/actors/development/programming_interface/actor_standby.md`)**:
>     - Use `Actor.configuration.web_server_port` and `Actor.configuration.standby_port` in HTTP server examples.
>     - Check `Actor.configuration.meta_origin` for Standby mode detection.
>   - **Environment variables (`sources/platform/actors/development/programming_interface/environment_variables.md`)**:
>     - Access and set token via `Actor.configuration.token` instead of `Actor.config.token`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b3f5d0d5bc0bf24e24ef1188297a31e9cde1eacf. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->