### PR TITLE
docs: add client-side rendering note to beginner courses

### DIFF
--- a/sources/academy/webscraping/scraping_basics_javascript/04_downloading_html.md
+++ b/sources/academy/webscraping/scraping_basics_javascript/04_downloading_html.md
@@ -126,6 +126,12 @@ $ node index.js
 
 Running `await fetch(url)`, we made a HTTP request and received a response. It's not particularly useful yet, but it's a good start of our scraper.
 
+:::info Client-side rendering
+
+Some websites use JavaScript to render content in the browser. When you download their HTML, you may get an almost empty page, because the data is loaded dynamically. The techniques in this course work for websites that include the data directly in the HTML (server-side rendering). If you encounter a website that loads data with JavaScript, you'll need a browser-based approach. See the [Puppeteer and Playwright course](/academy/puppeteer-playwright) for handling such websites.
+
+:::
+
 :::tip Client and server, request and response
 
 HTTP is a network protocol powering the internet. Understanding it well is an important foundation for successful scraping, but for this course, it's enough to know just the basic flow and terminology:

--- a/sources/academy/webscraping/scraping_basics_python/04_downloading_html.md
+++ b/sources/academy/webscraping/scraping_basics_python/04_downloading_html.md
@@ -83,6 +83,12 @@ $ python main.py
 
 Running `httpx.get(url)`, we made a HTTP request and received a response. It's not particularly useful yet, but it's a good start of our scraper.
 
+:::info Client-side rendering
+
+Some websites use JavaScript to render content in the browser. When you download their HTML, you may get an almost empty page, because the data is loaded dynamically. The techniques in this course work for websites that include the data directly in the HTML (server-side rendering). If you encounter a website that loads data with JavaScript, you'll need a browser-based approach. See the [Puppeteer and Playwright course](/academy/puppeteer-playwright) for handling such websites.
+
+:::
+
 :::tip Client and server, request and response
 
 HTTP is a network protocol powering the internet. Understanding it well is an important foundation for successful scraping, but for this course, it's enough to know just the basic flow and terminology:


### PR DESCRIPTION
## Summary
- Adds an `:::info` admonition to the "Downloading HTML" lesson (lesson 4) in both Python and JavaScript beginner web scraping courses
- Explains that some websites use client-side rendering and the techniques in the course only work for server-rendered pages
- Links to the Puppeteer and Playwright course for handling JavaScript-rendered sites

Closes #1900

## Test plan
- [ ] Verify the admonition renders correctly in both course lessons
- [ ] Verify the link to the Puppeteer and Playwright course works

Generated with [Claude Code](https://claude.com/claude-code)