### PR TITLE
fix: Correct Python code examples in inputs/outputs guide

### DIFF
--- a/sources/academy/platform/deploying_your_code/inputs_outputs.md
+++ b/sources/academy/platform/deploying_your_code/inputs_outputs.md
@@ -90,19 +90,19 @@ Alternatively, when writing in a language other than JavaScript, we can create o
 
 ```py
 # index.py
-from apify_client import ApifyClient
-from os import environ
 import json
+from os import environ
+from apify_client import ApifyClient
 
 client = ApifyClient(token='YOUR_TOKEN')
 
 # If being run on the platform, the "APIFY_IS_AT_HOME" environment variable
 # will be "1". Otherwise, it will be undefined/None
-def is_on_apify ():
+def is_on_apify():
     return 'APIFY_IS_AT_HOME' in environ
 
 # Get the input
-def get_input ():
+def get_input():
     if not is_on_apify():
         with open('./apify_storage/key_value_stores/default/INPUT.json') as actor_input:
             return json.load(actor_input)
@@ -110,7 +110,7 @@ def get_input ():
     kv_store = client.key_value_store(environ.get('APIFY_DEFAULT_KEY_VALUE_STORE_ID'))
     return kv_store.get_record('INPUT')['value']
 
-def add_all_numbers (nums):
+def add_all_numbers(nums):
     total = 0
 
     for num in nums:
@@ -119,9 +119,7 @@ def add_all_numbers (nums):
     return total
 
 actor_input = get_input()['numbers']
-
 solution = add_all_numbers(actor_input)
-
 print(solution)
 ```
 
@@ -168,16 +166,16 @@ You can read and write your output anywhere; however, it is standard practice to
 
 ```py
 # index.py
-from apify_client import ApifyClient
-from os import environ
 import json
+from os import environ
+from apify_client import ApifyClient
 
 client = ApifyClient(token='YOUR_TOKEN')
 
-def is_on_apify ():
+def is_on_apify():
     return 'APIFY_IS_AT_HOME' in environ
 
-def get_input ():
+def get_input():
     if not is_on_apify():
         with open('./apify_storage/key_value_stores/default/INPUT.json') as actor_input:
             return json.load(actor_input)
@@ -186,15 +184,15 @@ def get_input ():
     return kv_store.get_record('INPUT')['value']
 
 # Push the solution to the dataset
-def set_output (data):
+def set_output(data):
     if not is_on_apify():
         with open('./apify_storage/datasets/default/solution.json', 'w') as output:
             return output.write(json.dumps(data, indent=2))
 
     dataset = client.dataset(environ.get('APIFY_DEFAULT_DATASET_ID'))
-    dataset.push_items('OUTPUT', value=[json.dumps(data, indent=4)])
+    dataset.push_items([json.dumps(data, indent=4)])
 
-def add_all_numbers (nums):
+def add_all_numbers(nums):
     total = 0
 
     for num in nums:
@@ -203,10 +201,8 @@ def add_all_numbers (nums):
     return total
 
 actor_input = get_input()['numbers']
-
 solution = add_all_numbers(actor_input)
-
-set_output({ 'solution': solution })
+set_output({'solution': solution})
 ```
 
 ## Testing locally {#testing-locally}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Fixes and streamlines Python snippets in the inputs/outputs guide, correcting dataset push usage and formatting.
> 
> - **Docs (inputs_outputs.md)**
>   - **Python examples**:
>     - Correct `dataset.push_items` usage (push list; remove invalid key args) and adjust `set_output({'solution': solution})`.
>     - Normalize imports and function definitions (`is_on_apify`, `get_input`, `set_output`, `add_all_numbers`), removing extra spaces and blank lines.
>     - Minor cleanup for local I/O paths and JSON formatting in examples.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5327aacc2cfface78de258f4c5e2a9edda070830. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->