### PR TITLE
docs: correct Python client link in navigation menu

### DIFF
--- a/apify-docs-theme/src/config.js
+++ b/apify-docs-theme/src/config.js
@@ -59,7 +59,7 @@ const themeConfig = {
                     },
                     {
                         label: 'Client for Python',
-                        href: `${absoluteUrl}/api/client/python/docs/overview`,
+                        href: `${absoluteUrl}/api/client/python/docs`,
                         target: '_self',
                         rel: 'dofollow',
                     },
@@ -194,7 +194,7 @@ const themeConfig = {
                     },
                     {
                         label: 'Client for Python',
-                        href: `${absoluteUrl}/api/client/python/docs/overview`,
+                        href: `${absoluteUrl}/api/client/python/docs`,
                         target: '_self',
                         rel: 'dofollow',
                     },


### PR DESCRIPTION
## Summary
- Fix the "Client for Python" link in both the navbar and footer to point to `/api/client/python/docs` instead of `/api/client/python/docs/overview`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: updates two hardcoded documentation URLs in the theme config; no runtime logic or data handling changes.
> 
> **Overview**
> Fixes the **"Client for Python"** documentation link in both the navbar and footer to point to `.../api/client/python/docs` (removing the outdated `/overview` suffix), preventing navigation to a non-canonical/incorrect page.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b0857fdd3d04da98e4252d0fa6c1952c40530cc6. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->