### PR TITLE
feat(docs): Add Cursor & VSCode integration

### DIFF
--- a/apify-docs-theme/src/theme/LLMButtons/index.jsx
+++ b/apify-docs-theme/src/theme/LLMButtons/index.jsx
@@ -7,11 +7,13 @@ import {
     CheckIcon,
     ChevronDownIcon,
     CopyIcon,
+    CursorIcon,
     ExternalLinkIcon,
     LoaderIcon,
     MarkdownIcon,
     McpIcon,
     PerplexityIcon,
+    VscodeIcon,
 } from '@apify/ui-icons';
 import { Menu, Text, theme } from '@apify/ui-library';
 
@@ -34,25 +36,25 @@ const DROPDOWN_OPTIONS = [
     },
     {
         label: 'Copy MCP server',
-        description: 'Copy Apify MCP configuration',
+        description: 'Copy MCP Server URL to clipboard',
         showExternalIcon: false,
         Icon: McpIcon,
         value: 'copyMcpServer',
     },
     {
         label: 'Connect to Cursor',
-        description: 'Open MCP configurator for Cursor',
+        description: 'Install MCP Server on Cursor',
         showExternalIcon: true,
         // TODO: Replace with CursorIcon - we don't have one yet
-        Icon: ExternalLinkIcon,
+        Icon: CursorIcon,
         value: 'connectCursor',
     },
     {
         label: 'Connect to VS Code',
-        description: 'Open MCP configurator for VS Code',
+        description: 'Install MCP server on VS Code',
         showExternalIcon: true,
         // TODO: Replace with VS Code Icon - we don't have one yet
-        Icon: ExternalLinkIcon,
+        Icon: VscodeIcon,
         value: 'connectVsCode',
     },
     {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
                 "apify-docs-theme"
             ],
             "dependencies": {
-                "@apify/ui-icons": "^1.19.0",
+                "@apify/ui-icons": "^1.25.0",
                 "@apify/ui-library": "^1.97.2",
                 "@docusaurus/core": "^3.8.1",
                 "@docusaurus/faster": "^3.8.1",
@@ -750,10 +750,11 @@
             "dev": true
         },
         "node_modules/@apify/ui-icons": {
-            "version": "1.24.1",
-            "resolved": "https://registry.npmjs.org/@apify/ui-icons/-/ui-icons-1.24.1.tgz",
-            "integrity": "sha512-lnf3D189VjFFAe2/7a2zm04a7NKm6Dd5Fk6oHncLVDkEVph5R0ImvD4NPY08YzvrfZ7s5ewY0WPOOF3rFoMzhw==",
+            "version": "1.25.0",
+            "resolved": "https://registry.npmjs.org/@apify/ui-icons/-/ui-icons-1.25.0.tgz",
+            "integrity": "sha512-kD5ggDePMVz8H7wx5NSuwcP3E/mAy7oBN4ivC9Tuk9S20+LNy0jea7IPEnjLg16rjjfCPynZ2w/2CO/k5aJN0w==",
             "hasInstallScript": true,
+            "license": "Apache-2.0",
             "dependencies": {
                 "clsx": "^2.0.0"
             },

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     },
     "dependencies": {
         "@apify/ui-library": "^1.97.2",
-        "@apify/ui-icons": "^1.19.0",
+        "@apify/ui-icons": "^1.25.0",
         "@docusaurus/core": "^3.8.1",
         "@docusaurus/faster": "^3.8.1",
         "@docusaurus/plugin-client-redirects": "^3.8.1",


### PR DESCRIPTION
closes: https://github.com/apify/apify-docs/issues/2079
Add a Cursor & VSCode integration to LLM Dropdown.

Opening the Cursor and VSCode with predefined MCP configuration.

Icons needs to be merged first: https://github.com/apify/apify-core/pull/24852

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds LLM dropdown options to copy Apify MCP config and connect via Cursor/VS Code deeplinks with web configurator fallback.
> 
> - **LLM dropdown (`apify-docs-theme/src/theme/LLMButtons/index.jsx`)**:
>   - Add options: `copyMcpServer`, `connectCursor`, `connectVsCode` with corresponding icons and descriptions.
>   - Implement `MCP_CONFIG_JSON` and `onCopyMcpServerClick` to copy MCP config to clipboard.
>   - Implement deep links via `openMcpIntegration` for `cursor` and `vscode` (with `openApifyMcpConfigurator` fallback) and hook up `onConnectCursorClick`/`onConnectVsCodeClick`.
>   - Track analytics events for new actions.
>   - Minor tweak to chevron open-state toggle invocation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1c287d95e023e490b752c9ebeb4548393602919b. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->