### PR TITLE
fix: add missing docs for attachment param for KV getRecord

### DIFF
--- a/apify-api/openapi/paths/key-value-stores/key-value-stores@{storeId}@records@{recordKey}.yaml
+++ b/apify-api/openapi/paths/key-value-stores/key-value-stores@{storeId}@records@{recordKey}.yaml
@@ -14,6 +14,10 @@ get:
     Most HTTP clients support decompression by default. After using the HTTP
     client with decompression support, the `Accept-Encoding` header is set by
     the client and body is decompressed automatically.
+
+    Please note that for security reasons, Apify API can perform small modifications
+    to HTML documents before they are served via this endpoint. To fetch the raw HTML
+    content without any modifications, use the `attachment` query parameter.
   operationId: keyValueStore_record_get
   parameters:
     - name: storeId


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Updates OpenAPI docs for Key-value stores `getRecord`.
> 
> - Adds optional boolean `attachment` query parameter; when `true`/`1`, responses include `Content-Disposition: attachment` so browsers download HTML records instead of displaying them
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d7695485320b03955b49c07798324ece5f680420. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->