### PR TITLE
chore: update invalidate step in deploy workflow

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -53,7 +53,7 @@ jobs:
 
             -   name: Invalidate CloudFront cache
                 run: |
-                    gh workflow run invalidate-cloudfront.yaml \
+                    gh workflow run invalidate-cloudfront.yml \
                         --repo apify/apify-docs-private \
                         --field deployment=apify-docs
                     echo "✅ CloudFront cache invalidation workflow triggered successfully"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Updates the docs GitHub Pages workflow to trigger `invalidate-cloudfront.yaml` with a deployment field and log success.
> 
> - **CI/CD**
>   - **`.github/workflows/docs.yaml`**
>     - Update CloudFront cache invalidation step:
>       - Switch from `invalidate.yaml` to `invalidate-cloudfront.yaml`.
>       - Add `--field deployment=apify-docs` and use a multiline script.
>       - Echo a success message after triggering the workflow.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0c90445fe7245abc0882e94472bff57c0239365e. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->