### PR TITLE
fix: improve lychee link checker to catch dead links returning 403

### DIFF
--- a/.github/workflows/lychee.yml
+++ b/.github/workflows/lychee.yml
@@ -46,6 +46,7 @@ jobs:
                         --verbose
                         --no-progress
                         --timeout '60'
-                        --accept '100..=103,200..=299,403..=403,429'
+                        --accept '100..=103,200..=299,429'
+                        --max-redirects 5
                         --format markdown
                         './build/**/*.html'

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -13,3 +13,7 @@ https://console-backend.apify.com/
 https://mcp.apify.com/
 https://www.deviceinfo.me/
 https://trust.apify.com/
+# Bot-blocked sites (return 403 to non-browser clients)
+https?:\/\/(www\.)?soundcloud\.com\/.*
+https?:\/\/(www\.)?fandom\.com\/.*
+https?:\/\/(www\.)?remax\.com\.tr\/.*


### PR DESCRIPTION
- Remove blanket HTTP 403 acceptance from lychee config, which was masking genuinely dead links (e.g., make.com/en/integrations/apify-instagram-scraper). 
- Add `--max-redirects 5` to properly follow redirects instead of reporting 302 as errors.
- Add bot-blocking domains (soundcloud.com, fandom.com, remax.com.tr) to .lycheeignore to avoid false positives from sites that return 403 to non-browser clients.