### PR TITLE
chore: edit quick start note to reflect current state

### DIFF
--- a/sources/platform/actors/development/quick-start/start_locally.md
+++ b/sources/platform/actors/development/quick-start/start_locally.md
@@ -62,12 +62,6 @@ Run your Actor with:
 apify run
 ```
 
-:::tip Clear data with --purge
-
-During development, use `apify run --purge`. This clears all results from previous runs, so it's as if you're running the Actor for the first time.
-
-:::
-
 You'll see output similar to this in your terminal:
 
 ```bash


### PR DESCRIPTION
The `--purge` behavior is currently enabled by default, thus it does not make sense to explicitly mention it.