### PR TITLE
chore: check typos only on changed files in PRs

### DIFF
--- a/.github/workflows/spell-check.yaml
+++ b/.github/workflows/spell-check.yaml
@@ -11,7 +11,19 @@ jobs:
         name: Spell check
         runs-on: ubuntu-latest
         steps:
-            - name: Checkout repository
-              uses: actions/checkout@v6
-            - name: Check spelling with typos
-              uses: crate-ci/typos@v1.43.0
+            -   name: Checkout repository
+                uses: actions/checkout@v6
+                with:
+                    fetch-depth: 0
+
+            -   name: Get changed files
+                id: changed-files
+                uses: tj-actions/changed-files@v47
+                with:
+                    separator: ' '
+
+            -   name: Check spelling with typos
+                if: steps.changed-files.outputs.any_changed == 'true'
+                uses: crate-ci/typos@v1.43.0
+                with:
+                    files: ${{ steps.changed-files.outputs.all_changed_files }}


### PR DESCRIPTION
I've added a step to check only changed files since it has been failing PR's that were not connected to the failed check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow change; risk is limited to possibly missing typos outside the changed file set or mis-detecting changed files due to checkout/diff configuration.
> 
> **Overview**
> Updates the GitHub Actions `Spell check` workflow to run `typos` only against files changed in the PR/push, avoiding failures from unrelated existing typos.
> 
> This adds `tj-actions/changed-files` and configures `actions/checkout` with `fetch-depth: 0`, then gates the `typos` step on `any_changed` and passes `all_changed_files` to the action.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 38e51bff899e983981d22949f6a70a54c996ac32. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->