### PR TITLE
docs: add PPE event charging examples and restructure best practices

### DIFF
--- a/sources/platform/actors/publishing/monetize/pay_per_event.mdx
+++ b/sources/platform/actors/publishing/monetize/pay_per_event.mdx
@@ -203,114 +203,6 @@ If you're not using the Apify SDKs (JS/Python), you need to handle idempotency (
 
 The following examples show common charging patterns using the Apify SDK. Use the [JS](/sdk/js/reference/class/Actor#charge) or [Python](/sdk/python/reference/class/Actor#charge) SDK to handle idempotency, API errors, and spending limits automatically.
 
-### Respect spending limits
-
-Check `eventChargeLimitReached` after each charge and stop the Actor when the user's budget is exhausted. For Actors with multiple event types, use `chargeableWithinLimit` to check whether any event can still be charged before stopping.
-
-<Tabs groupId="main">
-<TabItem value="JavaScript" label="JavaScript">
-
-```js
-import { Actor } from 'apify';
-
-await Actor.init();
-
-const input = await Actor.getInput();
-const { items } = input;
-
-for (const item of items) {
-    const chargeResult = await Actor.charge({ eventName: 'result' });
-
-    if (chargeResult.eventChargeLimitReached) {
-        await Actor.exit('Spending limit reached');
-    }
-
-    await Actor.pushData(item);
-}
-
-await Actor.exit();
-```
-
-</TabItem>
-<TabItem value="Python" label="Python">
-
-```python
-from apify import Actor
-
-async def main():
-    await Actor.init()
-
-    input_data = await Actor.get_input()
-    items = input_data.get('items', [])
-
-    for item in items:
-        charge_result = await Actor.charge(event_name='result')
-
-        if charge_result.event_charge_limit_reached:
-            await Actor.exit('Spending limit reached')
-
-        await Actor.push_data(item)
-
-    await Actor.exit()
-```
-
-</TabItem>
-</Tabs>
-
-When charging multiple event types, use `chargeableWithinLimit` to check whether any event can still be charged before stopping.
-
-<Tabs groupId="main">
-<TabItem value="JavaScript" label="JavaScript">
-
-```js
-import { Actor } from 'apify';
-
-await Actor.init();
-
-const input = await Actor.getInput();
-const { items } = input;
-
-for (const item of items) {
-    const chargeResult = await Actor.charge({ eventName: 'result' });
-
-    // chargeableWithinLimit lists event types the user's budget still covers
-    if (!chargeResult.chargeableWithinLimit.includes('result')) {
-        await Actor.exit('Spending limit reached');
-    }
-
-    await Actor.pushData(item);
-}
-
-await Actor.exit();
-```
-
-</TabItem>
-<TabItem value="Python" label="Python">
-
-```python
-from apify import Actor
-
-async def main():
-    await Actor.init()
-
-    input_data = await Actor.get_input()
-    items = input_data.get('items', [])
-
-    for item in items:
-        charge_result = await Actor.charge(event_name='result')
-
-        # chargeable_within_limit lists event types the user's budget still covers
-        if 'result' not in charge_result.chargeable_within_limit:
-            await Actor.exit('Spending limit reached')
-
-        await Actor.push_data(item)
-
-    await Actor.exit()
-```
-
-</TabItem>
-</Tabs>
-
 ### Charge per result
 
 Charge an event when your Actor produces a data item and check the spending limit before continuing.
@@ -527,6 +419,114 @@ async def main():
         await process_url(url)
 
     # Rest of the Actor logic
+
+    await Actor.exit()
+```
+
+</TabItem>
+</Tabs>
+
+### Respect spending limits
+
+Check `eventChargeLimitReached` after each charge and stop the Actor when the user's budget is exhausted. For Actors with multiple event types, use `chargeableWithinLimit` to check whether any event can still be charged before stopping.
+
+<Tabs groupId="main">
+<TabItem value="JavaScript" label="JavaScript">
+
+```js
+import { Actor } from 'apify';
+
+await Actor.init();
+
+const input = await Actor.getInput();
+const { items } = input;
+
+for (const item of items) {
+    const chargeResult = await Actor.charge({ eventName: 'result' });
+
+    if (chargeResult.eventChargeLimitReached) {
+        await Actor.exit('Spending limit reached');
+    }
+
+    await Actor.pushData(item);
+}
+
+await Actor.exit();
+```
+
+</TabItem>
+<TabItem value="Python" label="Python">
+
+```python
+from apify import Actor
+
+async def main():
+    await Actor.init()
+
+    input_data = await Actor.get_input()
+    items = input_data.get('items', [])
+
+    for item in items:
+        charge_result = await Actor.charge(event_name='result')
+
+        if charge_result.event_charge_limit_reached:
+            await Actor.exit('Spending limit reached')
+
+        await Actor.push_data(item)
+
+    await Actor.exit()
+```
+
+</TabItem>
+</Tabs>
+
+When charging multiple event types, use `chargeableWithinLimit` to check whether any event can still be charged before stopping.
+
+<Tabs groupId="main">
+<TabItem value="JavaScript" label="JavaScript">
+
+```js
+import { Actor } from 'apify';
+
+await Actor.init();
+
+const input = await Actor.getInput();
+const { items } = input;
+
+for (const item of items) {
+    const chargeResult = await Actor.charge({ eventName: 'result' });
+
+    // chargeableWithinLimit lists event types the user's budget still covers
+    if (!chargeResult.chargeableWithinLimit.includes('result')) {
+        await Actor.exit('Spending limit reached');
+    }
+
+    await Actor.pushData(item);
+}
+
+await Actor.exit();
+```
+
+</TabItem>
+<TabItem value="Python" label="Python">
+
+```python
+from apify import Actor
+
+async def main():
+    await Actor.init()
+
+    input_data = await Actor.get_input()
+    items = input_data.get('items', [])
+
+    for item in items:
+        charge_result = await Actor.charge(event_name='result')
+
+        # chargeable_within_limit lists event types the user's budget still covers
+        if 'result' not in charge_result.chargeable_within_limit:
+            await Actor.exit('Spending limit reached')
+
+        await Actor.push_data(item)
 
     await Actor.exit()
 ```


### PR DESCRIPTION
Add three generic `Actor.charge()` examples (JS + Python) to the PPE docs:
- Charge per result with spending limit check
- Charge for multiple event types
- Charge for multiple items at once using count parameter

Move "Respect user spending limits" from standalone section into best practices and reorder subsections for logical flow: setup, spending limits, charging patterns, then pricing guidance. Clean up best practices intro prose.