### PR TITLE
feat: Update organization docs with more answers 

### DIFF
--- a/sources/platform/collaboration/organization_account/index.md
+++ b/sources/platform/collaboration/organization_account/index.md
@@ -50,9 +50,9 @@ Then, under the **Organizations** [tab](https://console.apify.com/account#/myorg
 
 Next, enter an organization name and select **Convert**.
 
-The name you enter becomes the organization's display name. The original account **username** stays the same, so any public Actors or API references (for example, `my_profile/my_actor`) keep their existing URLs. A new personal account is created for you with the same login credentials and a username based on your original username with `-owner` added (for example, `my_profile-owner`). You'll use this new personal account to manage and own the organization.
+The name you enter becomes the organization's display name. The original account **username** stays the same, so any public Actors or API references (for example, `my_profile/my_actor`) keep their existing URLs. A new personal account is created for you with the same login credentials and a username based on your original username with `-owner` added (for example, `my_profile-owner`). This applies to both **password** and **OAuth** methods. You'll use this new personal account to manage and own the organization.
 
-And that's it! Your personal account becomes the organization, and you will be logged out automatically. You can now log into your new personal account with the same credentials as you are currently logged in with. This applies to both **password** and **OAuth** methods.
+And that's it! Your personal account becomes the organization, and you will be logged out automatically.
 
 For information on [adding members and assigning roles](./setup.md), see the Setup page.
 


### PR DESCRIPTION
Clarify the organization account conversion flow by explaining the impact of naming on display name vs. username, and details about the auto-created personal owner account.

---
[Slack Thread](https://apify.slack.com/archives/CGZSN9DQC/p1765181868535339?thread_ts=1765181868.535339&cid=CGZSN9DQC)

<a href="https://cursor.com/background-agent?bcId=bc-3d8f60b4-cf3c-4aa7-90b2-65b41851b170"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3d8f60b4-cf3c-4aa7-90b2-65b41851b170"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Clarifies org conversion naming behavior, preserves URLs/usernames, and documents the auto-created personal owner account.
> 
> - **Docs**:
>   - Update `sources/platform/collaboration/organization_account/index.md`:
>     - Clarify conversion step wording (enter org name).
>     - Add note explaining that the org name is display-only, original `username` and public URLs remain unchanged, and a new personal owner account is auto-created with a derived username to manage the organization.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5c71ef7d86be9488d7d91a08a84e029dce5f6820. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->