### PR TITLE
fix: Fix markdown url links formatting

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -9,6 +9,15 @@ const { collectSlugs } = require('./tools/utils/collectSlugs');
 const { externalLinkProcessor, isInternal } = require('./tools/utils/externalLink');
 const { removeLlmButtons } = require('./tools/utils/removeLlmButtons');
 
+/**
+ * Helper to extract text from a node recursively.
+ */
+function getNodeText(node) {
+    if (node.type === 'text' || node.type === 'code' || node.type === 'inlineCode') return node.value || '';
+    if (node.children) return node.children.map(getNodeText).join('');
+    return '';
+}
+
 /** @type {Partial<import('@docusaurus/types').DocusaurusConfig>} */
 module.exports = {
     title: 'Apify Documentation',
@@ -301,7 +310,10 @@ module.exports = {
                                 const url = isUrlInternal ? `${config.absoluteUrl}${parsedUrl.pathname}.md` : node.url;
 
                                 if (isUrlInternal && !parsedUrl.pathname) return '';
+
                                 if (node.title) return `[${node.title}](${url})`;
+                                const linkText = getNodeText(node);
+                                if (linkText) return `[${linkText}](${url})`;
                                 return url;
                             },
                             code: (node) => {


### PR DESCRIPTION
The custom link handler was ignoring the link text (`node.children`) and only returning the URL.

I have fixed this by adding a helper to extract the link text and returing the links as `[text](url)` correctly.

### Testing

- npm run build
- npx docusaurus serve

Tested on following sites:
- https://localhost:3000/platform/integrations/actors/integration-ready-actors.md
- https://localhost:3000/platform/security.md
- https://localhost:3000/platform/integrations.md

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes markdown link serialization used by the LLMs export.
> 
> - Adds `getNodeText` helper to recursively extract link text from nodes
> - Updates `remarkStringify.handlers.link` in `docusaurus-plugin-llms-txt` config to output `[text](url)` using `title` or extracted text, falling back to raw URL
> - Keeps existing internal URL normalization and skip logic intact
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7afb909c66ed9d722779d2db3add14094af6708a. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->