### PR TITLE
docs: Improve Build with AI page clarity and structure

### DIFF
--- a/sources/platform/actors/development/quick-start/build_with_ai.md
+++ b/sources/platform/actors/development/quick-start/build_with_ai.md
@@ -15,25 +15,25 @@ import TabItem from '@theme/TabItem';
 
 This guide provides best practices for building new Actors or improving existing ones using AI code generation tools by providing the AI agents with the right instructions and context.
 
-The methods below are complementary - start with the [AI coding assistant instructions](#ai-coding-assistant-instructions) or [Actor templates with AGENTS.md](#use-actor-templates-with-agentsmd) to get going, then add [Agent Skills](#use-agent-skills) and the [Apify MCP server](#use-apify-mcp-server) to give your assistant more context and better results.
+The methods on this page are complementary. Start with the [AI coding assistant instructions](#ai-coding-assistant-instructions) or [Actor templates with AGENTS.md](#use-actor-templates-with-agentsmd) to get going, then add [Agent Skills](#use-agent-skills) and the [Apify MCP server](#use-apify-mcp-server) to give your assistant more context and better results.
 
 ## Quick start
 
 <Tabs>
 <TabItem value="prompt" label="Start with a prompt">
 
-1. Create a directory: `mkdir my-new-actor`
+1. Create a directory: `mkdir my-new-actor`.
 1. Open the directory in _Cursor_, _Claude Code_, _VS Code with GitHub Copilot_, etc.
-1. Copy the [AI coding assistant prompt](#ai-coding-assistant-instructions) and paste it into your AI coding assistant
-1. Run it, and develop your first Actor with the help of AI
+1. Copy the [AI coding assistant prompt](#ai-coding-assistant-instructions) and paste it into your AI coding assistant.
+1. Run it, and develop your first Actor with the help of AI.
 
 </TabItem>
 <TabItem value="template" label="Start with a template">
 
-1. [Install the Apify CLI](/cli/docs/installation) if you haven't already
-1. Run `apify create` to initialize an Actor from a [template](https://apify.com/templates) (includes AGENTS.md)
+1. [Install the Apify CLI](/cli/docs/installation) if you haven't already.
+1. Run `apify create` to initialize an Actor from a [template](https://apify.com/templates) (includes AGENTS.md).
 1. Open the project in _Cursor_, _Claude Code_, _VS Code with GitHub Copilot_, etc.
-1. Start developing - your AI coding assistant automatically picks up context from AGENTS.md
+1. Start developing - your AI coding assistant automatically picks up context from AGENTS.md.
 
 </TabItem>
 </Tabs>
@@ -60,15 +60,13 @@ The command above will guide you through Apify Actor initialization, where you s
 
 ## Use Agent Skills
 
-[Agent Skills](https://github.com/apify/agent-skills) are official Apify skills for Actor development, web scraping, data extraction, automation, etc. They work with Claude Code, Cursor, Codex, Gemini CLI, and other AI coding assistants. Agents are increasingly capable, but often lack the context they need to do real work reliably.
-
-Skills solve this by giving agents access to procedural knowledge. Agents with access to a set of skills can extend their capabilities based on the task they're working on.
+[Agent Skills](https://github.com/apify/agent-skills) are official Apify skills for Actor development, web scraping, data extraction, automation, etc. They work with Claude Code, Cursor, Codex, Gemini CLI, and other AI coding assistants.
 
 Install Agent Skills in your project directory:
 
-```bash
-npx skills add apify/agent-skills
-```
+	```bash
+	npx skills add apify/agent-skills
+	```
 
 This adds skill files to your project that AI coding assistants automatically discover and use for context. No additional configuration is needed.
 

--- a/sources/platform/actors/development/quick-start/build_with_ai.md
+++ b/sources/platform/actors/development/quick-start/build_with_ai.md
@@ -64,9 +64,9 @@ The command above will guide you through Apify Actor initialization, where you s
 
 Install Agent Skills in your project directory:
 
-	```bash
-	npx skills add apify/agent-skills
-	```
+```bash
+npx skills add apify/agent-skills
+```
 
 This adds skill files to your project that AI coding assistants automatically discover and use for context. No additional configuration is needed.
 

--- a/sources/platform/actors/development/quick-start/build_with_ai.md
+++ b/sources/platform/actors/development/quick-start/build_with_ai.md
@@ -60,7 +60,7 @@ The command above will guide you through Apify Actor initialization, where you s
 
 ## Use Agent Skills
 
-[Agent Skills](https://github.com/apify/agent-skills) are official Apify skills for Actor development, web scraping, data extraction, automation, etc. They work with Claude Code, Cursor, Codex, Gemini CLI, and other AI coding assistants. Agents are increasingly capable, but often lack the context they need to do real work reliably. 
+[Agent Skills](https://github.com/apify/agent-skills) are official Apify skills for Actor development, web scraping, data extraction, automation, etc. They work with Claude Code, Cursor, Codex, Gemini CLI, and other AI coding assistants. Agents are increasingly capable, but often lack the context they need to do real work reliably.
 
 Skills solve this by giving agents access to procedural knowledge. Agents with access to a set of skills can extend their capabilities based on the task they're working on.
 

--- a/sources/platform/actors/development/quick-start/build_with_ai.md
+++ b/sources/platform/actors/development/quick-start/build_with_ai.md
@@ -7,38 +7,44 @@ slug: /actors/development/quick-start/build-with-ai
 toc_max_heading_level: 4
 ---
 
-**Learn how to develop new Actors or improve existing ones using AI code generation and vibe coding tools.**
-
----
-
 import { AGENTS_PROMPT } from "@site/src/utils/agents-prompt";
 import PromptButton from "@site/src/components/PromptButton";
 import copyForAI from "./images/copy-for-ai.png";
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-This guide provides best practices for building new Actors or improving existing ones using AI code generation and vibe coding tools such as Antigravity, Cursor, Claude Code, or Visual Studio Code, by providing the AI agents with the right instructions and context.
+This guide provides best practices for building new Actors or improving existing ones using AI code generation tools by providing the AI agents with the right instructions and context.
+
+The methods below are complementary - start with the [AI coding assistant instructions](#ai-coding-assistant-instructions) or [Actor templates with AGENTS.md](#use-actor-templates-with-agentsmd) to get going, then add [Agent Skills](#use-agent-skills) and the [Apify MCP server](#use-apify-mcp-server) to give your assistant more context and better results.
+
+## Quick start
+
+<Tabs>
+<TabItem value="prompt" label="Start with a prompt">
+
+1. Create a directory: `mkdir my-new-actor`
+1. Open the directory in _Cursor_, _Claude Code_, _VS Code with GitHub Copilot_, etc.
+1. Copy the [AI coding assistant prompt](#ai-coding-assistant-instructions) and paste it into your AI coding assistant
+1. Run it, and develop your first Actor with the help of AI
+
+</TabItem>
+<TabItem value="template" label="Start with a template">
+
+1. [Install the Apify CLI](/cli/docs/installation) if you haven't already
+1. Run `apify create` to initialize an Actor from a [template](https://apify.com/templates) (includes AGENTS.md)
+1. Open the project in _Cursor_, _Claude Code_, _VS Code with GitHub Copilot_, etc.
+1. Start developing - your AI coding assistant automatically picks up context from AGENTS.md
+
+</TabItem>
+</Tabs>
 
 ## AI coding assistant instructions
 
-Use the following prompt in your AI coding assistant such as [Antigravity](https://antigravity.google/), [Cursor](https://cursor.com/), [Claude Code](https://claude.com/product/claude-code) or [GitHub Copilot](https://github.com/features/copilot):
+Use the following prompt in your AI coding assistant such as [Cursor](https://cursor.com/), [Claude Code](https://claude.com/product/claude-code), or [GitHub Copilot](https://github.com/features/copilot):
 
 <PromptButton prompt={AGENTS_PROMPT} title="Use pre-built prompt for your AI coding assistant" />
 
-The prompt guides AI coding assistants such as Antigravity, Cursor, Claude Code or GitHub Copilot to help users create and deploy an Apify Actor step by step. It walks through setting up the Actor structure, configuring all required files, installing dependencies, running it locally, logging in, and pushing it to the Apify platform and following Apify’s best practices.
-
-### Quick Start
-
-1. Create directory: `mkdir my-new-actor`
-1. Open the directory in _Antigravity_, _Cursor_, _Claude Code_, _VS Code with GitHub Copilot_, etc.
-1. Copy the prompt above and paste it into your AI coding assistant (Agent or Chat)
-1. Run it, and develop your first actor with the help of AI
-
-:::info Avoid copy-pasting
-
-The AI will follow the guide step-by-step, and you'll avoid copy-pasting from tools like ChatGPT or Claude.
-
-:::
+The prompt guides your AI coding assistant to create and deploy an Apify Actor step by step. It walks through setting up the Actor structure, configuring all required files, installing dependencies, running it locally, logging in, and pushing it to the Apify platform.
 
 ## Use Actor templates with AGENTS.md
 
@@ -52,9 +58,23 @@ If you do not have Apify CLI installed, see the [installation guide](/cli/docs/i
 
 The command above will guide you through Apify Actor initialization, where you select an Actor Template that works for you. The result is an initialized Actor (with AGENTS.md) ready for development.
 
-## Use Apify MCP Server
+## Use Agent Skills
 
-The Apify MCP Server has tools to search and fetch documentation. If you set it up in your AI editor, it will help you improve the generated code by providing additional context to the AI.
+[Agent Skills](https://github.com/apify/agent-skills) are official Apify skills for Actor development, web scraping, data extraction, automation, etc. They work with Claude Code, Cursor, Codex, Gemini CLI, and other AI coding assistants. Agents are increasingly capable, but often lack the context they need to do real work reliably. 
+
+Skills solve this by giving agents access to procedural knowledge. Agents with access to a set of skills can extend their capabilities based on the task they're working on.
+
+Install Agent Skills in your project directory:
+
+```bash
+npx skills add apify/agent-skills
+```
+
+This adds skill files to your project that AI coding assistants automatically discover and use for context. No additional configuration is needed.
+
+## Use Apify MCP server
+
+The Apify MCP server has tools to search and fetch documentation. If you set it up in your AI editor, it will help you improve the generated code by providing additional context to the AI.
 
 :::info Use Apify MCP server configuration
 
@@ -88,7 +108,7 @@ VS Code supports MCP through MCP-compatible extensions like _GitHub Copilot_, _C
 1. Install an MCP-compatible extension (e.g., GitHub Copilot, Cline).
 1. Locate the extension's MCP settings or configuration file (often `mcp.json`).
    - For _GitHub Copilot_: Run the **MCP: Open User Configuration** command.
-   - For _MCP-compatible extension_: Go to the MCP Servers tab in the extension interface.
+   - For _Cline_ or _Roo Code_: Go to the **MCP Servers** tab in the extension interface.
 1. Add the Apify server configuration:
 
     ```json
@@ -102,39 +122,13 @@ VS Code supports MCP through MCP-compatible extensions like _GitHub Copilot_, _C
     ```
 
 </TabItem>
-<TabItem value="claude" label="Claude">
+<TabItem value="claude-code" label="Claude Code">
 
-1. Go to **Settings** > **Connectors** in Claude.
-1. Click **Add custom connector**.
-1. Set the name to `Apify` and the URL to `https://mcp.apify.com/?tools=docs`.
-1. When chatting, select the **+** button and choose the **Apify** connector to add documentation context.
+Run the following command to add the Apify MCP server:
 
-</TabItem>
-<TabItem value="antigravity" label="Antigravity">
-
-To add Apify MCP server to Antigravity:
-
-1. Click on the **Chat tab**.
-2. Click the three dots (**Additional options**) menu.
-3. Select **Manage MCP Servers**.
-4. Click **View raw config** to open the configuration file.
-5. Add the following to the configuration file:
-
-    ```json
-    {
-      "mcpServers": {
-        "apify": {
-          "command": "npx",
-          "args": [
-            "-y",
-            "@apify/actors-mcp-server",
-            "--tools",
-            "docs"
-          ]
-        }
-      }
-    }
-    ```
+```bash
+claude mcp add apify "https://mcp.apify.com/?tools=docs" -t http
+```
 
 </TabItem>
 </Tabs>


### PR DESCRIPTION
## Summary

- Restructured **Quick Start** as a top-level section with two tabbed paths: starting with a prompt vs starting with a template (`apify create`)
- Added intro paragraph explaining that the methods on the page are complementary and where to start
- Added **Agent Skills** section with installation command and explanation of what happens after install
- Removed redundant tool lists (previously repeated 3 times with inconsistencies)
- Removed bold intro line that duplicated the front matter description
- Replaced Claude (web) MCP tab with **Claude Code** CLI command
- Removed all Antigravity references
- Fixed terminology: "actor" → "Actor", "MCP Server" → "MCP server"
- Added missing Oxford commas
- Made vague VS Code MCP instructions specific (Cline, Roo Code)