### PR TITLE
docs: Add more info about free users

### DIFF
--- a/sources/platform/actors/development/programming_interface/status_messages.md
+++ b/sources/platform/actors/development/programming_interface/status_messages.md
@@ -83,8 +83,8 @@ If your Actor has specific limitations for users on the Apify free plan (e.g., r
 
 - Status messages: Use `Actor.setStatusMessage` or `Actor.exit` message to explain why a run finished early or failed (e.g., "Daily limit for free plan reached. Upgrade to continue.").
 - Provide clear error messages: Don't return generic system errors or fail the run in a way that looks like a platform issue. This frustrates users and makes troubleshooting difficult.
-     - Wrong: API usage is limited to 10 results
-     - Right: This Actor only allows up to 10 results for free users. Upgrade to a paid plan to receive unlimited results.
+  - Wrong: API usage is limited to 10 results
+  - Right: This Actor only allows up to 10 results for free users. Upgrade to a paid plan to receive unlimited results.
 - Documentation: Clearly state any limitations in your Actor's `README` and input schema descriptions so users know what to expect before running the Actor.
-    - General restrictions (like limiting the number of results) must be explained in the top-level input schema description that renders above the input editor UI.
-    - Feature-specific limitations must be included in the title of an input field. The title must include explanation in parenthesis such as `(paying users only)` or `(limited for free users)`. E.g. `Max comments (paying users only)`.
+  - General restrictions (like limiting the number of results) must be explained in the top-level input schema description that renders above the input editor UI.
+  - Feature-specific limitations must be included in the title of an input field. The title must include explanation in parenthesis such as `(paying users only)` or `(limited for free users)`. E.g. `Max comments (paying users only)`.

--- a/sources/platform/actors/development/programming_interface/status_messages.md
+++ b/sources/platform/actors/development/programming_interface/status_messages.md
@@ -76,3 +76,11 @@ async def main():
 
 </TabItem>
 </Tabs>
+
+## Communicating limitations
+
+If your Actor has specific limitations for users on the Apify free plan (e.g., restricted features, limited results), it is crucial to communicate these clearly to avoid confusion.
+
+- **Status messages**: Use `setStatusMessage` or the exit message to explain why a run finished early or failed (e.g., "Daily limit for free plan reached. Upgrade to continue.").
+- **Avoid false errors**: Do not return generic system errors or fail the run in a way that looks like a platform issue. This frustrates users and makes troubleshooting difficult.
+- **Documentation**: Clearly state any limitations in your Actor's `README` and input schema descriptions so users know what to expect before running the Actor.

--- a/sources/platform/actors/development/programming_interface/status_messages.md
+++ b/sources/platform/actors/development/programming_interface/status_messages.md
@@ -83,4 +83,6 @@ If your Actor has specific limitations for users on the Apify free plan (e.g., r
 
 - Status messages: Use `Actor.setStatusMessage` or `Actor.exit` message to explain why a run finished early or failed (e.g., "Daily limit for free plan reached. Upgrade to continue.").
 - Avoid false errors: Do not return generic system errors or fail the run in a way that looks like a platform issue. This frustrates users and makes troubleshooting difficult.
+     - Wrong: API usage is limited to 10 results
+     - Right: This Actor only allows up to 10 results for free users. Upgrade to a paid plan to receive unlimited results.
 - Documentation: Clearly state any limitations in your Actor's `README` and input schema descriptions so users know what to expect before running the Actor.

--- a/sources/platform/actors/development/programming_interface/status_messages.md
+++ b/sources/platform/actors/development/programming_interface/status_messages.md
@@ -86,3 +86,5 @@ If your Actor has specific limitations for users on the Apify free plan (e.g., r
      - Wrong: API usage is limited to 10 results
      - Right: This Actor only allows up to 10 results for free users. Upgrade to a paid plan to receive unlimited results.
 - Documentation: Clearly state any limitations in your Actor's `README` and input schema descriptions so users know what to expect before running the Actor.
+    - General restrictions (like limiting the number of results) must be explained in the top-level input schema description that renders above the input editor UI.
+    - Feature-specific limitations must be included in the title of an input field. The title must include explanation in parenthesis such as `(paying users only)` or `(limited for free users`). E.g. `Max comments (paying users only)`.

--- a/sources/platform/actors/development/programming_interface/status_messages.md
+++ b/sources/platform/actors/development/programming_interface/status_messages.md
@@ -81,6 +81,6 @@ async def main():
 
 If your Actor has specific limitations for users on the Apify free plan (e.g., restricted features, limited results), it is crucial to communicate these clearly to avoid confusion.
 
-- **Status messages**: Use `setStatusMessage` or the exit message to explain why a run finished early or failed (e.g., "Daily limit for free plan reached. Upgrade to continue.").
-- **Avoid false errors**: Do not return generic system errors or fail the run in a way that looks like a platform issue. This frustrates users and makes troubleshooting difficult.
-- **Documentation**: Clearly state any limitations in your Actor's `README` and input schema descriptions so users know what to expect before running the Actor.
+- Status messages: Use `setStatusMessage` or the exit message to explain why a run finished early or failed (e.g., "Daily limit for free plan reached. Upgrade to continue.").
+- Avoid false errors: Do not return generic system errors or fail the run in a way that looks like a platform issue. This frustrates users and makes troubleshooting difficult.
+- Documentation: Clearly state any limitations in your Actor's `README` and input schema descriptions so users know what to expect before running the Actor.

--- a/sources/platform/actors/development/programming_interface/status_messages.md
+++ b/sources/platform/actors/development/programming_interface/status_messages.md
@@ -81,6 +81,6 @@ async def main():
 
 If your Actor has specific limitations for users on the Apify free plan (e.g., restricted features, limited results), it is crucial to communicate these clearly to avoid confusion.
 
-- Status messages: Use `setStatusMessage` or the exit message to explain why a run finished early or failed (e.g., "Daily limit for free plan reached. Upgrade to continue.").
+- Status messages: Use `Actor.setStatusMessage` or `Actor.exit` message to explain why a run finished early or failed (e.g., "Daily limit for free plan reached. Upgrade to continue.").
 - Avoid false errors: Do not return generic system errors or fail the run in a way that looks like a platform issue. This frustrates users and makes troubleshooting difficult.
 - Documentation: Clearly state any limitations in your Actor's `README` and input schema descriptions so users know what to expect before running the Actor.

--- a/sources/platform/actors/development/programming_interface/status_messages.md
+++ b/sources/platform/actors/development/programming_interface/status_messages.md
@@ -77,14 +77,14 @@ async def main():
 </TabItem>
 </Tabs>
 
-## Communicating limitations
+## Communicate limitations
 
-If your Actor has specific limitations for users on the Apify free plan (e.g., restricted features, limited results), it is crucial to communicate these clearly to avoid confusion.
+If your Actor has specific limitations for users on the Apify free plan (e.g., restricted features, limited results), communicate these clearly to avoid confusion.
 
 - Status messages: Use `Actor.setStatusMessage` or `Actor.exit` message to explain why a run finished early or failed (e.g., "Daily limit for free plan reached. Upgrade to continue.").
-- Avoid false errors: Do not return generic system errors or fail the run in a way that looks like a platform issue. This frustrates users and makes troubleshooting difficult.
+- Provide clear error messages: Don't return generic system errors or fail the run in a way that looks like a platform issue. This frustrates users and makes troubleshooting difficult.
      - Wrong: API usage is limited to 10 results
      - Right: This Actor only allows up to 10 results for free users. Upgrade to a paid plan to receive unlimited results.
 - Documentation: Clearly state any limitations in your Actor's `README` and input schema descriptions so users know what to expect before running the Actor.
     - General restrictions (like limiting the number of results) must be explained in the top-level input schema description that renders above the input editor UI.
-    - Feature-specific limitations must be included in the title of an input field. The title must include explanation in parenthesis such as `(paying users only)` or `(limited for free users`). E.g. `Max comments (paying users only)`.
+    - Feature-specific limitations must be included in the title of an input field. The title must include explanation in parenthesis such as `(paying users only)` or `(limited for free users)`. E.g. `Max comments (paying users only)`.

--- a/sources/platform/actors/development/programming_interface/status_messages.md
+++ b/sources/platform/actors/development/programming_interface/status_messages.md
@@ -81,7 +81,7 @@ async def main():
 
 If your Actor has specific limitations for users on the Apify free plan (e.g., restricted features, limited results), communicate these clearly to avoid confusion.
 
-- Status messages: Use `Actor.setStatusMessage` or `Actor.exit` message to explain why a run finished early or failed (e.g., "Daily limit for free plan reached. Upgrade to continue.").
+- Status messages: Use `Actor.setStatusMessage` or `Actor.exit` message to explain why a run finished early or failed (e.g., "This Actor has a special daily limit for free plan users. This was set by the Actor developer, not Apify. Upgrade to continue.").
 - Provide clear error messages: Don't return generic system errors or fail the run in a way that looks like a platform issue. This frustrates users and makes troubleshooting difficult.
   - Wrong: API usage is limited to 10 results
   - Right: This Actor only allows up to 10 results for free users. Upgrade to a paid plan to receive unlimited results.

--- a/sources/platform/actors/development/programming_interface/status_messages.md
+++ b/sources/platform/actors/development/programming_interface/status_messages.md
@@ -15,7 +15,7 @@ import TabItem from '@theme/TabItem';
 Each Actor run has a status, represented by the `status` field. The following table describes the possible values:
 
 |Status|Type|Description|
-|--- |--- |--- |
+|---|---|---|
 |`READY`|initial|Started but not allocated to any worker yet|
 |`RUNNING`|transitional|Executing on a worker|
 |`SUCCEEDED`|terminal|Finished successfully|

--- a/sources/platform/actors/publishing/monetize/index.mdx
+++ b/sources/platform/actors/publishing/monetize/index.mdx
@@ -123,7 +123,7 @@ The analytics dashboard allows you to select specific Actors and view key metric
 
 All metrics can be exported as JSON for custom analysis and reporting.
 
-## Promoting your Actor
+## Promote your Actor
 
 Create search-engine-optimized descriptions and README files to improve search engine visibility. Share your Actor on multiple channels:
 

--- a/sources/platform/actors/publishing/monetize/index.mdx
+++ b/sources/platform/actors/publishing/monetize/index.mdx
@@ -61,7 +61,7 @@ Follow the monetization wizard to configure your pricing model.
 </TabItem>
 </Tabs>
 
-### Changing monetization
+### Change monetization
 
 You can change the monetization setting of your Actor by using the same wizard as for the setup in the **Monetization** section of your Actor's **Publication** tab.
 

--- a/sources/platform/actors/publishing/monetize/index.mdx
+++ b/sources/platform/actors/publishing/monetize/index.mdx
@@ -40,6 +40,14 @@ The following table compares the two main pricing models available for monetizin
 | Custom event billing    | Not available                 | Not available                 | ✅ Charge for any event       |
 | Per-result billing      | Not available                 | ✅ Charge per dataset item    | Optional (via event; automatic via `apify-default-dataset-item`) |
 
+## Handling free users
+
+When monetizing your Actor, you might want to limit features or usage for users on the Apify free plan. If you choose to do this, you **must** handle it transparently:
+
+- **Communicate upfront**: Clearly state any limitations in your Actor's `README` and input schema. Users should know about restrictions _before_ they run the Actor.
+- **Graceful exits**: If a free user hits a limit, do not crash the Actor or return a system error. Instead, exit gracefully with a clear [status message](/platform/actors/development/programming-interface/status-messages#communicating-limitations) explaining the limit (e.g., "Free tier limit reached").
+- **Avoid confusion**: Never make a policy restriction look like a bug or platform error.
+
 ## Setting up monetization
 
 Navigate to your [Actor page](https://console.apify.com/actors?tab=my) in Apify Console, choose the Actor that you want to monetize, and select the Publication tab.

--- a/sources/platform/actors/publishing/monetize/index.mdx
+++ b/sources/platform/actors/publishing/monetize/index.mdx
@@ -100,12 +100,12 @@ If no action is taken, the payout will be automatically approved on the 14th, wi
 
 If the monthly profit does not meet these thresholds, as per our [Terms & Conditions](https://apify.com/store-terms-and-conditions), the funds will roll over to the next month until the threshold is reached.
 
-## Handling free users
+## Handle free users
 
-When monetizing your Actor, you might want to limit features or usage for users on the Apify free plan. If you choose to do this, you **must** handle it transparently:
+When monetizing your Actor, you might want to limit features or usage for users on the Apify free plan. If you choose to do this, you _must_ handle it transparently:
 
 - Communicate upfront: Clearly state any limitations in your Actor's `README` and input schema. Users should know about restrictions _before_ they run the Actor.
-- Graceful exits: If a free user hits a limit, do not crash the Actor or return a system error. Instead, exit gracefully with a clear [status message](/platform/actors/development/programming-interface/status-messages#communicating-limitations) explaining the limit (e.g., "Free tier limit reached").
+- Graceful exits: If a free user hits a limit, don't crash the Actor or return a system error. Instead, exit gracefully with a clear [status message](/platform/actors/development/programming-interface/status-messages#communicating-limitations) explaining the limit (e.g., "Free tier limit reached").
 - Avoid confusion: Never make a policy restriction look like a bug or platform error.
 
 ## Actor analytics

--- a/sources/platform/actors/publishing/monetize/index.mdx
+++ b/sources/platform/actors/publishing/monetize/index.mdx
@@ -29,16 +29,16 @@ For a detailed comparison of pricing models from the perspective of your users, 
 
 The following table compares the two main pricing models available for monetizing your Actors:
 
-| Feature/Category         | Rental                | Pay-per-result (PPR)         | Pay-per-event (PPE)           |
-|-------------------------|-------------------------------|-------------------------------|-------------------------------|
-| Revenue scalability     | Capped at monthly fee         | Unlimited, scales with usage  | Unlimited, scales with usage  |
-| AI/MCP compatibility    | ❌ Not compatible             | ✅ Fully compatible           | ✅ Fully compatible           |
-| User cost predictability| Unpredictable (rental + usage)    | Predictable    | Predictable    |
-| Store discounts         | ❌ Single price only          | ✅ Store discounts available  | ✅ Store discounts available  |
-| Marketing boost         | Standard visibility           | Standard visibility           | Priority store placement      |
-| Commission opportunities| Standard 20%                  | Standard 20%                  | Standard 20%       |
-| Custom event billing    | Not available                 | Not available                 | ✅ Charge for any event       |
-| Per-result billing      | Not available                 | ✅ Charge per dataset item    | Optional (via event; automatic via `apify-default-dataset-item`) |
+| Feature/Category         | Rental                         | Pay-per-result (PPR)          | Pay-per-event (PPE)                                              |
+|--------------------------|--------------------------------|-------------------------------|------------------------------------------------------------------|
+| Revenue scalability      | Capped at monthly fee          | Unlimited, scales with usage  | Unlimited, scales with usage                                     |
+| AI/MCP compatibility     | ❌ Not compatible              | ✅ Fully compatible           | ✅ Fully compatible                                              |
+| User cost predictability | Unpredictable (rental + usage) | Predictable                   | Predictable                                                      |
+| Store discounts          | ❌ Single price only           | ✅ Store discounts available  | ✅ Store discounts available                                     |
+| Marketing boost          | Standard visibility            | Standard visibility           | Priority store placement                                         |
+| Commission opportunities | Standard 20%                   | Standard 20%                  | Standard 20%                                                     |
+| Custom event billing     | Not available                  | Not available                 | ✅ Charge for any event                                          |
+| Per-result billing       | Not available                  | ✅ Charge per dataset item    | Optional (via event; automatic via `apify-default-dataset-item`) |
 
 ## Handling free users
 

--- a/sources/platform/actors/publishing/monetize/index.mdx
+++ b/sources/platform/actors/publishing/monetize/index.mdx
@@ -40,14 +40,6 @@ The following table compares the two main pricing models available for monetizin
 | Custom event billing     | Not available                  | Not available                 | ✅ Charge for any event                                          |
 | Per-result billing       | Not available                  | ✅ Charge per dataset item    | Optional (via event; automatic via `apify-default-dataset-item`) |
 
-## Handling free users
-
-When monetizing your Actor, you might want to limit features or usage for users on the Apify free plan. If you choose to do this, you **must** handle it transparently:
-
-- **Communicate upfront**: Clearly state any limitations in your Actor's `README` and input schema. Users should know about restrictions _before_ they run the Actor.
-- **Graceful exits**: If a free user hits a limit, do not crash the Actor or return a system error. Instead, exit gracefully with a clear [status message](/platform/actors/development/programming-interface/status-messages#communicating-limitations) explaining the limit (e.g., "Free tier limit reached").
-- **Avoid confusion**: Never make a policy restriction look like a bug or platform error.
-
 ## Setting up monetization
 
 Navigate to your [Actor page](https://console.apify.com/actors?tab=my) in Apify Console, choose the Actor that you want to monetize, and select the Publication tab.
@@ -107,6 +99,14 @@ If no action is taken, the payout will be automatically approved on the 14th, wi
 - $100 for other payout methods
 
 If the monthly profit does not meet these thresholds, as per our [Terms & Conditions](https://apify.com/store-terms-and-conditions), the funds will roll over to the next month until the threshold is reached.
+
+## Handling free users
+
+When monetizing your Actor, you might want to limit features or usage for users on the Apify free plan. If you choose to do this, you **must** handle it transparently:
+
+- **Communicate upfront**: Clearly state any limitations in your Actor's `README` and input schema. Users should know about restrictions _before_ they run the Actor.
+- **Graceful exits**: If a free user hits a limit, do not crash the Actor or return a system error. Instead, exit gracefully with a clear [status message](/platform/actors/development/programming-interface/status-messages#communicating-limitations) explaining the limit (e.g., "Free tier limit reached").
+- **Avoid confusion**: Never make a policy restriction look like a bug or platform error.
 
 ## Actor analytics
 

--- a/sources/platform/actors/publishing/monetize/index.mdx
+++ b/sources/platform/actors/publishing/monetize/index.mdx
@@ -40,7 +40,7 @@ The following table compares the two main pricing models available for monetizin
 | Custom event billing     | Not available                  | Not available                 | ✅ Charge for any event                                          |
 | Per-result billing       | Not available                  | ✅ Charge per dataset item    | Optional (via event; automatic via `apify-default-dataset-item`) |
 
-## Setting up monetization
+## Set up monetization
 
 Navigate to your [Actor page](https://console.apify.com/actors?tab=my) in Apify Console, choose the Actor that you want to monetize, and select the Publication tab.
 ![Monetization section](../images/monetization-section.png)

--- a/sources/platform/actors/publishing/monetize/index.mdx
+++ b/sources/platform/actors/publishing/monetize/index.mdx
@@ -104,9 +104,9 @@ If the monthly profit does not meet these thresholds, as per our [Terms & Condit
 
 When monetizing your Actor, you might want to limit features or usage for users on the Apify free plan. If you choose to do this, you **must** handle it transparently:
 
-- **Communicate upfront**: Clearly state any limitations in your Actor's `README` and input schema. Users should know about restrictions _before_ they run the Actor.
-- **Graceful exits**: If a free user hits a limit, do not crash the Actor or return a system error. Instead, exit gracefully with a clear [status message](/platform/actors/development/programming-interface/status-messages#communicating-limitations) explaining the limit (e.g., "Free tier limit reached").
-- **Avoid confusion**: Never make a policy restriction look like a bug or platform error.
+- Communicate upfront: Clearly state any limitations in your Actor's `README` and input schema. Users should know about restrictions _before_ they run the Actor.
+- Graceful exits: If a free user hits a limit, do not crash the Actor or return a system error. Instead, exit gracefully with a clear [status message](/platform/actors/development/programming-interface/status-messages#communicating-limitations) explaining the limit (e.g., "Free tier limit reached").
+- Avoid confusion: Never make a policy restriction look like a bug or platform error.
 
 ## Actor analytics
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds documentation on transparently handling free-plan limitations, including using status messages and graceful exits.
> 
> - **Docs: Handling free users / limitations**
>   - Add "Communicating limitations" to `platform/actors/development/programming_interface/status_messages.md` with guidance to:
>     - Use `setStatusMessage`/exit messages to explain early finishes or failures.
>     - Avoid misleading system-like errors.
>     - Document limits in `README` and input schema.
>   - Add "Handling free users" to `platform/actors/publishing/monetize/index.mdx` covering:
>     - Upfront communication of limits.
>     - Graceful exits with clear status messages (linked section).
>     - Avoiding confusion by not presenting policy limits as platform errors.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 803f9d6dbd6aba47aba5dea23656908a6bca47b6. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->