### PR TITLE
fix(docs): Replace the Claude icon [ignore]

### DIFF
--- a/apify-docs-theme/src/theme/LLMButtons/index.jsx
+++ b/apify-docs-theme/src/theme/LLMButtons/index.jsx
@@ -2,10 +2,10 @@ import clsx from 'clsx';
 import React, { useCallback, useState } from 'react';
 
 import {
-    AnthropicIcon,
     ChatGptIcon,
     CheckIcon,
     ChevronDownIcon,
+    ClaudeIcon,
     CopyIcon,
     CursorIcon,
     ExternalLinkIcon,
@@ -68,7 +68,7 @@ const DROPDOWN_OPTIONS = [
         label: 'Open in Claude',
         description: 'Ask questions about this page',
         showExternalIcon: true,
-        Icon: AnthropicIcon,
+        Icon: ClaudeIcon,
         value: 'openInClaude',
     },
     {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
                 "apify-docs-theme"
             ],
             "dependencies": {
-                "@apify/ui-icons": "^1.25.0",
+                "@apify/ui-icons": "^1.26.0",
                 "@apify/ui-library": "^1.97.2",
                 "@docusaurus/core": "^3.8.1",
                 "@docusaurus/faster": "^3.8.1",
@@ -62,7 +62,7 @@
         },
         "apify-docs-theme": {
             "name": "@apify/docs-theme",
-            "version": "1.0.225",
+            "version": "1.0.227",
             "license": "ISC",
             "dependencies": {
                 "@apify/docs-search-modal": "^1.3.3",
@@ -750,9 +750,9 @@
             "dev": true
         },
         "node_modules/@apify/ui-icons": {
-            "version": "1.25.0",
-            "resolved": "https://registry.npmjs.org/@apify/ui-icons/-/ui-icons-1.25.0.tgz",
-            "integrity": "sha512-kD5ggDePMVz8H7wx5NSuwcP3E/mAy7oBN4ivC9Tuk9S20+LNy0jea7IPEnjLg16rjjfCPynZ2w/2CO/k5aJN0w==",
+            "version": "1.26.0",
+            "resolved": "https://registry.npmjs.org/@apify/ui-icons/-/ui-icons-1.26.0.tgz",
+            "integrity": "sha512-TNMaxQgkeVBe4rcNl5b9S6EpF8AbHEmturY0Vv1vSJZZn2+cW3XMFKy1ySN6EYBqIbLkGU2e8b0KpeJ98S7wCQ==",
             "hasInstallScript": true,
             "license": "Apache-2.0",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     },
     "dependencies": {
         "@apify/ui-library": "^1.97.2",
-        "@apify/ui-icons": "^1.25.0",
+        "@apify/ui-icons": "^1.26.0",
         "@docusaurus/core": "^3.8.1",
         "@docusaurus/faster": "^3.8.1",
         "@docusaurus/plugin-client-redirects": "^3.8.1",


### PR DESCRIPTION
Replacing the Claude icon as mentioned here: https://apify.slack.com/archives/CQ96RHG2U/p1767710444660769

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches the Claude button to use the new `ClaudeIcon` and updates icons dependency.
> 
> - Replaces `AnthropicIcon` with `ClaudeIcon` in `apify-docs-theme/src/theme/LLMButtons/index.jsx` (import and `DROPDOWN_OPTIONS` entry)
> - Bumps `@apify/ui-icons` to `^1.26.0`; lockfile updated and theme package version reflects new build
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 26d0fde99ba3140892ab5ab2e8226ee9843e21fd. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->