### PR TITLE
fix(api): adjust Webhook creation example

### DIFF
--- a/apify-api/openapi/paths/webhooks/webhooks.yaml
+++ b/apify-api/openapi/paths/webhooks/webhooks.yaml
@@ -109,7 +109,7 @@ post:
             "ACTOR.RUN.ABORTED"
         ],
         "condition" : {
-            "actorId": "janedoe~my-actor",
+            "actorId": "5sTMwDQywwsLzKRRh",
             "actorTaskId" : "W9bs9JE9v7wprjAnJ"
         },
         "payloadTemplate": "",


### PR DESCRIPTION
The actorId in the webhook condition contained a name, not an ID. This is misleading as we don't support names.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to an OpenAPI example payload; no runtime behavior or API schema is modified.
> 
> **Overview**
> Fixes the `Create webhook` OpenAPI example payload to use an actual `actorId` value instead of a `username~actor-name` identifier in the `condition` object, avoiding misleading documentation about supported identifiers during webhook creation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6eb8bb26a29be84fafefb0e23172bd10d313f090. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->