### PR TITLE
feat: Add ActorJob and ActorJobResponse schemas to OpenAPI spec

### DIFF
--- a/apify-api/openapi/components/schemas/common/ActorJob.yaml
+++ b/apify-api/openapi/components/schemas/common/ActorJob.yaml
@@ -1,0 +1,9 @@
+title: ActorJob
+description: Minimal model for an Actor job (run or build) with status. Used for validation during polling operations.
+required:
+  - status
+type: object
+properties:
+  status:
+    description: Current status of the Actor job.
+    $ref: ./ActorJobStatus.yaml

--- a/apify-api/openapi/components/schemas/common/ActorJobResponse.yaml
+++ b/apify-api/openapi/components/schemas/common/ActorJobResponse.yaml
@@ -1,0 +1,8 @@
+title: ActorJobResponse
+description: Response wrapper for an Actor job (run or build). Used for minimal validation during polling operations.
+required:
+  - data
+type: object
+properties:
+  data:
+    $ref: ./ActorJob.yaml

--- a/apify-api/openapi/openapi.yaml
+++ b/apify-api/openapi/openapi.yaml
@@ -624,6 +624,11 @@ paths:
   /v2/users/me/limits:
     $ref: paths/users/users@me@limits.yaml
 components:
+  schemas:
+    ActorJob:
+      $ref: components/schemas/common/ActorJob.yaml
+    ActorJobResponse:
+      $ref: components/schemas/common/ActorJobResponse.yaml
   securitySchemes:
     httpBearer:
       $ref: components/securitySchemes/httpBearer.yaml


### PR DESCRIPTION
## Summary
- Adds `ActorJob` and `ActorJobResponse` schemas to `components/schemas/common/`
- References them from the root `openapi.yaml` components section so they're included in the bundled output
- These minimal schemas are needed for Actor job polling validation in the Python API client, which previously maintained them as custom internal models outside the spec

## Related
- Companion PR in apify-client-python will follow (removes the internal models module in favor of these generated ones)

## Test plan
- [x] `redocly bundle` produces valid output with both schemas present in `components.schemas`
- [ ] Verify the bundled spec passes `redocly lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds new schema definitions and references in the OpenAPI spec only, with no runtime behavior changes.
> 
> **Overview**
> Adds two minimal OpenAPI component schemas, `ActorJob` and `ActorJobResponse`, to represent an Actor run/build’s polling payload (status-only model plus a `data` wrapper).
> 
> Registers both schemas in the root `openapi.yaml` `components.schemas` so they are included in bundled spec outputs and available for client generation/validation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 078784352daf9f1bb60e0cf2593d9503ef34548f. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->