### PR TITLE
fix: resolve Dependabot security alerts and fix build for lockfile updates

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -255,6 +255,11 @@ module.exports = {
             name: 'webpack-loader-fix',
             configureWebpack() {
                 return {
+                    resolve: {
+                        fallback: {
+                            path: require.resolve('path-browserify'),
+                        },
+                    },
                     module: {
                         rules: [
                             {

--- a/package-lock.json
+++ b/package-lock.json
@@ -65,7 +65,7 @@
         },
         "apify-docs-theme": {
             "name": "@apify/docs-theme",
-            "version": "1.0.239",
+            "version": "1.0.240",
             "license": "ISC",
             "dependencies": {
                 "@apify/docs-search-modal": "^1.3.3",
@@ -6446,28 +6446,31 @@
             }
         },
         "node_modules/@emnapi/core": {
-            "version": "1.8.1",
-            "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.8.1.tgz",
-            "integrity": "sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg==",
+            "version": "1.9.0",
+            "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.0.tgz",
+            "integrity": "sha512-0DQ98G9ZQZOxfUcQn1waV2yS8aWdZ6kJMbYCJB3oUBecjWYO1fqJ+a1DRfPF3O5JEkwqwP1A9QEN/9mYm2Yd0w==",
+            "license": "MIT",
             "optional": true,
             "dependencies": {
-                "@emnapi/wasi-threads": "1.1.0",
+                "@emnapi/wasi-threads": "1.2.0",
                 "tslib": "^2.4.0"
             }
         },
         "node_modules/@emnapi/runtime": {
-            "version": "1.8.1",
-            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.8.1.tgz",
-            "integrity": "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==",
+            "version": "1.9.0",
+            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.0.tgz",
+            "integrity": "sha512-QN75eB0IH2ywSpRpNddCRfQIhmJYBCJ1x5Lb3IscKAL8bMnVAKnRg8dCoXbHzVLLH7P38N2Z3mtulB7W0J0FKw==",
+            "license": "MIT",
             "optional": true,
             "dependencies": {
                 "tslib": "^2.4.0"
             }
         },
         "node_modules/@emnapi/wasi-threads": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.1.0.tgz",
-            "integrity": "sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==",
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.0.tgz",
+            "integrity": "sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==",
+            "license": "MIT",
             "optional": true,
             "dependencies": {
                 "tslib": "^2.4.0"
@@ -6575,18 +6578,6 @@
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             }
         },
-        "node_modules/@eslint/config-array/node_modules/minimatch": {
-            "version": "3.1.5",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-            "dev": true,
-            "dependencies": {
-                "brace-expansion": "^1.1.7"
-            },
-            "engines": {
-                "node": "*"
-            }
-        },
         "node_modules/@eslint/config-helpers": {
             "version": "0.4.2",
             "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
@@ -6667,18 +6658,6 @@
             "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
             "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
             "dev": true
-        },
-        "node_modules/@eslint/eslintrc/node_modules/minimatch": {
-            "version": "3.1.5",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-            "dev": true,
-            "dependencies": {
-                "brace-expansion": "^1.1.7"
-            },
-            "engines": {
-                "node": "*"
-            }
         },
         "node_modules/@eslint/js": {
             "version": "9.39.4",
@@ -7491,6 +7470,7 @@
             "version": "1.0.7",
             "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.0.7.tgz",
             "integrity": "sha512-SeDnOO0Tk7Okiq6DbXmmBODgOAb9dp9gjlphokTUxmt8U3liIP1ZsozBahH69j/RJv+Rfs6IwUKHTgQYJ/HBAw==",
+            "license": "MIT",
             "optional": true,
             "dependencies": {
                 "@emnapi/core": "^1.5.0",
@@ -7778,6 +7758,7 @@
             "cpu": [
                 "arm64"
             ],
+            "license": "MIT",
             "optional": true,
             "os": [
                 "android"
@@ -7816,6 +7797,7 @@
             "cpu": [
                 "x64"
             ],
+            "license": "MIT",
             "optional": true,
             "os": [
                 "darwin"
@@ -7835,6 +7817,7 @@
             "cpu": [
                 "x64"
             ],
+            "license": "MIT",
             "optional": true,
             "os": [
                 "freebsd"
@@ -7854,6 +7837,7 @@
             "cpu": [
                 "arm"
             ],
+            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
@@ -7873,6 +7857,7 @@
             "cpu": [
                 "arm"
             ],
+            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
@@ -7892,6 +7877,7 @@
             "cpu": [
                 "arm64"
             ],
+            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
@@ -7911,6 +7897,7 @@
             "cpu": [
                 "arm64"
             ],
+            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
@@ -7930,6 +7917,7 @@
             "cpu": [
                 "x64"
             ],
+            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
@@ -7949,6 +7937,7 @@
             "cpu": [
                 "x64"
             ],
+            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
@@ -7968,6 +7957,7 @@
             "cpu": [
                 "arm64"
             ],
+            "license": "MIT",
             "optional": true,
             "os": [
                 "win32"
@@ -7987,6 +7977,7 @@
             "cpu": [
                 "ia32"
             ],
+            "license": "MIT",
             "optional": true,
             "os": [
                 "win32"
@@ -8006,6 +7997,7 @@
             "cpu": [
                 "x64"
             ],
+            "license": "MIT",
             "optional": true,
             "os": [
                 "win32"
@@ -8612,6 +8604,7 @@
             "cpu": [
                 "x64"
             ],
+            "license": "MIT",
             "optional": true,
             "os": [
                 "darwin"
@@ -8624,6 +8617,7 @@
             "cpu": [
                 "arm64"
             ],
+            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
@@ -8636,6 +8630,7 @@
             "cpu": [
                 "arm64"
             ],
+            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
@@ -8648,6 +8643,7 @@
             "cpu": [
                 "x64"
             ],
+            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
@@ -8660,6 +8656,7 @@
             "cpu": [
                 "x64"
             ],
+            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
@@ -8672,6 +8669,7 @@
             "cpu": [
                 "wasm32"
             ],
+            "license": "MIT",
             "optional": true,
             "dependencies": {
                 "@napi-rs/wasm-runtime": "1.0.7"
@@ -8684,6 +8682,7 @@
             "cpu": [
                 "arm64"
             ],
+            "license": "MIT",
             "optional": true,
             "os": [
                 "win32"
@@ -8696,6 +8695,7 @@
             "cpu": [
                 "ia32"
             ],
+            "license": "MIT",
             "optional": true,
             "os": [
                 "win32"
@@ -8708,6 +8708,7 @@
             "cpu": [
                 "x64"
             ],
+            "license": "MIT",
             "optional": true,
             "os": [
                 "win32"
@@ -9709,6 +9710,7 @@
             "cpu": [
                 "x64"
             ],
+            "license": "Apache-2.0 AND MIT",
             "optional": true,
             "os": [
                 "darwin"
@@ -9724,6 +9726,7 @@
             "cpu": [
                 "arm"
             ],
+            "license": "Apache-2.0",
             "optional": true,
             "os": [
                 "linux"
@@ -9739,6 +9742,7 @@
             "cpu": [
                 "arm64"
             ],
+            "license": "Apache-2.0 AND MIT",
             "optional": true,
             "os": [
                 "linux"
@@ -9754,6 +9758,7 @@
             "cpu": [
                 "arm64"
             ],
+            "license": "Apache-2.0 AND MIT",
             "optional": true,
             "os": [
                 "linux"
@@ -9769,6 +9774,7 @@
             "cpu": [
                 "x64"
             ],
+            "license": "Apache-2.0 AND MIT",
             "optional": true,
             "os": [
                 "linux"
@@ -9784,6 +9790,7 @@
             "cpu": [
                 "x64"
             ],
+            "license": "Apache-2.0 AND MIT",
             "optional": true,
             "os": [
                 "linux"
@@ -9799,6 +9806,7 @@
             "cpu": [
                 "arm64"
             ],
+            "license": "Apache-2.0 AND MIT",
             "optional": true,
             "os": [
                 "win32"
@@ -9814,6 +9822,7 @@
             "cpu": [
                 "ia32"
             ],
+            "license": "Apache-2.0 AND MIT",
             "optional": true,
             "os": [
                 "win32"
@@ -9829,6 +9838,7 @@
             "cpu": [
                 "x64"
             ],
+            "license": "Apache-2.0 AND MIT",
             "optional": true,
             "os": [
                 "win32"
@@ -9887,6 +9897,7 @@
             "cpu": [
                 "x64"
             ],
+            "license": "Apache-2.0 AND MIT",
             "optional": true,
             "os": [
                 "darwin"
@@ -9902,6 +9913,7 @@
             "cpu": [
                 "arm"
             ],
+            "license": "Apache-2.0",
             "optional": true,
             "os": [
                 "linux"
@@ -9917,6 +9929,7 @@
             "cpu": [
                 "arm64"
             ],
+            "license": "Apache-2.0 AND MIT",
             "optional": true,
             "os": [
                 "linux"
@@ -9932,6 +9945,7 @@
             "cpu": [
                 "arm64"
             ],
+            "license": "Apache-2.0 AND MIT",
             "optional": true,
             "os": [
                 "linux"
@@ -9947,6 +9961,7 @@
             "cpu": [
                 "x64"
             ],
+            "license": "Apache-2.0 AND MIT",
             "optional": true,
             "os": [
                 "linux"
@@ -9962,6 +9977,7 @@
             "cpu": [
                 "x64"
             ],
+            "license": "Apache-2.0 AND MIT",
             "optional": true,
             "os": [
                 "linux"
@@ -9977,6 +9993,7 @@
             "cpu": [
                 "arm64"
             ],
+            "license": "Apache-2.0 AND MIT",
             "optional": true,
             "os": [
                 "win32"
@@ -9992,6 +10009,7 @@
             "cpu": [
                 "ia32"
             ],
+            "license": "Apache-2.0 AND MIT",
             "optional": true,
             "os": [
                 "win32"
@@ -10007,6 +10025,7 @@
             "cpu": [
                 "x64"
             ],
+            "license": "Apache-2.0 AND MIT",
             "optional": true,
             "os": [
                 "win32"
@@ -10038,6 +10057,7 @@
             "version": "0.10.1",
             "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
             "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+            "license": "MIT",
             "optional": true,
             "dependencies": {
                 "tslib": "^2.4.0"
@@ -15315,18 +15335,6 @@
             "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
             "dev": true
         },
-        "node_modules/eslint/node_modules/minimatch": {
-            "version": "3.1.5",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-            "dev": true,
-            "dependencies": {
-                "brace-expansion": "^1.1.7"
-            },
-            "engines": {
-                "node": "*"
-            }
-        },
         "node_modules/espree": {
             "version": "10.4.0",
             "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
@@ -18788,6 +18796,7 @@
             "cpu": [
                 "arm64"
             ],
+            "license": "MPL-2.0",
             "optional": true,
             "os": [
                 "android"
@@ -18826,6 +18835,7 @@
             "cpu": [
                 "x64"
             ],
+            "license": "MPL-2.0",
             "optional": true,
             "os": [
                 "darwin"
@@ -18845,6 +18855,7 @@
             "cpu": [
                 "x64"
             ],
+            "license": "MPL-2.0",
             "optional": true,
             "os": [
                 "freebsd"
@@ -18864,6 +18875,7 @@
             "cpu": [
                 "arm"
             ],
+            "license": "MPL-2.0",
             "optional": true,
             "os": [
                 "linux"
@@ -18883,6 +18895,7 @@
             "cpu": [
                 "arm64"
             ],
+            "license": "MPL-2.0",
             "optional": true,
             "os": [
                 "linux"
@@ -18902,6 +18915,7 @@
             "cpu": [
                 "arm64"
             ],
+            "license": "MPL-2.0",
             "optional": true,
             "os": [
                 "linux"
@@ -18921,6 +18935,7 @@
             "cpu": [
                 "x64"
             ],
+            "license": "MPL-2.0",
             "optional": true,
             "os": [
                 "linux"
@@ -18940,6 +18955,7 @@
             "cpu": [
                 "x64"
             ],
+            "license": "MPL-2.0",
             "optional": true,
             "os": [
                 "linux"
@@ -18959,6 +18975,7 @@
             "cpu": [
                 "arm64"
             ],
+            "license": "MPL-2.0",
             "optional": true,
             "os": [
                 "win32"
@@ -18978,6 +18995,7 @@
             "cpu": [
                 "x64"
             ],
+            "license": "MPL-2.0",
             "optional": true,
             "os": [
                 "win32"
@@ -21773,9 +21791,10 @@
             "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
         },
         "node_modules/minimatch": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+            "license": "ISC",
             "dependencies": {
                 "brace-expansion": "^1.1.7"
             },
@@ -26301,10 +26320,11 @@
             "integrity": "sha512-IXgzBWvWQwE6PrDI05OvmXUIruQTcoMDzRsOd5CDvHCVLcLHMTSYvOK5Cm46kWqlV3yAbuSpBZdJ5oP5OUoStg=="
         },
         "node_modules/rollup": {
-            "version": "2.79.2",
-            "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.2.tgz",
-            "integrity": "sha512-fS6iqSPZDs3dr/y7Od6y5nha8dW1YnbgtsyotCVvoFGKbERG++CVRFv1meyGDE1SNItQA8BrnCw7ScdAhRJ3XQ==",
+            "version": "2.80.0",
+            "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.80.0.tgz",
+            "integrity": "sha512-cIFJOD1DESzpjOBl763Kp1AH7UE/0fcdHe6rZXUdQ9c50uvgigvW97u3IcSeBwOkgqL/PXPBktBCh0KEu5L8XQ==",
             "dev": true,
+            "license": "MIT",
             "bin": {
                 "rollup": "dist/bin/rollup"
             },
@@ -26724,11 +26744,12 @@
             }
         },
         "node_modules/serialize-javascript": {
-            "version": "6.0.2",
-            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-            "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
-            "dependencies": {
-                "randombytes": "^2.1.0"
+            "version": "7.0.4",
+            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.4.tgz",
+            "integrity": "sha512-DuGdB+Po43Q5Jxwpzt1lhyFSYKryqoNjQSA9M92tyw0lyHIOur+XCalOUe0KTJpyqzT8+fQ5A0Jf7vCx/NKmIg==",
+            "license": "BSD-3-Clause",
+            "engines": {
+                "node": ">=20.0.0"
             }
         },
         "node_modules/serve-handler": {
@@ -26762,17 +26783,6 @@
             },
             "engines": {
                 "node": ">= 0.6"
-            }
-        },
-        "node_modules/serve-handler/node_modules/minimatch": {
-            "version": "3.1.5",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-            "dependencies": {
-                "brace-expansion": "^1.1.7"
-            },
-            "engines": {
-                "node": "*"
             }
         },
         "node_modules/serve-handler/node_modules/path-to-regexp": {

--- a/package.json
+++ b/package.json
@@ -116,6 +116,18 @@
     "overrides": {
         "openapi-to-postmanv2": {
             "js-yaml": "4.1.1"
+        },
+        "@stoplight/spectral-core": {
+            "minimatch": "3.1.5"
+        },
+        "copy-webpack-plugin": {
+            "serialize-javascript": "^7.0.4"
+        },
+        "css-minimizer-webpack-plugin": {
+            "serialize-javascript": "^7.0.4"
+        },
+        "@stoplight/spectral-ruleset-bundler": {
+            "rollup": "2.80.0"
         }
     }
 }


### PR DESCRIPTION
## Summary

- Add `resolve.fallback` for `path` → `path-browserify` in webpack config to fix build breakage caused by `postman-code-generators@2.1.1` dropping its `path` polyfill dependency (was present in 2.1.0, removed in 2.1.1). This unblocks the Renovate lockfile update PR (#2325) and prevents future lockfile updates from breaking the build.
- Add targeted overrides for 3 transitive dependencies pinned to vulnerable version ranges that can't be resolved by a lockfile refresh alone:
  - `@stoplight/spectral-core` → `minimatch: 3.1.5` (pinned to exact `3.1.2`, ReDoS)
  - `copy-webpack-plugin` + `css-minimizer-webpack-plugin` → `serialize-javascript: ^7.0.4` (range `^6.x` excludes fix at 7.0.3+, RCE)
  - `@stoplight/spectral-ruleset-bundler` → `rollup: 2.80.0` (range `~2.79.2` excludes fix at 2.80.0, path traversal)
- Regenerate lockfile to pick up patched versions for deps with already-compatible ranges (minimatch in eslint plugins/glob, etc.)

Resolves Dependabot alerts: #152, #154, #157, #160, #162

## Test plan

- [x] `npm run build` passes locally
- [ ] CI docs build passes
- [ ] Verify Dependabot alerts are dismissed after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)