### PR TITLE
feat: Update MCP docs with telemetry info

### DIFF
--- a/sources/platform/integrations/ai/mcp.md
+++ b/sources/platform/integrations/ai/mcp.md
@@ -349,6 +349,14 @@ For the local stdio server, opt out of telemetry using a CLI flag or an environm
 
   ```bash
   npx @apify/actors-mcp-server --telemetry-enabled=false
+  ```
+
+- _Environment variable_: set the `TELEMETRY_ENABLED` environment variable to `false`:
+
+  ```bash
+  export TELEMETRY_ENABLED=false
+  npx @apify/actors-mcp-server
+  ```
 
 ## Advanced usage
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds telemetry documentation with opt-out instructions and fixes the tools table for runs/storage entries.
> 
> - **Docs (MCP server)**
>   - **Telemetry**: Add section detailing anonymous data collection, default enablement, and opt-out methods for both remote (`?telemetry-enabled=false`) and local stdio (`--telemetry-enabled=false` or env) servers.
>   - **Available tools table**: Fix and normalize entries for `runs` and `storage` tools (`get-actor-run*`, `get-dataset*`, `get-key-value-store*`), ensuring proper formatting and visibility.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c7023376652bff5fd866550e458ef70f8465a95d. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



close: https://github.com/apify/apify-docs/pull/2117