### PR TITLE
docs: document authentication token requirement for usage fields

### DIFF
--- a/apify-api/openapi/components/schemas/actor-builds/Build.yaml
+++ b/apify-api/openapi/components/schemas/actor-builds/Build.yaml
@@ -45,7 +45,11 @@ properties:
   usageTotalUsd:
     type: [number, "null"]
     examples: [0.02]
+    description: >-
+      Total cost in USD for this build. Requires authentication token to access.
   usageUsd:
+    description: >-
+      Platform usage costs breakdown in USD for this build. Requires authentication token to access.
     anyOf:
       - $ref: ./BuildUsage.yaml
       - type: "null"

--- a/apify-api/openapi/components/schemas/actor-runs/Run.yaml
+++ b/apify-api/openapi/components/schemas/actor-runs/Run.yaml
@@ -127,11 +127,13 @@ properties:
       For run owners: includes platform usage (compute units) and/or event costs depending on the Actor's pricing model.
       For run non-owners: only available for Pay-Per-Event Actors (event costs only).
       Not available for Pay-Per-Result Actors when you're not the Actor owner.
+      Requires authentication token to access.
   usageUsd:
     description: >-
       Platform usage costs breakdown in USD. Only present if you own the run AND are paying for platform usage
       (Pay-Per-Usage, Rental, or Pay-Per-Event with usage costs like standby Actors).
       Not available for standard Pay-Per-Event Actors or Pay-Per-Result Actors owned by others.
+      Requires authentication token to access.
     anyOf:
       - $ref: ./RunUsageUsd.yaml
       - type: "null"

--- a/apify-api/openapi/components/schemas/actor-runs/Run.yaml
+++ b/apify-api/openapi/components/schemas/actor-runs/Run.yaml
@@ -126,13 +126,12 @@ properties:
       Total cost in USD for this run. Represents what you actually pay.
       For run owners: includes platform usage (compute units) and/or event costs depending on the Actor's pricing model.
       For run non-owners: only available for Pay-Per-Event Actors (event costs only).
-      Not available for Pay-Per-Result Actors when you're not the Actor owner.
       Requires authentication token to access.
   usageUsd:
     description: >-
       Platform usage costs breakdown in USD. Only present if you own the run AND are paying for platform usage
       (Pay-Per-Usage, Rental, or Pay-Per-Event with usage costs like standby Actors).
-      Not available for standard Pay-Per-Event Actors or Pay-Per-Result Actors owned by others.
+      Not available for standard Pay-Per-Event Actors.
       Requires authentication token to access.
     anyOf:
       - $ref: ./RunUsageUsd.yaml


### PR DESCRIPTION
Fixes #1145

## Changes

Added documentation that authentication token is required to access `usageTotalUsd` and `usageUsd` fields.

### Fields updated:

**In Run schema** (`apify-api/openapi/components/schemas/actor-runs/Run.yaml`):
- `usageTotalUsd`: Added "Requires authentication token to access."
- `usageUsd`: Added "Requires authentication token to access."

**In Build schema** (`apify-api/openapi/components/schemas/actor-builds/Build.yaml`):
- `usageTotalUsd`: Added description with token requirement
- `usageUsd`: Added description with token requirement

## Why

These fields contain sensitive cost information and require authentication to access via the API. This was not previously documented, causing confusion for API users.

## Testing

- [x] OpenAPI schemas updated with clear token requirement notes
- [x] Descriptions follow existing documentation style
- [x] Both Run and Build schemas updated for consistency

---

🤖 Generated with Claude Code

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because it only changes OpenAPI documentation strings and does not affect runtime behavior or API responses.
> 
> **Overview**
> Updates the OpenAPI schemas for Actor `Run` and `Build` to explicitly document that cost-related fields `usageTotalUsd` and `usageUsd` require an authentication token to access.
> 
> This is a documentation-only change to schema field descriptions to reduce confusion around missing/unauthorized cost data.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c12859052b72eda301819ec37150458ceab135f9. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->