### PR TITLE
fix: Fix OpenAPI schema errors

### DIFF
--- a/apify-api/openapi/paths/datasets/datasets@{datasetId}@items.yaml
+++ b/apify-api/openapi/paths/datasets/datasets@{datasetId}@items.yaml
@@ -371,7 +371,7 @@ get:
       in: query
       description: Signature used to access the items.
       required: false
-      style: simple
+      style: form
       schema:
         type: string
         example: 2wTI46Bg8qWQrV7tavlPI

--- a/apify-api/openapi/paths/key-value-stores/key-value-stores@{storeId}@keys.yaml
+++ b/apify-api/openapi/paths/key-value-stores/key-value-stores@{storeId}@keys.yaml
@@ -51,7 +51,7 @@ get:
       in: query
       description: Signature used to access the keys.
       required: false
-      style: simple
+      style: form
       schema:
         type: string
         example: 2wTI46Bg8qWQrV7tavlPI

--- a/apify-api/openapi/paths/key-value-stores/key-value-stores@{storeId}@records@{recordKey}.yaml
+++ b/apify-api/openapi/paths/key-value-stores/key-value-stores@{storeId}@records@{recordKey}.yaml
@@ -40,7 +40,7 @@ get:
       in: query
       description: Signature used to access the record.
       required: false
-      style: simple
+      style: form
       schema:
         type: string
         example: 2wTI46Bg8qWQrV7tavlPI


### PR DESCRIPTION
- Fix OpenAPI schema errors reported by `express-openapi-validator`
- Change `style` of several `query` from `simple` to `form` to be compliant with the spec

Closes: #2269

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation/schema-only change that adjusts OpenAPI parameter metadata; runtime API behavior should be unaffected aside from client generation/validation.
> 
> **Overview**
> Fixes OpenAPI spec validation issues by changing the `signature` query parameter serialization from `style: simple` to `style: form` on several storage endpoints (`datasets/{datasetId}/items`, `key-value-stores/{storeId}/keys`, and `key-value-stores/{storeId}/records/{recordKey}`). This aligns the schema with OpenAPI rules and should stop `express-openapi-validator` from reporting errors for these routes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5bdc897557cf00f828f92f7d7ca47d26b2f0a220. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->