### PR TITLE
fix(docs): Fix heading in output schema docs

### DIFF
--- a/sources/platform/actors/development/actor_definition/output_schema/index.md
+++ b/sources/platform/actors/development/actor_definition/output_schema/index.md
@@ -62,33 +62,33 @@ The output schema defines the collections of keys and their properties. It allow
 
 | Property                          | Type                          | Required | Description                                                                                                     |
 |-----------------------------------|-------------------------------|----------|-----------------------------------------------------------------------------------------------------------------|
-| `actorOutputSchemaVersion`        | integer                       | true     | Specifies the version of output schema structure document. <br/>Currently only version 1 is available. |
-| `title`                           | string                        | true     | Title of the schema                                                               |
-| `description`                     | string                        | false    | Description of the schema                                                         |
-| `properties`                      | Object                        | true     | An object where each key is an output ID and its value is an Output object definition (see below).        |
+| `actorOutputSchemaVersion`        | integer                       | true     | Specifies the version of output schema structure document. <br/>Currently only version 1 is available.          |
+| `title`                           | string                        | true     | Title of the schema                                                                                             |
+| `description`                     | string                        | false    | Description of the schema                                                                                       |
+| `properties`                      | Object                        | true     | An object where each key is an output ID and its value is an Output object definition (see below).              |
 
 ### Output object definition
 
 | Property       | Type         | Required     | Description                                                                                                                                     |
 |----------------|--------------|--------------|-------------------------------------------------------------------------------------------------------------------------------------------------|
-| `title`        | string       | true         | The output's title, shown in the run's output tab if there are multiple outputs and in API as key for the generated output URL.    |
-| `description`  | string       | false        | A description of the output. Only used when reading the schema (useful for LLMs)  |
-| `template`     | string       | true         | Defines a template which will be translated into output URL. The template can use variables (see below) |
+| `title`        | string       | true         | The output's title, shown in the run's output tab if there are multiple outputs and in API as key for the generated output URL.                 |
+| `description`  | string       | false        | A description of the output. Only used when reading the schema (useful for LLMs)                                                                |
+| `template`     | string       | true         | Defines a template which will be translated into output URL. The template can use variables (see below)                                         |
 
 ### Available template variables
 
-| Variable       | Type         | Description |
-|----------------|--------------|--------------|
-| `links`        | object       | Contains quick links to most commonly used URLs    |
-| `links.publicRunUrl`        | string       | Public run url in format `https://console.apify.com/view/runs/:runId` |
-| `links.consoleRunUrl`        | string       | Console run url in format `https://console.apify.com/actors/runs/:runId` |
-| `links.apiRunUrl`        | string       | API run url in format `https://api.apify.com/v2/actor-runs/:runId` |
-| `links.apiDefaultDatasetUrl`        | string       | API url of default dataset in format `https://api.apify.com/v2/datasets/:defaultDatasetId` |
-| `links.apiDefaultKeyValueStoreUrl`        | string       | API url of default key-value store in format `https://api.apify.com/v2/key-value-stores/:defaultKeyValueStoreId` |
-| `run`        | object       | Contains information about the run same as it is returned from the `GET Run` API endpoint |
-| `run.containerUrl`        | string       | URL of a webserver running inside the run in format `https://<containerId>.runs.apify.net/` |
-| `run.defaultDatasetId`  | string | ID of the default dataset  |
-| `run.defaultKeyValueStoreId`     | string       | ID of the default key-value store |
+| Variable                           | Type   | Description                                                                                                                      |
+|------------------------------------|--------|----------------------------------------------------------------------------------------------------------------------------------|
+| `links`                            | object | Contains quick links to most commonly used URLs                                                                                  |
+| `links.publicRunUrl`               | string | Public run url in format `https://console.apify.com/view/runs/:runId`                                                            |
+| `links.consoleRunUrl`              | string | Console run url in format `https://console.apify.com/actors/runs/:runId`                                                         |
+| `links.apiRunUrl`                  | string | API run url in format `https://api.apify.com/v2/actor-runs/:runId`                                                               |
+| `links.apiDefaultDatasetUrl`       | string | API url of default dataset in format `https://api.apify.com/v2/datasets/:defaultDatasetId`                                       |
+| `links.apiDefaultKeyValueStoreUrl` | string | API url of default key-value store in format `https://api.apify.com/v2/key-value-stores/:defaultKeyValueStoreId`                 |
+| `run`                              | object | Contains information about the run same as it is returned from the `GET Run` API endpoint                                        |
+| `run.containerUrl`                 | string | URL of a webserver running inside the run in format `https://<containerId>.runs.apify.net/`                                      |
+| `run.defaultDatasetId`             | string | ID of the default dataset                                                                                                        |
+| `run.defaultKeyValueStoreId`       | string | ID of the default key-value store                                                                                                |
 
 ## Examples
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Improves clarity and consistency in the output schema documentation.
> 
> - Renames `Property object definition` to `Output object definition`
> - Fixes capitalization (e.g., "Output" object) and aligns table formatting
> - Minor spacing/consistency tweaks in the `template` row and `actorOutputSchemaVersion` entry
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 32b29be660f98fe255ed665b27cd8ef3d6a07608. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->