### PR TITLE
fix: broken link to pricing-and-costs section

### DIFF
--- a/sources/platform/actors/publishing/monetize/pay_per_event.mdx
+++ b/sources/platform/actors/publishing/monetize/pay_per_event.mdx
@@ -33,7 +33,7 @@ Your profit is calculated from the mentioned formula:
 where:
 
 - _Revenue_: The amount charged for events via the PPE charging API or through JS/Python SDK. You receive 80% of this revenue.
-- _Platform costs_: The underlying platform usage costs for running the Actor, calculated in the same way as for PPR. For more details, visit the [Computing your costs for PPE and PPR Actors](#computing-your-costs-for-ppe-and-ppr-actors) section.
+- _Platform costs_: The underlying platform usage costs for running the Actor, calculated in the same way as for PPR. For more details, visit the [Computing your costs for PPE and PPR Actors](/platform/actors/publishing/monetize/pricing-and-costs#computing-your-costs-for-ppe-and-ppr-actors) section.
 
 Only revenue and cost for Apify customers on paid plans are taken into consideration when computing your profit. Users on free plans are not reflected there.
 


### PR DESCRIPTION
The link to "Computing your costs for PPE and PPR Actors" was pointing to an anchor on the same page instead of the correct location on the pricing-and-costs page.

Slack thread: https://apify.slack.com/archives/C0L33UM7Z/p1770387965093389?thread_ts=1770373407.055589&cid=C0L33UM7Z

https://claude.ai/code/session_01CUftmTSfK9UmmcoByLE3Yv

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only change that updates a single hyperlink; no functional or runtime impact.
> 
> **Overview**
> Updates the `pay_per_event.mdx` documentation so the “Computing your costs for PPE and PPR Actors” link under *Platform costs* points to the correct `pricing-and-costs#computing-your-costs-for-ppe-and-ppr-actors` section instead of an in-page anchor that didn’t resolve.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4612af6309d6294f28d9a2d9e94301f5dabf8c59. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->