### PR TITLE
fix: Correct Python SDK getting started link

### DIFF
--- a/src/pages/sdk/index.tsx
+++ b/src/pages/sdk/index.tsx
@@ -83,7 +83,7 @@ export default function Home() {
                             exampleCodeSnippet={pythonExample}
                             language="Python"
                             githubRepoUrl="https://github.com/apify/apify-sdk-python"
-                            gettingStartedUrl="https://docs.apify.com/sdk/python/docs/overview/introduction"
+                            gettingStartedUrl="https://docs.apify.com/sdk/python/docs/overview"
                             referenceUrl="https://docs.apify.com/sdk/python/reference"
                         />
                     </StyledContent>


### PR DESCRIPTION
The "Get started" button for the Python SDK was pointing to /sdk/python/docs/overview/introduction which returns a 404. Changed it to /sdk/python/docs/overview which is the correct URL.

Slack thread: https://apify.slack.com/archives/C0L33UM7Z/p1769028437382859

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes broken "Getting started" link for the Python SDK.
> 
> - Updates `gettingStartedUrl` in `src/pages/sdk/index.tsx` for the Python SDK `SdkSection` from `/sdk/python/docs/overview/introduction` (404) to `/sdk/python/docs/overview`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0c9cf3928d3379fb6a66f5f132f9542d9838cd56. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->