### PR TITLE
docs: shorten front matter descriptions to SEO-optimal length

### DIFF
--- a/sources/academy/ai/ai-agents.mdx
+++ b/sources/academy/ai/ai-agents.mdx
@@ -1,6 +1,6 @@
 ---
 title: AI agent tutorial
-description: In this section of the Apify Academy, we show you how to build an AI agent with the CrewAI Python framework. You’ll learn how to create an agent for Instagram analysis and integrate it with LLMs and Apify Actors.
+description: Build an AI agent with the CrewAI Python framework. Create an agent for Instagram analysis and learn to integrate it with LLMs and Apify Actors.
 sidebar_label: Build and monetize AI agents
 sidebar_position: 1
 slug: /ai/ai-agents

--- a/sources/academy/build-and-publish/apify-store-basics/actors_and_emojis.md
+++ b/sources/academy/build-and-publish/apify-store-basics/actors_and_emojis.md
@@ -1,6 +1,6 @@
 ---
 title: Actors and emojis
-description: Discover how emojis can boost your Actors by grabbing attention, simplifying navigation, and enhancing clarity. Improve user experience and engagement on Apify Store.
+description: Use emojis in your Actors to grab attention, simplify navigation, and improve clarity. Enhance user experience and engagement on Apify Store.
 sidebar_position: 4
 category: build-and-publish
 slug: /actor-marketing-playbook/actor-basics/actors-and-emojis

--- a/sources/academy/build-and-publish/apify-store-basics/importance_of_actor_url.md
+++ b/sources/academy/build-and-publish/apify-store-basics/importance_of_actor_url.md
@@ -1,6 +1,6 @@
 ---
 title: Importance of Actor URL
-description: Learn how to set your Actor’s URL (technical name) and name effectively when creating it on Apify. Follow best practices to optimize your Actor’s web presence and ensure it stands out on Apify Store.
+description: Set your Actor's URL and name effectively when creating it on the Apify platform. Follow best practices to optimize your Actor's web presence.
 sidebar_position: 6
 category: build-and-publish
 slug: /actor-marketing-playbook/actor-basics/importance-of-actor-url

--- a/sources/academy/build-and-publish/how-to-build/index.md
+++ b/sources/academy/build-and-publish/how-to-build/index.md
@@ -1,6 +1,6 @@
 ---
 title: How to build Actors
-description: Learn how to create web scrapers and automation tools on Apify. Use universal scrapers for quick setup, code templates for a head start, or SDKs and libraries for full control.
+description: Create web scrapers and automation tools on Apify. Choose universal scrapers for quick setup, code templates for a head start, or SDKs for full control.
 category: build-and-publish
 slug: /actor-marketing-playbook/store-basics/how-to-build-actors
 ---

--- a/sources/academy/build-and-publish/interacting-with-users/emails_to_actor_users.md
+++ b/sources/academy/build-and-publish/interacting-with-users/emails_to_actor_users.md
@@ -1,6 +1,6 @@
 ---
 title: Emails to Actor users
-description: Email communication is a key tool to keep users engaged and satisfied. Learn when and how to email your users effectively to build loyalty and strengthen relationships with this practical guide.
+description: Keep your Actor users engaged and satisfied through effective email communication. Learn when and how to email your users and build lasting loyalty.
 sidebar_position: 1
 category: build-and-publish
 slug: /actor-marketing-playbook/interact-with-users/emails-to-actor-users

--- a/sources/academy/build-and-publish/promoting-your-actor/affiliates.md
+++ b/sources/academy/build-and-publish/promoting-your-actor/affiliates.md
@@ -1,6 +1,6 @@
 ---
 title: Affiliates
-description: Join the Apify Affiliate Program to earn recurring commissions by promoting Actors, platform features, and professional services. Learn how to use your network, create content, and maximize your earnings.
+description: Join the Apify Affiliate Program to earn recurring commissions by promoting Actors, the Apify platform features, and its professional services.
 sidebar_position: 8
 category: build-and-publish
 slug: /actor-marketing-playbook/promote-your-actor/affiliates

--- a/sources/academy/build-and-publish/promoting-your-actor/blogs_and_blog_resources.md
+++ b/sources/academy/build-and-publish/promoting-your-actor/blogs_and_blog_resources.md
@@ -1,6 +1,6 @@
 ---
 title: Blogs and blog resources
-description: Blogs are still a powerful way to promote your Actors and build authority. By sharing expertise, engaging users, and driving organic traffic, blogging remains a key strategy to complement social media, SEO, and other platforms in growing your audience.
+description: Promote your Actors and build authority through blogging. Share your expertise, engage users, and drive organic traffic to grow your audience.
 sidebar_position: 5
 category: build-and-publish
 slug: /actor-marketing-playbook/promote-your-actor/blogs-and-blog-resources

--- a/sources/academy/build-and-publish/promoting-your-actor/checklist.md
+++ b/sources/academy/build-and-publish/promoting-your-actor/checklist.md
@@ -1,6 +1,6 @@
 ---
 title: Marketing checklist
-description: A comprehensive, actionable checklist to promote your Actor. Follow this step-by-step guide to reach more users through social media, content marketing, and community engagement.
+description: Follow this actionable checklist to promote your Actor and reach more users through social media, content marketing, and community engagement.
 sidebar_position: 0
 category: build-and-publish
 slug: /actor-marketing-playbook/promote-your-actor/checklist

--- a/sources/academy/build-and-publish/promoting-your-actor/product_hunt.md
+++ b/sources/academy/build-and-publish/promoting-your-actor/product_hunt.md
@@ -1,6 +1,6 @@
 ---
 title: Product Hunt
-description: Boost your Actor’s visibility by launching it on Product Hunt, a top platform for tech innovations. Attract early adopters, developers, and businesses while showcasing your tool’s value through visuals or demos.
+description: Launch your Actor on Product Hunt to attract early adopters and developers. Showcase your tool's value through visuals, demos, and community engagement.
 sidebar_position: 4
 category: build-and-publish
 slug: /actor-marketing-playbook/promote-your-actor/product-hunt

--- a/sources/academy/tutorials/apify_actors/adding_rapidapi_project.md
+++ b/sources/academy/tutorials/apify_actors/adding_rapidapi_project.md
@@ -1,6 +1,6 @@
 ---
 title: Adding your RapidAPI project to Apify
-description: If you've published an API project on RapidAPI, you can expand your project's visibility by listing it on Apify Store. This gives you access to Apify's developer community and ecosystem.
+description: Expand your RapidAPI project's visibility by listing it on Apify Store. Access Apify's developer community and broader ecosystem for wider reach.
 sidebar_position: 1
 category: apify platform
 slug: /apify-actors/adding-rapidapi-project

--- a/sources/academy/webscraping/advanced_web_scraping/index.md
+++ b/sources/academy/webscraping/advanced_web_scraping/index.md
@@ -1,6 +1,6 @@
 ---
 title: Advanced web scraping
-description: Take your scrapers to a production-ready level by learning various advanced concepts and techniques that will help you build highly scalable and reliable crawlers.
+description: Take your scrapers to a production-ready level with advanced web scraping concepts and techniques for building scalable and reliable crawlers.
 sidebar_position: 6
 category: web scraping & automation
 slug: /advanced-web-scraping

--- a/sources/academy/webscraping/scraping_basics_javascript/08_saving_data.md
+++ b/sources/academy/webscraping/scraping_basics_javascript/08_saving_data.md
@@ -1,7 +1,7 @@
 ---
 title: Saving data with Node.js
 sidebar_label: Saving data
-description: Lesson about building a Node.js application for watching prices. Using the json2csv library to save data scraped from product listing pages in both JSON and CSV.
+description: Build a Node.js price-watching application. Use the json2csv library to save data scraped from product listing pages in both JSON and CSV formats.
 slug: /scraping-basics-javascript/saving-data
 ---
 

--- a/sources/academy/webscraping/scraping_basics_javascript/11_scraping_variants.md
+++ b/sources/academy/webscraping/scraping_basics_javascript/11_scraping_variants.md
@@ -1,7 +1,7 @@
 ---
 title: Scraping product variants with Node.js
 sidebar_label: Scraping product variants
-description: Lesson about building a Node.js application for watching prices. Using browser DevTools to figure out how to extract product variants and exporting them as separate items.
+description: Build a Node.js price-watching application. Use browser DevTools to figure out how to extract product variants and export them as separate items.
 slug: /scraping-basics-javascript/scraping-variants
 ---
 

--- a/sources/academy/webscraping/scraping_basics_python/08_saving_data.md
+++ b/sources/academy/webscraping/scraping_basics_python/08_saving_data.md
@@ -1,7 +1,7 @@
 ---
 title: Saving data with Python
 sidebar_label: Saving data
-description: Lesson about building a Python application for watching prices. Using standard library to save data scraped from product listing pages in popular formats such as CSV or JSON.
+description: Build a Python price-watching application. Use the standard library to save data scraped from product listing pages in formats like CSV and JSON.
 slug: /scraping-basics-python/saving-data
 ---
 

--- a/sources/academy/webscraping/scraping_basics_python/11_scraping_variants.md
+++ b/sources/academy/webscraping/scraping_basics_python/11_scraping_variants.md
@@ -1,7 +1,7 @@
 ---
 title: Scraping product variants with Python
 sidebar_label: Scraping product variants
-description: Lesson about building a Python application for watching prices. Using browser DevTools to figure out how to extract product variants and exporting them as separate items.
+description: Build a Python price-watching application. Use browser DevTools to figure out how to extract product variants and export them as separate items.
 slug: /scraping-basics-python/scraping-variants
 ---
 

--- a/sources/platform/actors/development/actor_definition/docker.md
+++ b/sources/platform/actors/development/actor_definition/docker.md
@@ -1,6 +1,6 @@
 ---
 title: Dockerfile
-description: Learn about the available Docker images you can use as a base for your Apify Actors. Choose the right base image based on your Actor's requirements and the programming language you're using.
+description: Choose the right Docker base image for your Apify Actors based on your requirements and programming language. Explore available images and tags.
 slug: /actors/development/actor-definition/dockerfile
 sidebar_position: 7
 ---

--- a/sources/platform/actors/development/actor_definition/dynamic_actor_memory/index.md
+++ b/sources/platform/actors/development/actor_definition/dynamic_actor_memory/index.md
@@ -1,6 +1,6 @@
 ---
 title: Dynamic Actor memory
-description: Learn how to automatically adjust your Actor's memory based on input size and run options, so you can optimize performance and reduce costs without manual configuration.
+description: Automatically adjust your Actor's memory allocation based on input size and run options to optimize performance and reduce costs without manual setup.
 slug: /actors/development/actor-definition/dynamic-actor-memory
 ---
 

--- a/sources/platform/actors/publishing/monetize/pay_per_event.mdx
+++ b/sources/platform/actors/publishing/monetize/pay_per_event.mdx
@@ -1,6 +1,6 @@
 ---
 title: Pay per event
-description: Learn how to monetize your Actor with pay-per-event (PPE) pricing, charging users for specific actions like Actor starts, dataset items, or API calls, and understand how to set profitable, transparent event-based pricing.
+description: Monetize your Actor with pay-per-event (PPE) pricing. Charge users for specific actions like Actor starts, dataset items, or API calls and more.
 slug: /actors/publishing/monetize/pay-per-event
 sidebar_position: 1
 ---

--- a/sources/platform/actors/publishing/monetize/pay_per_result.mdx
+++ b/sources/platform/actors/publishing/monetize/pay_per_result.mdx
@@ -1,6 +1,6 @@
 ---
 title: Pay per result
-description: Learn how to monetize your Actor with pay-per-result (PPR) pricing, charging users based on the number of results produced and stored in the dataset, and understand how to set profitable, transparent result-based pricing.
+description: Monetize your Actor with pay-per-result (PPR) pricing. Charge users based on the number of scraped results they produce and store in the dataset.
 slug: /actors/publishing/monetize/pay-per-result
 sidebar_position: 2
 ---

--- a/sources/platform/actors/publishing/monetize/pricing_and_costs.mdx
+++ b/sources/platform/actors/publishing/monetize/pricing_and_costs.mdx
@@ -1,6 +1,6 @@
 ---
 title: Pricing and costs
-description: Learn how to set Actor pricing and calculate your costs, including platform usage rates, discount tiers, and profit formulas for PPE and PPR monetization models.
+description: Set Actor pricing and calculate your costs, including platform usage rates, discount tiers, and profit formulas for PPE and PPR monetization models.
 slug: /actors/publishing/monetize/pricing-and-costs
 sidebar_position: 4
 ---

--- a/sources/platform/actors/publishing/monetize/rental.mdx
+++ b/sources/platform/actors/publishing/monetize/rental.mdx
@@ -1,6 +1,6 @@
 ---
 title: Rental pricing model
-description: Learn how to monetize your Actor with the rental pricing model, offering users a free trial and a flat monthly fee, and understand how profit is calculated and the limitations of this approach.
+description: Monetize your Actor with the rental pricing model. Offer users a free trial and a flat monthly fee, and understand how profit is calculated.
 slug: /actors/publishing/monetize/rental
 sidebar_position: 3
 ---

--- a/sources/platform/actors/publishing/quality_score.mdx
+++ b/sources/platform/actors/publishing/quality_score.mdx
@@ -1,6 +1,6 @@
 ---
 title: Actor quality score
-description: The Actor quality score tells you how well your Actor is doing in terms of reliability, ease of use, popularity and other quality indicators. The score ranges from 0 to 100 and influences your visibility in the Store.
+description: Understand the Actor quality score, a 0-to-100 metric that evaluates reliability, ease of use, and popularity to determine Store visibility.
 slug: /actors/publishing/quality-score
 sidebar_position: 5
 ---

--- a/sources/platform/actors/running/usage_and_resources.md
+++ b/sources/platform/actors/running/usage_and_resources.md
@@ -1,6 +1,6 @@
 ---
 title: Usage and resources
-description: Learn about your Actors' memory and processing power requirements, their relationship with Docker resources, minimum requirements for different use cases and its impact on the cost.
+description: Understand Actor memory and processing power requirements, their relationship with Docker resources, and how resource allocation impacts cost.
 sidebar_position: 2
 slug: /actors/running/usage-and-resources
 ---

--- a/sources/platform/collaboration/general-resource-access.md
+++ b/sources/platform/collaboration/general-resource-access.md
@@ -1,6 +1,6 @@
 ---
 title: General resource access
-description: Control how Apify resources are shared. Set default access (Anyone with ID can read or Restricted), and learn about link sharing, exceptions, and pre-signed URLs.
+description: Control how Apify resources are shared. Set default access levels, configure link sharing and exceptions, and use pre-signed URLs for storage.
 sidebar_position: 1
 category: platform
 slug: /collaboration/general-resource-access

--- a/sources/platform/console/billing.md
+++ b/sources/platform/console/billing.md
@@ -1,6 +1,6 @@
 ---
 title: Billing
-description: The Billings page is the central place for all information regarding your invoices, billing information regarding current usage, historical usage, subscriptions & limits.
+description: Manage your invoices, review current and historical platform usage, subscription details, and spending limits from the Apify Console Billing page.
 sidebar_position: 3
 category: platform
 slug: /console/billing

--- a/sources/platform/integrations/programming/webhooks/events.md
+++ b/sources/platform/integrations/programming/webhooks/events.md
@@ -1,6 +1,6 @@
 ---
 title: Events types for webhooks
-description: Specify the types of events that trigger a webhook in an Actor or task run. Trigger an action on Actor or task run creation, success, failure, termination, or timeout.
+description: Specify the event types that trigger a webhook for Actor or task runs, including run creation, success, failure, termination, and timeout events.
 sidebar_position: 1
 slug: /integrations/webhooks/events
 ---

--- a/sources/platform/integrations/workflows-and-notifications/windmill.md
+++ b/sources/platform/integrations/workflows-and-notifications/windmill.md
@@ -1,6 +1,6 @@
 ---
 title: Windmill integration
-description: Use Windmill to run Apify Actors and tasks, react to Apify events via webhooks or polling, and move data between Apify and other services with Windmill scripts and flows.
+description: Run Apify Actors and tasks with Windmill scripts and flows. React to events via webhooks or polling, and move data between Apify and other services.
 sidebar_label: Windmill
 sidebar_position: 8
 slug: /integrations/windmill

--- a/sources/platform/monitoring/index.md
+++ b/sources/platform/monitoring/index.md
@@ -1,6 +1,6 @@
 ---
 title: Monitoring
-description: Learn how to continuously make sure that your Actors and tasks perform as expected and retrieve correct results. Receive alerts when your jobs or their metrics are not as you expect.
+description: Monitor your Actors and tasks to ensure they perform as expected. Set up alerts when your jobs or their metrics deviate from your expectations.
 sidebar_position: 12
 category: guides
 slug: /monitoring


### PR DESCRIPTION
## Summary
- Shortens 28 front matter `description` fields that exceeded the 160-character SEO limit
- All descriptions now fit within the 140-160 character target range defined in `content-standards.md`
- Preserves core meaning and keywords while using active voice and imperative tone

Closes #1882

## Files changed
28 files across `sources/platform/` and `sources/academy/` - all description-only changes (single line per file)

## Test plan
- [ ] Verify all descriptions are 140-160 characters
- [ ] Check that SEO metadata renders correctly
- [ ] Spot-check descriptions for accuracy and readability

Generated with [Claude Code](https://claude.com/claude-code)