### PR TITLE
docs: fix grammatical error in residential proxy documentation

### DIFF
--- a/sources/platform/proxy/residential_proxy.md
+++ b/sources/platform/proxy/residential_proxy.md
@@ -129,7 +129,7 @@ This IP/session ID combination is persisted for 1 minute. Each subsequent reques
 If the proxy server becomes unresponsive or the session expires, a new IP address is selected for the next request.
 
 > If you really need to persist the same session, you can try sending some data using that session (e.g. every 20 seconds) to keep it alive.<br/>
-> Providing the connection is not interrupted, this will let you keep the IP address for longer.
+> Provided the connection is not interrupted, this will let you keep the IP address for longer.
 
 To learn more about [sessions](./usage.md#sessions) and [IP address rotation](./usage.md#ip-address-rotation), see the proxy [overview page](./index.md).
 


### PR DESCRIPTION
Fixes #1950

## Changes

Fixed grammatical error in the session persistence tip on the residential proxy page.

**Before**: "Providing the connection is not interrupted..."  
**After**: "Provided the connection is not interrupted..."

## Why

The conditional clause requires the past participle form "Provided" rather than the present participle "Providing" for correct grammar.

## Testing

- [x] Grammar is now correct
- [x] Meaning is preserved
- [x] Follows documentation style guide

---

🤖 Generated with Claude Code

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only wording change with no impact on runtime behavior or APIs.
> 
> **Overview**
> Fixes a small grammar issue in `residential_proxy.md` by changing the session persistence tip from “Providing the connection is not interrupted…” to “Provided the connection is not interrupted…”, preserving meaning while improving correctness.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e5d637629979b2f843af8e3eeda4a4e91b2e35bd. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->