### PR TITLE
fix(nginx): use rewrite instead of return for trailing slash redirect

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -36,8 +36,8 @@ server {
 
     # remove trailing slashes from all URLs (except root /)
     # exact match locations (e.g., location = /sdk/js/) take priority over this regex
-    location ~ "^(.+)/$" {
-        return 301 $1$is_args$args;
+    location ~ ^(.+)/$ {
+        rewrite ^(.+)/$ $1$is_args$args? redirect;
     }
 
     location / {


### PR DESCRIPTION
Changes the trailing slash redirect from using `return` with location regex to using `rewrite` directive inside the location block. Also removes quotes from the regex pattern to match the style of other regex locations in the config.

This should fix the issue where the previous approach wasn't working.

Slack thread: https://apify.slack.com/archives/C0L33UM7Z/p1770281199186039

https://claude.ai/code/session_01GqcrG6JU9Y1YaSA5ns87Yz