### PR TITLE
chore: remove 1M challenge promotion banner from homepage

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -64,11 +64,6 @@ export default function Home() {
             <Hero
                 heading="Apify Documentation"
                 align="center"
-                promotion={{
-                    badge: 'Build',
-                    label: 'Win big in $1M Challenge',
-                    href: 'https://apify.com/challenge',
-                }}
                 description={
                     <Text color={theme.color.neutral.textMuted} size="large">
                         Learn how to put the web to work with Apify.


### PR DESCRIPTION
Remove the $1M challenge promotion banner from homepage
Will be merged on Monday 1.2.2026 after the challenge ends.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes the $1M Challenge promotion from the homepage hero.
> 
> - Deletes the `promotion` prop (badge/label/link) from `Hero` in `src/pages/index.tsx`; no other content or layout changes
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 24f80590c2e4defb72488af20ecf3135e68624f4. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->