### PR TITLE
fix(openapi): Add format specs and constraints to schema fields

### DIFF
--- a/apify-api/openapi/components/schemas/actor-builds/BuildsMeta.yaml
+++ b/apify-api/openapi/components/schemas/actor-builds/BuildsMeta.yaml
@@ -9,6 +9,7 @@ properties:
     examples: [WEB]
   clientIp:
     type: string
+    format: ipv4
     examples: [172.234.12.34]
   userAgent:
     type: string

--- a/apify-api/openapi/components/schemas/actor-builds/GetOpenApiResponse.yaml
+++ b/apify-api/openapi/components/schemas/actor-builds/GetOpenApiResponse.yaml
@@ -23,6 +23,7 @@ properties:
       properties:
         url:
           type: string
+          format: uri
           examples: [https://api.apify.com/v2]
   paths:
     type: object

--- a/apify-api/openapi/components/schemas/actor-runs/Run.yaml
+++ b/apify-api/openapi/components/schemas/actor-runs/Run.yaml
@@ -103,6 +103,7 @@ properties:
     description: Build number of the Actor build used for this run.
   containerUrl:
     type: string
+    format: uri
     examples: ["https://g8kd8kbc5ge8.runs.apify.net"]
     description: URL of the container running the Actor.
   isContainerServerReady:

--- a/apify-api/openapi/components/schemas/actor-runs/RunOptions.yaml
+++ b/apify-api/openapi/components/schemas/actor-runs/RunOptions.yaml
@@ -11,16 +11,22 @@ properties:
     examples: [latest]
   timeoutSecs:
     type: integer
+    minimum: 0
     examples: [300]
   memoryMbytes:
     type: integer
+    minimum: 128
+    maximum: 32768
     examples: [1024]
   diskMbytes:
     type: integer
+    minimum: 0
     examples: [2048]
   maxItems:
     type: integer
+    minimum: 1
     examples: [1000]
   maxTotalChargeUsd:
     type: number
+    minimum: 0
     examples: [5]

--- a/apify-api/openapi/components/schemas/actor-runs/RunStats.yaml
+++ b/apify-api/openapi/components/schemas/actor-runs/RunStats.yaml
@@ -7,27 +7,35 @@ type: object
 properties:
   inputBodyLen:
     type: integer
+    minimum: 0
     examples: [240]
   migrationCount:
     type: integer
+    minimum: 0
     examples: [0]
   rebootCount:
     type: integer
+    minimum: 0
     examples: [0]
   restartCount:
     type: integer
+    minimum: 0
     examples: [0]
   resurrectCount:
     type: integer
+    minimum: 0
     examples: [2]
   memAvgBytes:
     type: number
+    minimum: 0
     examples: [267874071.9]
   memMaxBytes:
     type: integer
+    minimum: 0
     examples: [404713472]
   memCurrentBytes:
     type: integer
+    minimum: 0
     examples: [0]
   cpuAvgUsage:
     type: number
@@ -40,19 +48,25 @@ properties:
     examples: [0]
   netRxBytes:
     type: integer
+    minimum: 0
     examples: [103508042]
   netTxBytes:
     type: integer
+    minimum: 0
     examples: [4854600]
   durationMillis:
     type: integer
+    minimum: 0
     examples: [248472]
   runTimeSecs:
     type: number
+    minimum: 0
     examples: [248.472]
   metamorph:
     type: integer
+    minimum: 0
     examples: [0]
   computeUnits:
     type: number
+    minimum: 0
     examples: [0.13804]

--- a/apify-api/openapi/components/schemas/actor-tasks/Task.yaml
+++ b/apify-api/openapi/components/schemas/actor-tasks/Task.yaml
@@ -48,3 +48,4 @@ properties:
       - type: "null"
   standbyUrl:
     type: [string, "null"]
+    format: uri

--- a/apify-api/openapi/components/schemas/actors/SourceCodeFile.yaml
+++ b/apify-api/openapi/components/schemas/actors/SourceCodeFile.yaml
@@ -6,11 +6,7 @@ required:
   - name
 properties:
   format:
-    type: string
-    enum:
-      - BASE64
-      - TEXT
-    examples: [TEXT]
+    $ref: ../common/SourceCodeFileFormat.yaml
   content:
     type: string
     examples: ["console.log('This is the main.js file');"]

--- a/apify-api/openapi/components/schemas/common/HttpMethod.yaml
+++ b/apify-api/openapi/components/schemas/common/HttpMethod.yaml
@@ -1,0 +1,12 @@
+type: string
+enum:
+  - GET
+  - HEAD
+  - POST
+  - PUT
+  - DELETE
+  - CONNECT
+  - OPTIONS
+  - TRACE
+  - PATCH
+examples: [GET]

--- a/apify-api/openapi/components/schemas/common/PaginationResponse.yaml
+++ b/apify-api/openapi/components/schemas/common/PaginationResponse.yaml
@@ -11,14 +11,17 @@ properties:
   total:
     type: integer
     description: The total number of items available across all pages.
+    minimum: 0
     examples: [2]
   offset:
     type: integer
     description: The starting position for this page of results.
+    minimum: 0
     examples: [0]
   limit:
     type: integer
     description: The maximum number of items returned per page.
+    minimum: 1
     examples: [1000]
   desc:
     type: boolean
@@ -27,4 +30,5 @@ properties:
   count:
     type: integer
     description: The number of items returned in this response.
+    minimum: 0
     examples: [2]

--- a/apify-api/openapi/components/schemas/common/SourceCodeFileFormat.yaml
+++ b/apify-api/openapi/components/schemas/common/SourceCodeFileFormat.yaml
@@ -1,0 +1,5 @@
+type: string
+enum:
+  - BASE64
+  - TEXT
+examples: [TEXT]

--- a/apify-api/openapi/components/schemas/datasets/Dataset.yaml
+++ b/apify-api/openapi/components/schemas/datasets/Dataset.yaml
@@ -33,9 +33,11 @@ properties:
     examples: ["2019-12-14T08:36:13.202Z"]
   itemCount:
     type: integer
+    minimum: 0
     examples: [7]
   cleanItemCount:
     type: integer
+    minimum: 0
     examples: [5]
   actId:
     type: [string, "null"]
@@ -66,9 +68,11 @@ properties:
                 format: link
   consoleUrl:
     type: string
+    format: uri
     examples: ["https://console.apify.com/storage/datasets/27TmTznX9YPeAYhkC"]
   itemsPublicUrl:
     type: string
+    format: uri
     description: A public link to access the dataset items directly.
     examples: ["https://api.apify.com/v2/datasets/WkzbQMuFYuamGv3YF/items?signature=abc123"]
   urlSigningSecretKey:

--- a/apify-api/openapi/components/schemas/key-value-stores/KeyValueStore.yaml
+++ b/apify-api/openapi/components/schemas/key-value-stores/KeyValueStore.yaml
@@ -40,9 +40,11 @@ properties:
     examples: [null]
   consoleUrl:
     type: string
+    format: uri
     examples: ["https://console.apify.com/storage/key-value-stores/27TmTznX9YPeAYhkC"]
   keysPublicUrl:
     type: string
+    format: uri
     description: A public link to access keys of the key-value store directly.
     examples: ["https://api.apify.com/v2/key-value-stores/WkzbQMuFYuamGv3YF/keys?signature=abc123"]
   urlSigningSecretKey:

--- a/apify-api/openapi/components/schemas/key-value-stores/KeyValueStoreKey.yaml
+++ b/apify-api/openapi/components/schemas/key-value-stores/KeyValueStoreKey.yaml
@@ -13,5 +13,6 @@ properties:
     examples: [36]
   recordPublicUrl:
     type: string
+    format: uri
     description: A public link to access this record directly.
     examples: ["https://api.apify.com/v2/key-value-stores/WkzbQMuFYuamGv3YF/records/some-key?signature=abc123"]

--- a/apify-api/openapi/components/schemas/request-queues/HeadRequest.yaml
+++ b/apify-api/openapi/components/schemas/request-queues/HeadRequest.yaml
@@ -16,6 +16,7 @@ properties:
     examples: [GET|60d83e70|e3b0c442|https://apify.com]
   url:
     type: string
+    format: uri
     description: The URL of the request.
     examples: [https://apify.com]
   method:

--- a/apify-api/openapi/components/schemas/request-queues/LockedHeadRequest.yaml
+++ b/apify-api/openapi/components/schemas/request-queues/LockedHeadRequest.yaml
@@ -17,6 +17,7 @@ properties:
     examples: [GET|60d83e70|e3b0c442|https://apify.com]
   url:
     type: string
+    format: uri
     description: The URL of the request.
     examples: [https://apify.com]
   method:

--- a/apify-api/openapi/components/schemas/request-queues/Request.yaml
+++ b/apify-api/openapi/components/schemas/request-queues/Request.yaml
@@ -16,6 +16,7 @@ properties:
     examples: [GET|60d83e70|e3b0c442|https://apify.com/career]
   url:
     type: string
+    format: uri
     description: The URL of the request.
     examples: [https://apify.com/career]
   method:
@@ -28,6 +29,7 @@ properties:
     examples: [0]
   loadedUrl:
     type: [string, "null"]
+    format: uri
     description: The final URL that was loaded, after redirects (if any).
     examples: [https://apify.com/jobs]
   payload:

--- a/apify-api/openapi/components/schemas/request-queues/RequestDraft.yaml
+++ b/apify-api/openapi/components/schemas/request-queues/RequestDraft.yaml
@@ -12,6 +12,7 @@ properties:
     examples: [GET|60d83e70|e3b0c442|https://apify.com]
   url:
     type: string
+    format: uri
     description: The URL of the request.
     examples: [https://apify.com]
   method:

--- a/apify-api/openapi/components/schemas/request-queues/RequestQueue.yaml
+++ b/apify-api/openapi/components/schemas/request-queues/RequestQueue.yaml
@@ -43,14 +43,17 @@ properties:
   totalRequestCount:
     type: integer
     description: The total number of requests in the request queue.
+    minimum: 0
     examples: [870]
   handledRequestCount:
     type: integer
     description: The number of requests that have been handled.
+    minimum: 0
     examples: [100]
   pendingRequestCount:
     type: integer
     description: The number of requests that are pending and have not been handled yet.
+    minimum: 0
     examples: [670]
   hadMultipleClients:
     type: boolean
@@ -59,6 +62,7 @@ properties:
   consoleUrl:
     type: string
     description: The URL to view the request queue in the Apify console.
+    format: uri
     examples: [https://api.apify.com/v2/request-queues/27TmTznX9YPeAYhkC]
   stats:
     $ref: ./RequestQueueStats.yaml

--- a/apify-api/openapi/components/schemas/request-queues/RequestUserData.yaml
+++ b/apify-api/openapi/components/schemas/request-queues/RequestUserData.yaml
@@ -9,5 +9,6 @@ properties:
     examples: [DETAIL]
   image:
     type: [string, "null"]
+    format: uri
     description: Optional image URL associated with the request.
     examples: [https://picserver1.eu]

--- a/apify-api/openapi/components/schemas/store/StoreListActor.yaml
+++ b/apify-api/openapi/components/schemas/store/StoreListActor.yaml
@@ -39,12 +39,15 @@ properties:
     type: string
   pictureUrl:
     type: [string, "null"]
+    format: uri
     examples: ["https://..."]
   userPictureUrl:
     type: [string, "null"]
+    format: uri
     examples: ["https://..."]
   url:
     type: [string, "null"]
+    format: uri
     examples: ["https://..."]
   stats:
     $ref: ../actors/ActorStats.yaml

--- a/apify-api/openapi/components/schemas/users/Profile.yaml
+++ b/apify-api/openapi/components/schemas/users/Profile.yaml
@@ -9,12 +9,14 @@ properties:
     examples: [Jane Doe]
   pictureUrl:
     type: string
+    format: uri
     examples: [/img/anonymous_user_picture.png]
   githubUsername:
     type: string
     examples: [torvalds.]
   websiteUrl:
     type: string
+    format: uri
     examples: ["http://www.example.com"]
   twitterUsername:
     type: string

--- a/apify-api/openapi/components/schemas/users/UserPrivateInfo.yaml
+++ b/apify-api/openapi/components/schemas/users/UserPrivateInfo.yaml
@@ -21,6 +21,7 @@ properties:
     $ref: ./Profile.yaml
   email:
     type: string
+    format: email
     examples: [bob@example.com]
   proxy:
     $ref: ./Proxy.yaml

--- a/apify-api/openapi/components/schemas/webhooks/Webhook.yaml
+++ b/apify-api/openapi/components/schemas/webhooks/Webhook.yaml
@@ -45,6 +45,7 @@ properties:
     examples: [false]
   requestUrl:
     type: string
+    format: uri
     examples: ["http://example.com/"]
   payloadTemplate:
     type: [string, "null"]

--- a/apify-api/openapi/components/schemas/webhooks/WebhookCreate.yaml
+++ b/apify-api/openapi/components/schemas/webhooks/WebhookCreate.yaml
@@ -26,6 +26,7 @@ properties:
     examples: [false]
   requestUrl:
     type: string
+    format: uri
     examples: ["http://example.com/"]
   payloadTemplate:
     type: [string, "null"]

--- a/apify-api/openapi/components/schemas/webhooks/WebhookShort.yaml
+++ b/apify-api/openapi/components/schemas/webhooks/WebhookShort.yaml
@@ -46,6 +46,7 @@ properties:
     examples: [false]
   requestUrl:
     type: string
+    format: uri
     examples: ["http://example.com/"]
   lastDispatch:
     anyOf:

--- a/apify-api/openapi/components/schemas/webhooks/WebhookUpdate.yaml
+++ b/apify-api/openapi/components/schemas/webhooks/WebhookUpdate.yaml
@@ -22,6 +22,7 @@ properties:
     examples: [false]
   requestUrl:
     type: [string, "null"]
+    format: uri
     examples: ["http://example.com/"]
   payloadTemplate:
     type: [string, "null"]


### PR DESCRIPTION
### Issue

- Relates #2182

### Description

- Add `format` specifications for URI, email, and IP address fields.
- Add `minimum`/`maximum` constraints for numeric fields (counts, memory limits, timeouts).
- Extract reusable enum schemas for `HttpMethod` and `SourceCodeFileFormat`.

### Tests

- [x] CI passes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Strengthens schema validation and centralizes common enums.
> 
> - Adds `format` constraints (e.g., `uri`, `email`, `ipv4`) to many string fields across `datasets`, `key-value-stores`, `request-queues`, `webhooks`, `users`, `actor-runs`, and `actor-tasks` (e.g., `containerUrl`, `consoleUrl`, `itemsPublicUrl`, `requestUrl`, `loadedUrl`)
> - Adds numeric `minimum`/`maximum` constraints to counts and resource settings (e.g., `RunOptions` memory/disk/timeout, `RunStats` metrics, pagination/count fields)
> - Introduces common enums `common/HttpMethod.yaml` and `common/SourceCodeFileFormat.yaml`; updates `actors/SourceCodeFile.yaml` to reference the new `SourceCodeFileFormat` schema
> - Minor: marks `servers[].url` in `GetOpenApiResponse` as `uri` and adds `format` to assorted URL fields throughout
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ce5b3c0ff340fe972d8b2d342aef2c9a025bef21. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->