### PR TITLE
fix: polish the force permission level example

### DIFF
--- a/sources/platform/actors/development/permissions/migration_guide.md
+++ b/sources/platform/actors/development/permissions/migration_guide.md
@@ -27,6 +27,8 @@ You can override the permission level for a single run using run options under t
 You can do the same using the Apify Client as well:
 
 ```ts
+import { ACTOR_PERMISSION_LEVEL } from '@apify/consts';
+
 await apifyClient.actor(actorId).call(input, {
     forcePermissionLevel: ACTOR_PERMISSION_LEVEL.LIMITED_PERMISSIONS,
 });
@@ -35,7 +37,7 @@ await apifyClient.actor(actorId).call(input, {
 Or just using the API:
 
 ```tsx
- POST https://api.apify.com/v2/acts/<actor_id>/runs?**forcePermissionLevel=LIMITED_PERMISSIONS**
+ POST https://api.apify.com/v2/acts/<actor_id>/runs?forcePermissionLevel=LIMITED_PERMISSIONS
 ```
 
 


### PR DESCRIPTION
I randomly noticed this.

- I think referencing the constant directly could be confusing, so I added an import.
- The `**` were presumably supposed to make the param bold but it did not work :smile: 

<img width="1415" height="529" alt="image" src="https://github.com/user-attachments/assets/063213c1-a4c9-4a34-adfa-19359ebaf932" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Polishes the limited-permissions examples by adding the missing constant import and fixing the API query parameter formatting.
> 
> - **Docs (migration guide)**:
>   - **Apify Client example**: Adds explicit `import { ACTOR_PERMISSION_LEVEL } from '@apify/consts'` for `forcePermissionLevel` usage.
>   - **API example**: Fixes `POST /v2/acts/<actor_id>/runs?forcePermissionLevel=LIMITED_PERMISSIONS` formatting by removing incorrect bold markup.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 05ac2dc51c112ba24effa9bba4c0bd4960ccd4de. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->