### PR TITLE
docs: Enhance output schema template property documentation

### DIFF
--- a/sources/platform/actors/development/actor_definition/output_schema/index.md
+++ b/sources/platform/actors/development/actor_definition/output_schema/index.md
@@ -97,7 +97,7 @@ Templates allow you to dynamically generate URLs that point to your Actor's outp
 1. Replacing `{{variable}}` placeholders with actual runtime values
 1. Creating the final output URL from the interpolated template
 
-The generated URL then appears in the **Output** tab of the Apify Console and in the `output` property of the API response.
+The generated URL then appears in the **Output** tab of Apify Console and in the `output` property of the API response.
 
 ### Template syntax
 


### PR DESCRIPTION
## Summary

- Enhanced the `template` property description in the output schema documentation
- Added a new "Understanding templates" section that explains how templates work
- Improved documentation flow from definitions → variables → understanding → examples

## Changes

### 1. Enhanced Property Description
Updated the `template` property description in the "Output object definition" table to include:
- Clear explanation of what templates do (generate output links)
- Mention of Mustache-style `{{variable}}` syntax
- Where generated URLs appear (Console Output tab and API response)

### 2. New "Understanding Templates" Section
Added a comprehensive section between "Available template variables" and "Examples" that covers:
- How the Apify platform processes templates (variable interpolation, URL generation, display)
- Template syntax with concrete examples showing before/after transformations
- Where templates appear (Apify Console and API Response)
- Smooth transition to the examples section

## Context

Addresses feedback from GitHub issue #2165 where users requested better explanation of the `template` property.

The enhancement maintains brevity while providing essential information that helps users understand template mechanics before seeing practical examples.

## Related

- Issue: #2165

## Test Plan

- [x] Build documentation locally to verify no syntax errors
- [x] Verify markdown rendering displays correctly
- [x] Confirm logical flow: Definitions → Variables → Understanding → Examples
- [x] Check that all code examples remain valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves the output schema docs to better explain how URL templates work.
> 
> - Updates `template` property description to note Mustache `{{variable}}` syntax and where generated URLs surface (Console Output tab and API `output`)
> - Adds **Understanding templates** section covering interpolation, URL generation, display, and basic examples
> - Refines doc flow from definitions → variables → understanding → examples in `sources/platform/actors/development/actor_definition/output_schema/index.md`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b6ce3ddd0d2f359d1412515a52f0dd5a617fdeef. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->