### PR TITLE
docs: main event mentioned in docs

### DIFF
--- a/sources/academy/build-and-publish/apify-store-basics/how_actor_monetization_works.md
+++ b/sources/academy/build-and-publish/apify-store-basics/how_actor_monetization_works.md
@@ -95,11 +95,22 @@ If you want more details about rental pricing, refer to our [rental pricing docu
 
 1. _Go to your Actor page_: navigate to the **Publication** tab and open the **Monetization** section.
 2. _Fill in billing details_: set up your payment details for payouts.
-3. _Choose your pricing model_: use the monetization wizard to select your model and set fees.
+3. _Choose your pricing model_: use the monetization wizard to select your model.
+4. _Define chargeable events (PPE)_: select the events users pay for (for example, per result, per API call, or per Actor start), then set clear names, descriptions, and prices.
+5. _Choose a primary event (PPE)_: select the event that best represents the main value of your Actor. This primary event is emphasized on the Actor detail page, so users can quickly understand what they are mainly paying for.
+
 
 ### Changing monetization
 
-Adjustments to monetization settings take 14 days to take effect and can be made once per month.
+Some monetization updates are applied immediately. However, significant pricing changes require a 14-day notice period.
+
+Significant changes include:
+
+- Increasing prices
+- Adding a new paid pricing event (PPE)
+- Changing the pricing model
+
+You can make these significant changes only once per month.
 
 ### Tracking and promotion
 

--- a/sources/platform/actors/publishing/monetize/pay_per_event.mdx
+++ b/sources/platform/actors/publishing/monetize/pay_per_event.mdx
@@ -50,6 +50,7 @@ An Actor's negative net profit does not affect the positive profit of another Ac
 
 1. _Understand your costs_: Analyze resource usage (e.g CPU, memory, proxies, external APIs) and identify cost drivers
 1. _Define clear events_: break your Actor's functionality into measurable, chargeable events.
+1. _Choose a primary event_: Pick the event that best represents the main value of your Actor. This primary event is highlighted on the Actor detail page, so users quickly understand what they are mainly paying for.
 1. _Common use cases_:
    1. _For scraping_: combine Actor start and dataset items pricing to reflect setup and per-result cost.
    1. _Beyond scraping_: Account for integrations with external systems or external API calls.


### PR DESCRIPTION
PR makes sure primary event is mentioned in docs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no impact on runtime behavior; main risk is minor user confusion if the policy details are inaccurate.
> 
> **Overview**
> Updates the monetization setup steps to explicitly include defining pay-per-event (PPE) chargeable events and selecting a **primary event** that is highlighted on the Actor detail page.
> 
> Reworks the “Changing monetization” section to clarify that some updates apply immediately, while *significant* changes (price increases, adding paid PPE events, or switching pricing model) require a 14-day notice period and are limited to once per month.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2b594d99f2cf6bf7702b3235c3911ab9b0cbcac3. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->