### PR TITLE
fix: update SDK JS URLs after docs restructure (apify-sdk-js#542, #562)

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -89,9 +89,9 @@ jobs:
                     assert_header "http://localhost:8080/llms-full.txt" "Content-Type" "text/markdown"
 
                     echo "🧪 Checking Nginx responses... (apify-sdk-js)"
-                    assert_header "http://localhost:8080/sdk/js/docs/guides/apify-platform" "Content-Type" "text/html"
-                    assert_header "http://localhost:8080/sdk/js/docs/guides/apify-platform.md" "Content-Type" "text/markdown"
-                    assert_header "http://localhost:8080/sdk/js/docs/guides/apify-platform" "Content-Type" "text/markdown" -H "Accept: text/markdown"
+                    assert_header "http://localhost:8080/sdk/js/docs/introduction/quick-start" "Content-Type" "text/html"
+                    assert_header "http://localhost:8080/sdk/js/docs/introduction/quick-start.md" "Content-Type" "text/markdown"
+                    assert_header "http://localhost:8080/sdk/js/docs/introduction/quick-start" "Content-Type" "text/markdown" -H "Accept: text/markdown"
                     assert_header "http://localhost:8080/sdk/js/llms.txt" "Content-Type" "text/markdown"
                     assert_header "http://localhost:8080/sdk/js/llms-full.txt" "Content-Type" "text/markdown"
 

--- a/nginx.conf
+++ b/nginx.conf
@@ -443,10 +443,12 @@ server {
     rewrite ^/sdk/js/api(.*)$ /sdk/js/reference$1 permanent;
     rewrite ^/sdk/js/reference/apify(.*)$ /sdk/js/reference$1 redirect;
     rewrite ^/sdk/js/reference/next/apify(.*)$ /sdk/js/reference/next$1 redirect;
-    rewrite ^/sdk/js/docs$ /sdk/js/docs/guides/apify-platform$1 redirect;
-    rewrite ^/sdk/js/docs/next$ /sdk/js/docs/next/guides/apify-platform$1 redirect;
-    rewrite ^/sdk/js/docs/guides/getting-started$ /sdk/js/docs/next/guides/apify-platform$1 redirect;
-    rewrite ^/sdk/js/docs/next/guides/getting-started$ /sdk/js/docs/next/guides/apify-platform$1 redirect;
+    rewrite ^/sdk/js/docs$ /sdk/js/docs/overview redirect;
+    rewrite ^/sdk/js/docs/next$ /sdk/js/docs/next/overview redirect;
+    rewrite ^/sdk/js/docs/guides/getting-started$ /sdk/js/docs/overview redirect;
+    rewrite ^/sdk/js/docs/next/guides/getting-started$ /sdk/js/docs/next/overview redirect;
+    rewrite ^/sdk/js/docs/guides/apify-platform$ /sdk/js/docs/overview redirect;
+    rewrite ^/sdk/js/docs/next/guides/apify-platform$ /sdk/js/docs/next/overview redirect;
 
     # old sdk version redirects (we keep only latest, and version only major/minor)
     rewrite ^/sdk/js/docs/1\.\d+\.\d+(.*)$ /sdk/js/docs/1.3$1 redirect;


### PR DESCRIPTION
The SDK JS docs reorganization renamed paths from guides/apify-platform to numbered directories. Update Nginx rewrites and CI test URLs to match.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts Nginx rewrite targets and CI header-check URLs; impact is limited to routing/redirect behavior for SDK JS docs paths.
> 
> **Overview**
> Updates SDK JS documentation routing after the docs restructure.
> 
> `nginx.conf` rewrites for `/sdk/js/docs` and legacy guide URLs now redirect to the new `overview` pages (including `next`), replacing redirects that previously pointed at `guides/apify-platform`. The GitHub Actions Nginx header assertions are updated to hit the new JS SDK docs path (`/sdk/js/docs/introduction/quick-start`) instead of the old guide URL.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1585d6a39052cb941337a10debe5a61200c2caa7. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->