### PR TITLE
docs: Deprecation of `patternKey` and `patternValue` in input schema

### DIFF
--- a/sources/platform/actors/development/actor_definition/input_schema/specification.md
+++ b/sources/platform/actors/development/actor_definition/input_schema/specification.md
@@ -979,10 +979,12 @@ This setting defines runtime access only and doesn't change field visibility or 
 
 ### Deprecation of `patternKey` and `patternValue`
 
-The following properties are deprecated and will be removed in a future version:
+::::warning Deprecation notice
+**The following properties are deprecated and will continue to be supported until May 31, 2026:**
 
 - `patternKey` - Used to validate keys in objects and arrays
 - `patternValue` - Used to validate values in objects and arrays
+::::
 
 We are deprecating these properties to better align with the JSON schema specification. The current approach with `patternKey` and `patternValue` is Apify-specific and doesn't follow standard JSON schema validation patterns. By moving to standard JSON schema, we provide a more consistent experience that matches industry standards while enabling more powerful validation capabilities through the ability to define sub-properties.
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Marks `patternKey` and `patternValue` as deprecated in object/array fields and adds a deprecation section with migration examples using `items` subschemas.
> 
> - **Docs — Input schema**:
>   - **Deprecation**: Adds a warning section deprecating `patternKey` and `patternValue` (supported until May 31, 2026) with rationale and scope.
>   - **Object fields**: Updates properties table to mark `patternKey` and `patternValue` as deprecated and link to the deprecation section.
>   - **Array fields**:
>     - Reorganizes properties table and marks `patternKey`/`patternValue` as deprecated with migration link.
>     - Adds migration examples replacing `patternValue` (strings) and both `patternKey`/`patternValue` (key-value pairs) with `items` subschemas.
>   - **Guidance**: Notes no direct replacement for objects; recommends using predefined `properties` schemas.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1c7b4450e7d055ca31e60ca39395b2b54190c8a0. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->