### PR TITLE
fix: resolve fast-xml-parser, lodash security vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -65,7 +65,7 @@
         },
         "apify-docs-theme": {
             "name": "@apify/docs-theme",
-            "version": "1.0.230",
+            "version": "1.0.231",
             "license": "ISC",
             "dependencies": {
                 "@apify/docs-search-modal": "^1.3.3",
@@ -20290,9 +20290,9 @@
             "license": "MIT"
         },
         "node_modules/lodash-es": {
-            "version": "4.17.22",
-            "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.22.tgz",
-            "integrity": "sha512-XEawp1t0gxSi9x01glktRZ5HDy0HXqrM0x5pXQM98EaI0NxO6jVM7omDOxsuEo5UIASAnm2bRp1Jt/e0a2XU8Q==",
+            "version": "4.17.23",
+            "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.23.tgz",
+            "integrity": "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==",
             "license": "MIT"
         },
         "node_modules/lodash.debounce": {

--- a/package.json
+++ b/package.json
@@ -116,6 +116,7 @@
     "overrides": {
         "openapi-to-postmanv2": {
             "js-yaml": "4.1.1"
-        }
+        },
+        "fast-xml-parser": "5.3.4"
     }
 }


### PR DESCRIPTION
## Summary
- Adds npm overrides to fix high-severity fast-xml-parser vulnerability (GHSA-37qj-frw5-hhjh)
- Adds npm overrides to fix medium-severity lodash/lodash-es vulnerabilities (GHSA-xxjr-mmjv-4gpg)
- Resolves Dependabot alert #142

## Test plan
- [x] `npm audit` shows 0 vulnerabilities
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Forces upgraded transitive dependencies (including `fast-xml-parser` 4→5) via npm overrides, which could introduce subtle runtime/build incompatibilities despite being security-driven.
> 
> **Overview**
> Pins security-patched dependency versions via `package.json` `overrides`, forcing `fast-xml-parser@5.3.4`, `lodash@4.17.23`, and `lodash-es@4.17.23`.
> 
> Updates `package-lock.json` to reflect the forced resolutions (including `strnum` bump and removal of redundant nested `lodash-es` entries) and bumps the workspace `@apify/docs-theme` from `1.0.230` to `1.0.231`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit de325482e534c5173a114a1007817f6578d87e70. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->