### PR TITLE
chore(openapi): rename GeneralAccessEnum to GeneralAccess

### DIFF
--- a/apify-api/openapi/components/schemas/actor-runs/Run.yaml
+++ b/apify-api/openapi/components/schemas/actor-runs/Run.yaml
@@ -84,7 +84,7 @@ properties:
     description: Exit code of the Actor run process.
   generalAccess:
     description: General access level for the Actor run.
-    $ref: ../common/GeneralAccessEnum.yaml
+    $ref: ../common/GeneralAccess.yaml
   defaultKeyValueStoreId:
     type: string
     examples: [eJNzqsbPiopwJcgGQ]

--- a/apify-api/openapi/components/schemas/actor-runs/UpdateRunRequest.yaml
+++ b/apify-api/openapi/components/schemas/actor-runs/UpdateRunRequest.yaml
@@ -11,4 +11,4 @@ properties:
     type: boolean
     examples: [true]
   generalAccess:
-    $ref: ../common/GeneralAccessEnum.yaml
+    $ref: ../common/GeneralAccess.yaml

--- a/apify-api/openapi/components/schemas/common/GeneralAccess.yaml
+++ b/apify-api/openapi/components/schemas/common/GeneralAccess.yaml
@@ -1,3 +1,4 @@
+title: GeneralAccess
 type: string
 enum:
   - ANYONE_WITH_ID_CAN_READ

--- a/apify-api/openapi/components/schemas/datasets/Dataset.yaml
+++ b/apify-api/openapi/components/schemas/datasets/Dataset.yaml
@@ -79,6 +79,6 @@ properties:
     type: [string, "null"]
     description: A secret key for generating signed public URLs. It is only provided to clients with WRITE permission for the dataset.
   generalAccess:
-    $ref: ../common/GeneralAccessEnum.yaml
+    $ref: ../common/GeneralAccess.yaml
   stats:
     $ref: ./DatasetStats.yaml

--- a/apify-api/openapi/components/schemas/datasets/UpdateDatasetRequest.yaml
+++ b/apify-api/openapi/components/schemas/datasets/UpdateDatasetRequest.yaml
@@ -4,7 +4,7 @@ properties:
   name:
     type: string
   generalAccess:
-    $ref: ../common/GeneralAccessEnum.yaml
+    $ref: ../common/GeneralAccess.yaml
 example:
   name: new-dataset-name
   generalAccess: RESTRICTED

--- a/apify-api/openapi/components/schemas/key-value-stores/KeyValueStore.yaml
+++ b/apify-api/openapi/components/schemas/key-value-stores/KeyValueStore.yaml
@@ -49,6 +49,6 @@ properties:
     type: [string, "null"]
     description: A secret key for generating signed public URLs. It is only provided to clients with WRITE permission for the key-value store.
   generalAccess:
-    $ref: ../common/GeneralAccessEnum.yaml
+    $ref: ../common/GeneralAccess.yaml
   stats:
     $ref: ./KeyValueStoreStats.yaml

--- a/apify-api/openapi/components/schemas/request-queues/RequestQueue.yaml
+++ b/apify-api/openapi/components/schemas/request-queues/RequestQueue.yaml
@@ -67,4 +67,4 @@ properties:
   stats:
     $ref: ./RequestQueueStats.yaml
   generalAccess:
-    $ref: ../common/GeneralAccessEnum.yaml
+    $ref: ../common/GeneralAccess.yaml

--- a/apify-api/openapi/components/schemas/request-queues/UpdateRequestQueueRequest.yaml
+++ b/apify-api/openapi/components/schemas/request-queues/UpdateRequestQueueRequest.yaml
@@ -6,7 +6,7 @@ properties:
     type: string
     description: The new name for the request queue.
   generalAccess:
-    $ref: ../common/GeneralAccessEnum.yaml
+    $ref: ../common/GeneralAccess.yaml
 example:
   name: new-request-queue-name
   generalAccess: RESTRICTED

--- a/apify-api/openapi/components/schemas/store/UpdateStoreRequest.yaml
+++ b/apify-api/openapi/components/schemas/store/UpdateStoreRequest.yaml
@@ -4,7 +4,7 @@ properties:
   name:
     type: string
   generalAccess:
-    $ref: ../common/GeneralAccessEnum.yaml
+    $ref: ../common/GeneralAccess.yaml
 example:
   name: new-store-name
   generalAccess: RESTRICTED


### PR DESCRIPTION
because of https://github.com/apify/apify-sdk-python/pull/782#discussion_r2826039398