### PR TITLE
fix: Prevent H5 anchor link icon from shifting text on hover

### DIFF
--- a/apify-docs-theme/src/theme/Heading/styles.module.css
+++ b/apify-docs-theme/src/theme/Heading/styles.module.css
@@ -7,7 +7,9 @@
 }
 
 .headingCopyIcon {
-  display: none;
+  display: inline-block;
+  opacity: 0;
+  pointer-events: none;
   position: relative;
   left: .4rem;
   color: var(--ifm-color-emphasis-700);
@@ -24,27 +26,13 @@ h3:hover .headingCopyIcon,
 h4:hover .headingCopyIcon,
 h5:hover .headingCopyIcon,
 h6:hover .headingCopyIcon {
-  display: inline-block;
-}
-
-h5 .headingCopyIcon {
-  display: inline-block !important;
-  opacity: 0;
-  pointer-events: none;
-}
-
-h5:hover .headingCopyIcon {
-  opacity: 1;
-  pointer-events: auto;
-}
-
-h5 .headingCopyIcon.copied {
   opacity: 1;
   pointer-events: auto;
 }
 
 .headingCopyIcon.copied {
-  display: inline-block !important;
+  opacity: 1;
+  pointer-events: auto;
 }
 
 .headingCopyIcon.copied svg {
@@ -60,4 +48,3 @@ h5 .headingCopyIcon.copied {
   vertical-align: middle;
   line-height: 1;
 }
-


### PR DESCRIPTION
Use opacity instead of display toggling for H5 heading icons so the element stays in the flow at all times, keeping line height stable.

Fix for: https://apify.slack.com/archives/C0L33UM7Z/p1772032024184449

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only change scoped to `h5` heading icon hover behavior; minimal risk beyond potential minor styling regressions.
> 
> **Overview**
> Prevents `h5` heading anchor/link icons (`.headingCopyIcon`) from causing text/line-height shifts on hover by keeping the icon in the layout and toggling visibility via `opacity` and `pointer-events` instead of `display`.
> 
> Other heading levels (`h2`–`h4`, `h6`) keep the existing hover behavior, while the `copied` state remains forced visible.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 94eea770aeffc26cfe9e2a89a973fc12d8368418. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->