### PR TITLE
fix: do not render `<link rel=alternate` on versioned API reference pages

### DIFF
--- a/apify-docs-theme/src/theme/Layout/index.jsx
+++ b/apify-docs-theme/src/theme/Layout/index.jsx
@@ -17,11 +17,11 @@ export default function LayoutWrapper(props) {
 
     const allPluginData = {
         ...docsPluginData,
-        'typedoc-plugin-default': typedocPluginData
+        'typedoc-plugin-default': typedocPluginData,
     };
 
     const isVersionedPage = Object.values(allPluginData).some(
-        (pluginData) => pluginData.versions?.some((version) => !version.isLast && pathname.startsWith(version.path))
+        (pluginData) => pluginData.versions?.some((version) => !version.isLast && pathname.startsWith(version.path)),
     );
 
     const shouldRenderAlternateLink = currentPath && currentPath !== '404' && !isVersionedPage;


### PR DESCRIPTION
Checks the `docusaurus-plugin-typedoc-api` global data for available versions and only adds the markdown alternate link to "current" latest versions.

Check e.g. `lychee` check for 404 links on the `/next` pages in `apify-client-js` ([link](https://github.com/apify/apify-client-js/actions/runs/22395917589#summary-64829405227))

<img width="1326" height="818" alt="image" src="https://github.com/user-attachments/assets/29b79be0-7393-4fc6-925e-20929cfb8549" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small change to link-tag rendering that only broadens the versioned-page detection to include Typedoc plugin data, with minimal impact outside SEO/link metadata.
> 
> **Overview**
> Prevents rendering the markdown `rel="alternate"` link on versioned API reference routes by expanding the versioned-page check to also consider `docusaurus-plugin-typedoc-api` global data (in addition to regular docs versions).
> 
> This consolidates docs + typedoc plugin version metadata and uses optional chaining when checking `pluginData.versions`, avoiding 404 markdown alternate links on non-latest version pages.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 875061dbe4467e2a833b651c2fd12f543197bdf5. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->