### PR TITLE
docs: add missing title property to webhook API schemas

### DIFF
--- a/apify-api/openapi/components/schemas/webhooks/Webhook.yaml
+++ b/apify-api/openapi/components/schemas/webhooks/Webhook.yaml
@@ -54,6 +54,9 @@ properties:
   headersTemplate:
     type: [string, "null"]
     examples: ['{\n "Authorization": "Bearer ..."}']
+  title:
+    type: [string, "null"]
+    examples: [Actor run succeeded webhook]
   description:
     type: [string, "null"]
     examples: [this is webhook description]

--- a/apify-api/openapi/components/schemas/webhooks/WebhookCreate.yaml
+++ b/apify-api/openapi/components/schemas/webhooks/WebhookCreate.yaml
@@ -35,6 +35,9 @@ properties:
   headersTemplate:
     type: [string, "null"]
     examples: ['{\n "Authorization": "Bearer ..."}']
+  title:
+    type: [string, "null"]
+    examples: [Actor run succeeded webhook]
   description:
     type: [string, "null"]
     examples: [this is webhook description]

--- a/apify-api/openapi/components/schemas/webhooks/WebhookUpdate.yaml
+++ b/apify-api/openapi/components/schemas/webhooks/WebhookUpdate.yaml
@@ -31,6 +31,9 @@ properties:
   headersTemplate:
     type: [string, "null"]
     examples: ['{\n "Authorization": "Bearer ..."}']
+  title:
+    type: [string, "null"]
+    examples: [Actor run succeeded webhook]
   description:
     type: [string, "null"]
     examples: [this is webhook description]


### PR DESCRIPTION
## Summary
- Adds the missing `title` property to `WebhookCreate`, `WebhookUpdate`, and `Webhook` OpenAPI schemas
- The Apify API supports a `title` field on webhooks, but it was not documented in the OpenAPI spec

Closes #2035

## Test plan
- [ ] Verify the OpenAPI spec still validates correctly
- [ ] Check that the webhook create/update/get endpoints show the `title` property in rendered API docs

Generated with [Claude Code](https://claude.com/claude-code)