### PR TITLE
docs: add PR title format requirements to Claude instructions

### DIFF
--- a/.claude/instructions.md
+++ b/.claude/instructions.md
@@ -129,6 +129,31 @@ See the `/api-doc` skill for comprehensive OpenAPI specification standards, oper
 4. Check all links are valid
 5. Ensure front matter is complete
 
+### Creating pull requests
+
+When creating PRs for this repository, follow these requirements:
+
+**PR Title Format**: Use [Conventional Commits](https://www.conventionalcommits.org/) format:
+
+- `docs: <description>` - Documentation changes (most common)
+- `fix: <description>` - Bug fixes
+- `feat: <description>` - New features
+- `chore: <description>` - Maintenance tasks
+- `refactor: <description>` - Code refactoring
+- `test: <description>` - Test updates
+
+**Examples**:
+
+- ✅ `docs: fix grammatical error in residential proxy documentation`
+- ✅ `docs: add missing actor.json properties`
+- ✅ `fix: correct data retention period in storage docs`
+- ❌ `Fix grammatical error` (missing type prefix)
+- ❌ `Documentation Update` (wrong format)
+
+**Enforcement**: PR titles are validated by GitHub Actions. PRs with incorrect titles will fail CI checks.
+
+**Reference**: See `CONTRIBUTING.md` and `.github/workflows/check-pr-title.yaml`
+
 ### Testing changes
 
 ```bash


### PR DESCRIPTION
## Summary

Adds PR title format documentation to `.claude/instructions.md` to prevent AI agents from creating PRs with incorrect titles that fail CI checks.

## Problem

PR title format requirements were:
- ✅ Documented in `CONTRIBUTING.md:350` (link only, no examples)
- ✅ Enforced by `.github/workflows/check-pr-title.yaml`
- ❌ **Missing from `.claude/instructions.md`** (where AI looks first)

This caused all 4 Phase 1 PRs (#2216, #2217, #2218, #2219) to initially fail CI checks and require manual title corrections.

## Solution

Added new "Creating pull requests" section in `.claude/instructions.md` with:

- **Format requirements**: Conventional Commits (`docs:`, `fix:`, `feat:`, etc.)
- **Clear examples**: Both correct (✅) and incorrect (❌) formats
- **Enforcement notice**: GitHub Actions validation
- **References**: Links to `CONTRIBUTING.md` and workflow file

## Location

Added after line 130 in the "Before submitting" section to keep all pre-submission requirements together.

## Benefits

1. **Prevents errors**: AI agents know correct format upfront
2. **Faster workflow**: No manual fixes needed after PR creation
3. **Self-documenting**: Instructions where AI looks first
4. **Consistent**: Aligns with other pre-submission checks

## Testing

- [x] Section added to correct location
- [x] Markdown formatting correct (no linting errors)
- [x] Examples are clear and actionable
- [x] Consistent with existing documentation style

---

🤖 Generated with Claude Code

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no code or workflow logic modifications; risk is limited to potential confusion if the guidance is inaccurate.
> 
> **Overview**
> Adds a new **“Creating pull requests”** section to `.claude/instructions.md` that documents the required **Conventional Commits** PR title format, with accepted type prefixes, good/bad examples, and a note that CI enforces this via the PR title check workflow (with references to `CONTRIBUTING.md` and `.github/workflows/check-pr-title.yaml`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c816d2455193d11ac8d98d9bba1eeb4353ebf7b0. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->