### PR TITLE
docs: add ideas submission form back

### DIFF
--- a/sources/academy/build-and-publish/actor-ideas/what_software_an_actor_can_be.md
+++ b/sources/academy/build-and-publish/actor-ideas/what_software_an_actor_can_be.md
@@ -188,17 +188,9 @@ Apify Store can host multiple Actors with similar functions. However, the "first
 Competition motivates developers to improve the code. You can still build the Actor, but differentiate with a unique set of features. -->
 
 
-<!-- ### Submit your own ideas
+### Submit your own ideas
 
-The Ideas page is also where you contribute concepts to drive innovation in the community.
-
-Here's how you can contribute too:
-
-- _Submit ideas_: Share Actor concepts through the [Ideas submission form](https://apify.typeform.com/to/BNON8poB#source=ideas).
-Provide clear details about what the tool should do and how it should work.
-
-- _Engage with the community_: Upvote ideas you find intriguing. More support
-increases the likelihood a developer will build it. -->
+You can submit your own Actor ideas through the [Ideas submission form](https://apify.typeform.com/to/BNON8poB#source=ideas). Provide clear details about what the tool should do and how it should work.
 
 ## Find ideas from other sources
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Restores the “Submit your own ideas” section with a direct link to the Ideas submission form in the Actor ideas guide.
> 
> - **Docs**:
>   - Reintroduces `### Submit your own ideas` section in `sources/academy/build-and-publish/actor-ideas/what_software_an_actor_can_be.md`, replacing previously commented content with a concise sentence linking to the Ideas submission form.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e6898c80fa97a4db2285da4c92e15e86b7570287. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->