### PR TITLE
ci: trigger Python client model regeneration on OpenAPI spec changes

### DIFF
--- a/.github/workflows/openapi-ci.yaml
+++ b/.github/workflows/openapi-ci.yaml
@@ -120,3 +120,30 @@ jobs:
                     exit 1
                   fi
                   echo "✓ Bundles have valid sizes"
+
+    trigger-client-model-regeneration:
+        name: Trigger Python client model regeneration
+        runs-on: ubuntu-latest
+        needs: [validate]
+        if: github.event_name == 'pull_request'
+
+        steps:
+            - uses: actions/checkout@v6
+
+            - name: Check if OpenAPI files changed
+              uses: dorny/paths-filter@v3
+              id: filter
+              with:
+                  filters: |
+                      openapi:
+                          - 'apify-api/openapi/**'
+
+            - name: Trigger apify-client-python model regeneration
+              if: steps.filter.outputs.openapi == 'true'
+              run: |
+                  gh workflow run regenerate_models.yaml \
+                      --repo apify/apify-client-python \
+                      --field docs_pr_number=${{ github.event.pull_request.number }} \
+                      --field docs_pr_branch=${{ github.head_ref }}
+              env:
+                  GITHUB_TOKEN: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- Add a `trigger-client-model-regeneration` job to `openapi-ci.yaml`
- Detects OpenAPI file changes in PRs using `dorny/paths-filter` (path: `apify-api/openapi/**`)
- Triggers `regenerate_models.yaml` workflow in `apify/apify-client-python` via `gh workflow run`
- Uses `APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN` for cross-repo trigger (existing pattern)

## How it works

```
PR in apify-docs (changes openapi specs)
  → openapi-ci.yaml: lint → build → validate → trigger-client-model-regeneration
    → gh workflow run regenerate_models.yaml in apify-client-python
      → Build spec from PR branch → datamodel-codegen → PR + comment on docs PR
```

## Related

- apify-client-python counterpart: https://github.com/apify/apify-client-python/pull/657

## Test plan

- [ ] Merge the apify-client-python counterpart first (workflow must exist on default branch)
- [ ] Then merge this PR
- [ ] Create a test PR that changes files in `apify-api/openapi/`
- [ ] Verify the trigger fires and creates a PR in apify-client-python

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 9dac315f4c27546fb30fba90c5a3a33d7cc11b2b. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->