### PR TITLE
docs: fix capitalization of Apify platform on API landing page

### DIFF
--- a/src/pages/api/index.tsx
+++ b/src/pages/api/index.tsx
@@ -121,7 +121,7 @@ export default function Api() {
             <UiLibraryWrapper>
                 <Hero
                     heading="Apify API"
-                    description={<>Apify API provides programmatic access to the <Link to="/">Apify Platform</Link></>}
+                    description={<>Apify API provides programmatic access to the <Link to="/">Apify platform</Link></>}
                 />
                 <SectionWrapper
                     className={styles.LargerContent}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Lowercases “Platform” to “platform” in the API page hero description link text (“Apify platform”).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bfde47a444194399a4d3f3a7358b74117b611365. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->