### PR TITLE
docs: fix dynamic actor memory example typo

### DIFF
--- a/sources/platform/actors/development/actor_definition/dynamic_actor_memory/index.md
+++ b/sources/platform/actors/development/actor_definition/dynamic_actor_memory/index.md
@@ -69,7 +69,7 @@ You can define a dynamic memory expression in your `actor.json`:
 
 ```json
 {
-  "defaultMemoryMbytes": "get(input, 'startUrls.length' * 1024)"
+  "defaultMemoryMbytes": "get(input, 'startUrls.length') * 1024"
 }
 ```
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Fixes an example expression in `sources/platform/actors/development/actor_definition/dynamic_actor_memory/index.md`.
> 
> - Updates `"defaultMemoryMbytes": "get(input, 'startUrls.length') * 1024"` (was `get(input, 'startUrls.length' * 1024)`), ensuring multiplication happens outside `get()`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5bc277b5b60b3d3009c3212f41e74def5a74ceb6. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->