### PR TITLE
chore(api): add the new 'ownership' parameter for listing storages

### DIFF
--- a/apify-api/openapi/components/schemas/common/StorageOwnership.yaml
+++ b/apify-api/openapi/components/schemas/common/StorageOwnership.yaml
@@ -1,0 +1,5 @@
+type: string
+enum:
+  - ownedByMe
+  - sharedWithMe
+examples: [ownedByMe]

--- a/apify-api/openapi/paths/datasets/datasets.yaml
+++ b/apify-api/openapi/paths/datasets/datasets.yaml
@@ -57,18 +57,14 @@ get:
     - name: ownership
       in: query
       description: |
-        Filter by ownership. By default, all accessible datasets are returned.
+        Filter by ownership. If this parameter is omitted, all accessible datasets are returned.
 
         - `ownedByMe`: Return only datasets owned by the user.
         - `sharedWithMe`: Return only datasets shared with the user by other users.
       style: form
       explode: true
       schema:
-        type: string
-        enum:
-          - ownedByMe
-          - sharedWithMe
-        example: ownedByMe
+        $ref: ../../components/schemas/common/StorageOwnership.yaml
   responses:
     "200":
       description: ""

--- a/apify-api/openapi/paths/key-value-stores/key-value-stores.yaml
+++ b/apify-api/openapi/paths/key-value-stores/key-value-stores.yaml
@@ -62,18 +62,14 @@ get:
     - name: ownership
       in: query
       description: |
-        Filter by ownership. By default, all accessible key-value stores are returned.
+        Filter by ownership. If this parameter is omitted, all accessible key-value stores are returned.
 
         - `ownedByMe`: Return only key-value stores owned by the user.
         - `sharedWithMe`: Return only key-value stores shared with the user by other users.
       style: form
       explode: true
       schema:
-        type: string
-        enum:
-          - ownedByMe
-          - sharedWithMe
-        example: ownedByMe
+        $ref: ../../components/schemas/common/StorageOwnership.yaml
   responses:
     "200":
       description: ""

--- a/apify-api/openapi/paths/request-queues/request-queues.yaml
+++ b/apify-api/openapi/paths/request-queues/request-queues.yaml
@@ -60,18 +60,14 @@ get:
     - name: ownership
       in: query
       description: |
-        Filter by ownership. By default, all accessible request queues are returned.
+        Filter by ownership. If this parameter is omitted, all accessible request queues are returned.
 
         - `ownedByMe`: Return only request queues owned by the user.
         - `sharedWithMe`: Return only request queues shared with the user by other users.
       style: form
       explode: true
       schema:
-        type: string
-        enum:
-          - ownedByMe
-          - sharedWithMe
-        example: ownedByMe
+        $ref: ../../components/schemas/common/StorageOwnership.yaml
   responses:
     "200":
       description: ""


### PR DESCRIPTION
Document the new 'ownership' parameter in the listing requests for storages.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Documents a new optional `ownership` query parameter for storage listing endpoints to filter by resource ownership.
> 
> - Adds `ownership` to `GET` listings for datasets, key-value stores, and request queues (`datasets.yaml`, `key-value-stores.yaml`, `request-queues.yaml`)
> - Accepts `ownedByMe` or `sharedWithMe`; default remains all accessible resources
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ee02f2e732419b607a8d00567d7c9eb0b4172bd5. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->