### PR TITLE
chore: remove unused NPM_TOKEN from CI workflows

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -35,7 +35,6 @@ jobs:
                     npm run build
                 env:
                     APIFY_SIGNING_TOKEN: ${{ secrets.APIFY_SIGNING_TOKEN }}
-                    NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
                     INTERCOM_APP_ID: ${{ secrets.INTERCOM_APP_ID }}
                     SEGMENT_TOKEN: ${{ secrets.SEGMENT_TOKEN }}
 

--- a/.github/workflows/lychee.yml
+++ b/.github/workflows/lychee.yml
@@ -28,7 +28,6 @@ jobs:
                     npm run build
                 env:
                     APIFY_SIGNING_TOKEN: ${{ secrets.APIFY_SIGNING_TOKEN }}
-                    NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
                     INTERCOM_APP_ID: ${{ secrets.INTERCOM_APP_ID }}
                     SEGMENT_TOKEN: ${{ secrets.SEGMENT_TOKEN }}
 

--- a/.github/workflows/openapi-ci.yaml
+++ b/.github/workflows/openapi-ci.yaml
@@ -26,8 +26,6 @@ jobs:
 
             - name: Install dependencies
               run: npm ci --force
-              env:
-                  NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
             - name: Lint with Redocly
               run: npm run openapi:lint:redocly -- --format=github-actions
@@ -58,8 +56,6 @@ jobs:
 
             - name: Install dependencies
               run: npm ci --force
-              env:
-                  NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
             - name: Build bundles
               run: npm run openapi:build
@@ -93,8 +89,6 @@ jobs:
 
             - name: Install dependencies
               run: npm ci --force
-              env:
-                  NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
             - name: Download bundles
               uses: actions/download-artifact@v8

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -26,8 +26,6 @@ jobs:
 
             -   name: Install Dependencies
                 run: npm ci --force
-                env:
-                    NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
             -   run: npm run build
                 env:
@@ -157,8 +155,6 @@ jobs:
 
             -   name: Install Dependencies
                 run: npm ci --force
-                env:
-                    NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
             -   name: List and Lint Changed Markdown Files
                 env:
@@ -190,7 +186,5 @@ jobs:
 
             -   name: Install Dependencies
                 run: npm ci --force
-                env:
-                    NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
             -   run: npm run lint:code


### PR DESCRIPTION
## Summary
- Removed `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}` from all 4 CI workflow files (8 occurrences total)
- All `@apify/*` packages resolve to the public npm registry (`registry.npmjs.org`) and `.npmrc` has no private registry config, so this token was never needed

## Test plan
- [ ] CI workflows pass without the token (build, lint, openapi, lychee jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)