### PR TITLE
fix(ci): update Python docs workflow filename

### DIFF
--- a/.github/workflows/publish-to-npm.yaml
+++ b/.github/workflows/publish-to-npm.yaml
@@ -132,4 +132,4 @@ jobs:
             -   env:
                     GITHUB_TOKEN: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}
                 run: |
-                    gh workflow run build_and_deploy_docs.yaml --repo ${{ matrix.repo }}
+                    gh workflow run _release_docs.yaml --repo ${{ matrix.repo }}


### PR DESCRIPTION
## Summary
- Updates the workflow dispatch target for Python repos from `build_and_deploy_docs.yaml` to `_release_docs.yaml`
- The Python SDK and client repos renamed their docs deployment workflow

## Test plan
- [ ] Verify the workflow runs successfully after a theme publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small CI-only change that just updates a referenced workflow filename; failure mode is limited to Python docs rebuilds not triggering.
> 
> **Overview**
> After publishing `@apify/docs-theme`, the CI job that triggers docs rebuilds for `apify-sdk-python` and `apify-client-python` now dispatches `_release_docs.yaml` instead of `build_and_deploy_docs.yaml` via `gh workflow run`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 296763b89ac8ef646ea6d2f467121842aef86997. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->