### PR TITLE
docs: Update clipboard handling for Safari compatibility in LLMButtons

### DIFF
--- a/apify-docs-theme/src/theme/LLMButtons/index.jsx
+++ b/apify-docs-theme/src/theme/LLMButtons/index.jsx
@@ -173,7 +173,12 @@ const onCopyAsMarkdownClick = async ({ setCopyingStatus }) => {
         // awaiting fetch first — otherwise Safari would reject the clipboard operation.
         const markdownContent = new ClipboardItem({
             'text/plain': fetch(markdownUrl)
-                .then(async (response) => response.text())
+                .then((response) => {
+                    if (!response.ok) {
+                        throw new Error(`Failed to fetch markdown: ${response.status}`);
+                    }
+                    return response.text();
+                })
                 .then((content) => new Blob([content], { type: 'text/plain' })),
         });
 


### PR DESCRIPTION
https://wolfgangrittner.dev/how-to-use-clipboard-api-in-safari/

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to a UI clipboard action; main risk is browser support/behavior differences for `ClipboardItem` and async fetch failures.
> 
> **Overview**
> Updates the `LLMButtons` “Copy for LLM” flow to write fetched Markdown to the clipboard via `navigator.clipboard.write([new ClipboardItem(...)])` instead of `writeText`, avoiding Safari rejecting clipboard operations when the fetch is awaited before the write.
> 
> Adds an in-function debug `console.log` of the created `ClipboardItem`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8ecd7a94de49e8cb0d822f0b16e6cc4e45b08ac6. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->