### PR TITLE
docs: add TC-MO as codeowner to Academy

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,7 +5,7 @@
 /sources/legal/ @mnmkng
 
 # Academy
-/sources/academy/ @honzajavorek
+/sources/academy/ @honzajavorek @TC-MO
 
 # OpenAPI spec
 /apify-api/ @janbuchar @fnesveda


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Add @TC-MO as codeowner for `sources/academy/` in `.github/CODEOWNERS`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f75e9c9f4ccc0756ecf3cafb5626bd6c44592c80. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->