### PR TITLE
fix(nginx): add redirects for client restructuring

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -526,6 +526,10 @@ server {
     rewrite ^/scraping/tutorial/introduction$ /academy/apify-scrapers/getting-started permanent;
     rewrite ^/scraping/tutorial/web-scraper$ /academy/apify-scrapers/web-scraper permanent;
 
+    # apify-client-js restructuring
+    rewrite ^/api/client/js/docs/getting-started$ /api/client/js/docs/introduction/quick-start permanent;
+    rewrite ^/api/client/js/docs/examples$ /api/client/js/docs/guides/examples permanent;
+
     # Articles moved from the platform documentation to the Academy
     # Web Scraping 101
     rewrite ^/platform/web-scraping-101$                              /academy/web-scraping-for-beginners redirect;
@@ -634,7 +638,13 @@ server {
 
     # Python docs
 
-    rewrite ^/api/client/python/docs$ /api/client/python/docs/overview/introduction permanent;
+    # apify-client-python restructuring
+
+    rewrite ^/api/client/python/docs/overview$ /api/client/python/docs permanent;
+    rewrite ^/api/client/python/docs/examples/passing-input-to-actor$ /api/client/python/docs/guides/passing-input-to-actor permanent;
+    rewrite ^/api/client/python/docs/examples/manage-tasks-for-reusable-input$ /api/client/python/docs/guides/manage-tasks-for-reusable-input permanent;
+    rewrite ^/api/client/python/docs/examples/retrieve-actor-data$ /api/client/python/docs/guides/retrieve-actor-data permanent;
+    rewrite ^/api/client/python/docs/examples/integration-with-data-libraries$ /api/client/python/docs/guides/integration-with-data-libraries permanent;
 
     # API docs reorganization
 


### PR DESCRIPTION
- [apify-client-js PR #850](https://github.com/apify/apify-client-js/pull/850): getting-started → introduction/quick-start, examples → guides/examples
- [apify-client-python #647](https://github.com/apify/apify-client-python/pull/647): overview → docs root, examples/* → guides/*
- Remove stale redirect of python /docs to non-existent /docs/overview/introduction