### PR TITLE
chore: fix styles on typedoc generated API reference pages

### DIFF
--- a/apify-docs-theme/src/theme/custom.css
+++ b/apify-docs-theme/src/theme/custom.css
@@ -313,10 +313,6 @@ html[data-theme='dark'] {
     font-size: 1.4rem;
 }
 
-.tsd-panel-header .tsd-flag-group {
-    margin-right: 0.8rem;
-}
-
 .tsd-comment {
     margin-bottom: var(--tsd-spacing-vertical);
 }
@@ -656,7 +652,7 @@ article .card h2 {
 }
 
 .tsd-panel-header .tsd-flag-group {
-    margin-right: .5rem;
+    margin-right: .8rem;
     margin-left: .5rem;
 }
 


### PR DESCRIPTION
Fixes `font-size`-related rendering bugs. Follows https://crawlee.dev/js/api as the original source of visual style.

|before|after|
|---|---|
|<img width="1460" height="1211" alt="image" src="https://github.com/user-attachments/assets/48267e7d-c32d-439e-b455-c1c5f4f6a203" />| <img width="1460" height="1211" alt="image" src="https://github.com/user-attachments/assets/7cc9d0fd-f4ff-4b6c-a0ee-ebcd0d1ae027" /> |

Closes https://github.com/apify/apify-sdk-js/issues/531

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adjusts fonts, heading sizes, and TypeDoc spacing; adds `Lota Grotesque` font for headings to fix API reference typography.
> 
> - **CSS (apify-docs-theme/src/theme/custom.css)**:
>   - **Typography**: Set `--ifm-heading-font-family` to `Lota Grotesque`; added `@font-face` for `Lota Grotesque`.
>   - **TypeDoc layout**: Introduced `--tsd-spacing-*` variables; tuned `.tsd-flag-group` margin and `.tsd-comment` spacing.
>   - **Headings**: Added explicit sizes for `.apiItemContainer h2–h5`; refined Markdown heading size variables.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1403943c72b6bab05820af447c0d91166f9f0006. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->