### PR TITLE
fix: Clarify default build version for resurrected run

### DIFF
--- a/apify-api/openapi/paths/actor-runs/actor-runs@{runId}@resurrect.yaml
+++ b/apify-api/openapi/paths/actor-runs/actor-runs@{runId}@resurrect.yaml
@@ -24,7 +24,7 @@ post:
       schema:
         type: string
       example: 0.1.234
-      description: Specifies the Actor build to run. It can be either a build tag or build number. By default, the run uses the build specified in the run that is being resurrected (typically `latest`).
+      description: Specifies the Actor build to run. It can be either a build tag or build number. By default, the run is resurrected with the same build that it originally used. Specifically, if a run is first started with the `latest` tag, which resolves to version `0.0.3` at the time, a run resurrected without the `build` parameter will continue running with the version `0.0.3`, even if the `latest` tag already points to a newer build.
     - name: timeout
       in: query
       required: false


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Clarifies that resurrected runs default to the original build/version and adds an explicit example in the resurrect endpoint spec.
> 
> - **OpenAPI**:
>   - Update `build` query parameter description in `apify-api/openapi/paths/actor-runs/actor-runs@{runId}@resurrect.yaml` to state resurrected runs use the same build as originally used, with an example illustrating `latest` resolving to a specific version.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fbed2a142ab4eba8f16fa43dbd335634e6ac8b5b. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->