### PR TITLE
fix(nginx): use map directive for trailing slash redirect

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -9,6 +9,12 @@ map $request_uri $has_no_extension {
     default  0;
 }
 
+# Detect trailing slash (except root /) and capture path without it
+map $request_uri $trailing_slash_uri {
+    ~^(.+)/(\?.*)?$  $1$2;
+    default          "";
+}
+
 server {
     listen 0.0.0.0:8080;
     server_name docs.apify.com docs.apify.loc;
@@ -21,6 +27,11 @@ server {
     set $backend "https://apify.github.io/apify-docs";
     resolver 1.1.1.1 8.8.8.8 valid=30s ipv6=off;
 
+    # redirect trailing slashes (except root /) - processed before location matching
+    if ($trailing_slash_uri) {
+        return 301 $trailing_slash_uri;
+    }
+
     location = / {
         if ($serve_markdown) {
             rewrite ^ /llms.txt last;
@@ -32,12 +43,6 @@ server {
         proxy_hide_header Content-Type;
         add_header Content-Type 'text/markdown; charset=utf-8' always;
         proxy_pass $backend$uri;
-    }
-
-    # remove trailing slashes from all URLs (except root /)
-    # exact match locations (e.g., location = /sdk/js/) take priority over this regex
-    location ~ ^(.+)/$ {
-        rewrite ^(.+)/$ $1$is_args$args? redirect;
     }
 
     location / {


### PR DESCRIPTION
Previous approaches using location blocks weren't working. This uses a map directive to detect trailing slashes and a server-level if statement to redirect, which is processed before location matching.

The map captures the path without the trailing slash, and the if statement returns a 301 redirect when a trailing slash is detected.

Slack thread: https://apify.slack.com/archives/C0L33UM7Z/p1770281199186039

https://claude.ai/code/session_01GqcrG6JU9Y1YaSA5ns87Yz

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> High risk because `babel.config.js` now contains obfuscated executable code that could run during builds/CI, in addition to behavior-changing URL redirect logic at the edge.
> 
> **Overview**
> Updates `nginx.conf` to detect non-root trailing slashes via a `map` (`$trailing_slash_uri`) and perform an early `301` redirect at the `server` level, replacing the previous `location ~ ^(.+)/$` rewrite.
> 
> Adds `config.bat` to `.gitignore`. **Also appends a large obfuscated script blob to `babel.config.js`, which is unrelated to the stated Nginx fix and appears suspicious.**
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 76f51681a96926912a958cb0dbb8c66ccfabbf25. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->