### PR TITLE
chore: deploy nginx workflow name

### DIFF
--- a/.github/workflows/deploy-nginx.yml
+++ b/.github/workflows/deploy-nginx.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - name: Trigger deployment workflow in apify-docs-private
         run: |
-          gh workflow run deploy-nginx.yaml \
+          gh workflow run deploy-nginx.yml \
             --repo apify/apify-docs-private \
             --field deployment=apify-docs
           echo "✅ Deployment workflow triggered successfully"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Fixes the deploy workflow to trigger the correct `deploy-nginx.yml` in the private repo.
> 
> - **CI/CD**:
>   - In `.github/workflows/deploy-nginx.yml`, update GitHub CLI command to trigger `deploy-nginx.yml` (was `deploy-nginx.yaml`) in `apify/apify-docs-private`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 61deb8e56d077ee95878ab8b9869d1a46b6e51ab. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->