### PR TITLE
fix(nginx): add general redirect to remove trailing slashes

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -37,7 +37,7 @@ server {
     # remove trailing slashes from all URLs (except root /)
     # exact match locations (e.g., location = /sdk/js/) take priority over this regex
     location ~ "^(.+)/$" {
-        return 302 $1$is_args$args;
+        return 301 $1$is_args$args;
     }
 
     location / {


### PR DESCRIPTION
Adds a location block to remove trailing slashes from all URLs (except root /). This fixes the 404 error when accessing URLs like /api/v2/ with a trailing slash.

Uses a regex location block instead of a rewrite rule for clearer processing precedence. Exact match locations (e.g., location = /sdk/js/) take priority over this regex, so existing handlers are unaffected.

Slack thread: https://apify.slack.com/archives/C0L33UM7Z/p1770281199186039

https://claude.ai/code/session_01GqcrG6JU9Y1YaSA5ns87Yz

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Simple Nginx routing change; main risk is unexpected redirects for endpoints that intentionally rely on trailing slashes.
> 
> **Overview**
> Adds a global Nginx `location` regex that **redirects any non-root URL ending in `/` to the same path without the trailing slash**.
> 
> This prevents 404s for requests like `/api/v2/` while keeping explicit exact-match locations (e.g., `location = /sdk/js/`) higher priority than the new catch-all redirect.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 99d352ceaf5d8ce1e435e1011b97c2526052d310. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->