### PR TITLE
docs: update starter plan pricing in storage pricing calculator

### DIFF
--- a/src/components/StoragePricingCalculator/index.jsx
+++ b/src/components/StoragePricingCalculator/index.jsx
@@ -8,7 +8,7 @@ import styles from './StoragePricingCalculator.module.css';
 const pricingTiers = [
   {
     name: 'Free/Starter',
-    description: '$0/month & $39/month',
+    description: '$0/month & $29/month',
     storageMultiplier: 1.0,
     readMultiplier: 1.0,
     writeMultiplier: 1.0,


### PR DESCRIPTION
The pricing changed on Monday, this change reflects that 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates displayed pricing for the Starter tier.
> 
> - In `src/components/StoragePricingCalculator/index.jsx`, changes `pricingTiers["Free/Starter"].description` from `$0/month & $39/month` to `$0/month & $29/month`
> 
> No calculation logic or other tiers modified.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a916bdc2e096592a27ab6cd21f8aa2d55a7c0f1b. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->