### PR TITLE
docs(openapi): Storage related fixes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,6 +53,7 @@ Add code samples by creating files in `apify-api/openapi/code_samples/{javascrip
 
 ### OpenAPI specification changes
 
+- Target OpenAPI specification version should be extracted from `/openapi/openapi.yaml`. All specification changes should be compliant with syntax for that specific OpenAPI specification version.
 - Prefer re-use of existing objects via `$ref` over duplication. Reusable components can be found in `/openapi/components`.
 - Components most suitable for re-use are:
   - Request parameters and path parameters defined in  `/openapi/components/parameters`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -196,7 +196,7 @@ The API reference documentation at [docs.apify.com/api/v2](https://docs.apify.co
 
 We use the following tools for API documentation:
 
-- **[OpenAPI 3.0](https://spec.openapis.org/oas/v3.0.3)** - API specification format
+- **[OpenAPI 3.1.2](https://spec.openapis.org/oas/v3.1.2.html)** - API specification format
 - **[Redocly CLI](https://redocly.com/docs/cli/)** - Linting and validation of OpenAPI specs
 - **[`docusaurus-plugin-openapi-docs`](https://github.com/PaloAltoNetworks/docusaurus-openapi-docs)** - Generates MDX docs from OpenAPI
 - **[`docusaurus-theme-openapi-docs`](https://github.com/PaloAltoNetworks/docusaurus-openapi-docs)** - Renders API reference with interactive explorer

--- a/apify-api/openapi/components/headers/ApifyPaginationHeaders.yaml
+++ b/apify-api/openapi/components/headers/ApifyPaginationHeaders.yaml
@@ -1,0 +1,28 @@
+X-Apify-Pagination-Offset:
+  description: The offset of the first item in the current page.
+  content:
+    text/plain:
+      schema:
+        type: string
+      example: "0"
+X-Apify-Pagination-Limit:
+  description: The maximum number of items returned per page.
+  content:
+    text/plain:
+      schema:
+        type: string
+      example: "100"
+X-Apify-Pagination-Count:
+  description: The number of items returned in the current page.
+  content:
+    text/plain:
+      schema:
+        type: string
+      example: "100"
+X-Apify-Pagination-Total:
+  description: The total number of items in the dataset.
+  content:
+    text/plain:
+      schema:
+        type: string
+      example: "10204"

--- a/apify-api/openapi/components/objects/actors/acts@{actorId}@versions@{versionNumber}@env-vars@{envVarName}put.yaml
+++ b/apify-api/openapi/components/objects/actors/acts@{actorId}@versions@{versionNumber}@env-vars@{envVarName}put.yaml
@@ -1,64 +1,105 @@
-tags:
-  - Actors/Actor versions
-parameters:
-  - $ref: "../../parameters/runAndBuildParameters.yaml#/actorId"
-  - $ref: "../../parameters/runAndBuildParameters.yaml#/versionNumber"
-  - name: envVarName
-    in: path
-    description: The name of the environment variable
-    required: true
-    style: simple
-    schema:
-      type: string
-      example: MY_ENV_VAR
-requestBody:
-  description: ""
-  content:
-    application/json:
+shared: &shared
+  tags:
+    - Actors/Actor versions
+  parameters:
+    - $ref: "../../parameters/runAndBuildParameters.yaml#/actorId"
+    - $ref: "../../parameters/runAndBuildParameters.yaml#/versionNumber"
+    - name: envVarName
+      in: path
+      description: The name of the environment variable
+      required: true
+      style: simple
       schema:
-        $ref: ../../schemas/actors/EnvVar.yaml
-      example:
-        name: MY_ENV_VAR
-        value: my-new-value
-        isSecret: false
-  required: true
-responses:
-  "200":
+        type: string
+        example: MY_ENV_VAR
+  requestBody:
     description: ""
-    headers: {}
     content:
       application/json:
         schema:
-          $ref: ../../schemas/actors/EnvVarResponse.yaml
+          $ref: ../../schemas/actors/EnvVar.yaml
         example:
-          data:
-            name: MY_ENV_VAR
-            value: my-value
-            isSecret: false
-  "400":
-    $ref: ../../responses/BadRequest.yaml
-  "401":
-    $ref: ../../responses/Unauthorized.yaml
-  "403":
-    $ref: ../../responses/Forbidden.yaml
-  "404":
-    description: Not found - the requested resource was not found.
-    content:
-      application/json:
-        schema:
-          oneOf:
-            - $ref: "../../schemas/common/errors/ActorErrors.yaml#/ActorNotFoundError"
-            - $ref: "../../schemas/common/errors/ActorErrors.yaml#/ActorVersionNotFoundError"
-            - $ref: "../../schemas/common/errors/EnvVariableErrors.yaml#/EnvironmentVariableNotFoundError"
-  "405":
-    $ref: ../../responses/MethodNotAllowed.yaml
-  "413":
-    $ref: ../../responses/PayloadTooLarge.yaml
-  "415":
-    $ref: ../../responses/UnsupportedMediaType.yaml
-  "429":
-    $ref: ../../responses/TooManyRequests.yaml
-deprecated: false
-x-py-parent: ActorEnvVarClientAsync
-x-py-name: update
-x-py-doc-url: https://docs.apify.com/api/client/python/reference/class/ActorEnvVarClientAsync#update
+          name: MY_ENV_VAR
+          value: my-new-value
+          isSecret: false
+    required: true
+  responses:
+    "200":
+      description: ""
+      headers: {}
+      content:
+        application/json:
+          schema:
+            $ref: ../../schemas/actors/EnvVarResponse.yaml
+          example:
+            data:
+              name: MY_ENV_VAR
+              value: my-value
+              isSecret: false
+    "400":
+      $ref: ../../responses/BadRequest.yaml
+    "401":
+      $ref: ../../responses/Unauthorized.yaml
+    "403":
+      $ref: ../../responses/Forbidden.yaml
+    "404":
+      description: Not found - the requested resource was not found.
+      content:
+        application/json:
+          schema:
+            oneOf:
+              - $ref: "../../schemas/common/errors/ActorErrors.yaml#/ActorNotFoundError"
+              - $ref: "../../schemas/common/errors/ActorErrors.yaml#/ActorVersionNotFoundError"
+              - $ref: "../../schemas/common/errors/EnvVariableErrors.yaml#/EnvironmentVariableNotFoundError"
+    "405":
+      $ref: ../../responses/MethodNotAllowed.yaml
+    "413":
+      $ref: ../../responses/PayloadTooLarge.yaml
+    "415":
+      $ref: ../../responses/UnsupportedMediaType.yaml
+    "429":
+      $ref: ../../responses/TooManyRequests.yaml
+  deprecated: false
+  x-py-parent: ActorEnvVarClientAsync
+  x-py-name: update
+  x-py-doc-url: https://docs.apify.com/api/client/python/reference/class/ActorEnvVarClientAsync#update
+
+put:
+  <<: *shared
+  summary: Update environment variable
+  description: |
+    Updates Actor environment variable using values specified by a [EnvVar
+    object](#/reference/actors/environment-variable-object)
+    passed as JSON in the POST payload.
+    If the object does not define a specific property, its value will not be
+    updated.
+
+    The request needs to specify the `Content-Type: application/json` HTTP
+    header!
+
+    When providing your API authentication token, we recommend using the
+    request's `Authorization` header, rather than the URL. ([More
+    info](#/introduction/authentication)).
+
+    The response is the [EnvVar object](#/reference/actors/environment-variable-object) as returned by the
+    [Get environment variable](#/reference/actors/environment-variable-object/get-environment-variable)
+    endpoint.
+  operationId: act_version_envVar_put
+  x-legacy-doc-urls:
+    - https://docs.apify.com/api/v2#/reference/actors/environment-variable-object/update-environment-variable
+    - https://docs.apify.com/api/v2#/reference/actors/update-environment-variable
+    - https://docs.apify.com/api/v2#tag/ActorsEnvironment-variable-object/operation/act_version_envVar_put
+
+post:
+  <<: *shared
+  summary: Update environment variable (POST)
+  description: |
+    Updates Actor environment variable using values specified by a [EnvVar
+    object](#/reference/actors/environment-variable-object)
+    passed as JSON in the POST payload.
+    This endpoint is an alias for the [`PUT` update environment variable](#tag/ActorsEnvironment-variable-object/operation/act_version_envVar_put) method and behaves identically.
+  operationId: act_version_envVar_post
+  x-legacy-doc-urls:
+    - https://docs.apify.com/api/v2#/reference/actors/environment-variable-object/update-environment-variable
+    - https://docs.apify.com/api/v2#/reference/actors/update-environment-variable
+    - https://docs.apify.com/api/v2#tag/ActorsEnvironment-variable-object/operation/act_version_envVar_post

--- a/apify-api/openapi/components/objects/actors/acts@{actorId}@versions@{versionNumber}@env-vars@{envVarName}put.yaml
+++ b/apify-api/openapi/components/objects/actors/acts@{actorId}@versions@{versionNumber}@env-vars@{envVarName}put.yaml
@@ -1,0 +1,64 @@
+tags:
+  - Actors/Actor versions
+parameters:
+  - $ref: "../../parameters/runAndBuildParameters.yaml#/actorId"
+  - $ref: "../../parameters/runAndBuildParameters.yaml#/versionNumber"
+  - name: envVarName
+    in: path
+    description: The name of the environment variable
+    required: true
+    style: simple
+    schema:
+      type: string
+      example: MY_ENV_VAR
+requestBody:
+  description: ""
+  content:
+    application/json:
+      schema:
+        $ref: ../../schemas/actors/EnvVar.yaml
+      example:
+        name: MY_ENV_VAR
+        value: my-new-value
+        isSecret: false
+  required: true
+responses:
+  "200":
+    description: ""
+    headers: {}
+    content:
+      application/json:
+        schema:
+          $ref: ../../schemas/actors/EnvVarResponse.yaml
+        example:
+          data:
+            name: MY_ENV_VAR
+            value: my-value
+            isSecret: false
+  "400":
+    $ref: ../../responses/BadRequest.yaml
+  "401":
+    $ref: ../../responses/Unauthorized.yaml
+  "403":
+    $ref: ../../responses/Forbidden.yaml
+  "404":
+    description: Not found - the requested resource was not found.
+    content:
+      application/json:
+        schema:
+          oneOf:
+            - $ref: "../../schemas/common/errors/ActorErrors.yaml#/ActorNotFoundError"
+            - $ref: "../../schemas/common/errors/ActorErrors.yaml#/ActorVersionNotFoundError"
+            - $ref: "../../schemas/common/errors/EnvVariableErrors.yaml#/EnvironmentVariableNotFoundError"
+  "405":
+    $ref: ../../responses/MethodNotAllowed.yaml
+  "413":
+    $ref: ../../responses/PayloadTooLarge.yaml
+  "415":
+    $ref: ../../responses/UnsupportedMediaType.yaml
+  "429":
+    $ref: ../../responses/TooManyRequests.yaml
+deprecated: false
+x-py-parent: ActorEnvVarClientAsync
+x-py-name: update
+x-py-doc-url: https://docs.apify.com/api/client/python/reference/class/ActorEnvVarClientAsync#update

--- a/apify-api/openapi/components/objects/actors/acts@{actorId}@versions@{versionNumber}put.yaml
+++ b/apify-api/openapi/components/objects/actors/acts@{actorId}@versions@{versionNumber}put.yaml
@@ -1,0 +1,57 @@
+tags:
+  - Actors/Actor versions
+parameters:
+  - $ref: "../../parameters/runAndBuildParameters.yaml#/actorId"
+  - $ref: "../../parameters/runAndBuildParameters.yaml#/versionNumber"
+requestBody:
+  description: ""
+  content:
+    application/json:
+      schema:
+        $ref: ../../schemas/actors/CreateOrUpdateVersionRequest.yaml
+      example:
+        versionNumber: "0.0"
+        sourceType: SOURCE_FILES
+        envVars:
+          - name: DOMAIN
+            value: http://example.com
+            isSecret: false
+          - name: SECRET_PASSWORD
+            value: MyTopSecretPassword123
+            isSecret: true
+        applyEnvVarsToBuild: false
+        buildTag: latest
+        sourceFiles: []
+  required: true
+responses:
+  "200":
+    description: ""
+    headers: {}
+    content:
+      application/json:
+        schema:
+          $ref: ../../schemas/actors/VersionResponse.yaml
+  "400":
+    $ref: ../../responses/BadRequest.yaml
+  "401":
+    $ref: ../../responses/Unauthorized.yaml
+  "403":
+    $ref: ../../responses/Forbidden.yaml
+  "404":
+    description: Not found - the requested resource was not found.
+    content:
+      application/json:
+        schema:
+          $ref: "../../schemas/common/errors/ActorErrors.yaml#/ActorNotFoundError"
+  "405":
+    $ref: ../../responses/MethodNotAllowed.yaml
+  "413":
+    $ref: ../../responses/PayloadTooLarge.yaml
+  "415":
+    $ref: ../../responses/UnsupportedMediaType.yaml
+  "429":
+    $ref: ../../responses/TooManyRequests.yaml
+deprecated: false
+x-py-parent: ActorVersionClientAsync
+x-py-name: update
+x-py-doc-url: https://docs.apify.com/api/client/python/reference/class/ActorVersionClientAsync#update

--- a/apify-api/openapi/components/objects/actors/acts@{actorId}@versions@{versionNumber}put.yaml
+++ b/apify-api/openapi/components/objects/actors/acts@{actorId}@versions@{versionNumber}put.yaml
@@ -1,57 +1,94 @@
-tags:
-  - Actors/Actor versions
-parameters:
-  - $ref: "../../parameters/runAndBuildParameters.yaml#/actorId"
-  - $ref: "../../parameters/runAndBuildParameters.yaml#/versionNumber"
-requestBody:
-  description: ""
-  content:
-    application/json:
-      schema:
-        $ref: ../../schemas/actors/CreateOrUpdateVersionRequest.yaml
-      example:
-        versionNumber: "0.0"
-        sourceType: SOURCE_FILES
-        envVars:
-          - name: DOMAIN
-            value: http://example.com
-            isSecret: false
-          - name: SECRET_PASSWORD
-            value: MyTopSecretPassword123
-            isSecret: true
-        applyEnvVarsToBuild: false
-        buildTag: latest
-        sourceFiles: []
-  required: true
-responses:
-  "200":
+shared: &shared
+  tags:
+    - Actors/Actor versions
+  parameters:
+    - $ref: "../../parameters/runAndBuildParameters.yaml#/actorId"
+    - $ref: "../../parameters/runAndBuildParameters.yaml#/versionNumber"
+  requestBody:
     description: ""
-    headers: {}
     content:
       application/json:
         schema:
-          $ref: ../../schemas/actors/VersionResponse.yaml
-  "400":
-    $ref: ../../responses/BadRequest.yaml
-  "401":
-    $ref: ../../responses/Unauthorized.yaml
-  "403":
-    $ref: ../../responses/Forbidden.yaml
-  "404":
-    description: Not found - the requested resource was not found.
-    content:
-      application/json:
-        schema:
-          $ref: "../../schemas/common/errors/ActorErrors.yaml#/ActorNotFoundError"
-  "405":
-    $ref: ../../responses/MethodNotAllowed.yaml
-  "413":
-    $ref: ../../responses/PayloadTooLarge.yaml
-  "415":
-    $ref: ../../responses/UnsupportedMediaType.yaml
-  "429":
-    $ref: ../../responses/TooManyRequests.yaml
-deprecated: false
-x-py-parent: ActorVersionClientAsync
-x-py-name: update
-x-py-doc-url: https://docs.apify.com/api/client/python/reference/class/ActorVersionClientAsync#update
+          $ref: ../../schemas/actors/CreateOrUpdateVersionRequest.yaml
+        example:
+          versionNumber: "0.0"
+          sourceType: SOURCE_FILES
+          envVars:
+            - name: DOMAIN
+              value: http://example.com
+              isSecret: false
+            - name: SECRET_PASSWORD
+              value: MyTopSecretPassword123
+              isSecret: true
+          applyEnvVarsToBuild: false
+          buildTag: latest
+          sourceFiles: []
+    required: true
+  responses:
+    "200":
+      description: ""
+      headers: {}
+      content:
+        application/json:
+          schema:
+            $ref: ../../schemas/actors/VersionResponse.yaml
+    "400":
+      $ref: ../../responses/BadRequest.yaml
+    "401":
+      $ref: ../../responses/Unauthorized.yaml
+    "403":
+      $ref: ../../responses/Forbidden.yaml
+    "404":
+      description: Not found - the requested resource was not found.
+      content:
+        application/json:
+          schema:
+            $ref: "../../schemas/common/errors/ActorErrors.yaml#/ActorNotFoundError"
+    "405":
+      $ref: ../../responses/MethodNotAllowed.yaml
+    "413":
+      $ref: ../../responses/PayloadTooLarge.yaml
+    "415":
+      $ref: ../../responses/UnsupportedMediaType.yaml
+    "429":
+      $ref: ../../responses/TooManyRequests.yaml
+  deprecated: false
+  x-py-parent: ActorVersionClientAsync
+  x-py-name: update
+  x-py-doc-url: https://docs.apify.com/api/client/python/reference/class/ActorVersionClientAsync#update
+
+put:
+  <<: *shared
+  summary: Update version
+  description: |
+    Updates Actor version using values specified by a [Version object](#/reference/actors/version-object) passed as JSON in the POST payload.
+
+    If the object does not define a specific property, its value will not be
+    updated.
+
+    The request needs to specify the `Content-Type: application/json` HTTP
+    header!
+
+    When providing your API authentication token, we recommend using the
+    request's `Authorization` header, rather than the URL. ([More
+    info](#/introduction/authentication)).
+
+    The response is the [Version object](#/reference/actors/version-object) as
+    returned by the [Get version](#/reference/actors/version-object/get-version) endpoint.
+  operationId: act_version_put
+  x-legacy-doc-urls:
+    - https://docs.apify.com/api/v2#/reference/actors/version-object/update-version
+    - https://docs.apify.com/api/v2#/reference/actors/update-version
+    - https://docs.apify.com/api/v2#tag/ActorsVersion-object/operation/act_version_put
+
+post:
+  <<: *shared
+  summary: Update version (POST)
+  description: |
+    Updates Actor version using values specified by a [Version object](#/reference/actors/version-object) passed as JSON in the POST payload.
+    This endpoint is an alias for the [`PUT` update version](#tag/ActorsVersion-object/operation/act_version_put) method and behaves identically.
+  operationId: act_version_post
+  x-legacy-doc-urls:
+    - https://docs.apify.com/api/v2#/reference/actors/version-object/update-version
+    - https://docs.apify.com/api/v2#/reference/actors/update-version
+    - https://docs.apify.com/api/v2#tag/ActorsVersion-object/operation/act_version_post

--- a/apify-api/openapi/components/objects/key-value-stores/key-value-stores@{storeId}@records@{recordKey}put.yaml
+++ b/apify-api/openapi/components/objects/key-value-stores/key-value-stores@{storeId}@records@{recordKey}put.yaml
@@ -1,62 +1,101 @@
-tags:
-  - Storage/Key-value stores
-parameters:
-  - $ref: "../../parameters/storageParameters.yaml#/storeId"
-  - $ref: "../../parameters/storageParameters.yaml#/recordKey"
-  - name: Content-Encoding
-    in: header
-    description: ""
-    required: false
-    style: simple
-    schema:
-      enum:
-        - gzip
-        - deflate
-        - br
-      type: string
-requestBody:
-  description: ""
-  content:
-    application/json:
+shared: &shared
+  tags:
+    - Storage/Key-value stores
+  parameters:
+    - $ref: "../../parameters/storageParameters.yaml#/storeId"
+    - $ref: "../../parameters/storageParameters.yaml#/recordKey"
+    - name: Content-Encoding
+      in: header
+      description: ""
+      required: false
+      style: simple
       schema:
-        $ref: ../../schemas/key-value-stores/PutRecordRequest.yaml
-    "*/*":
-      schema: {}
-  required: true
-responses:
-  "201":
+        enum:
+          - gzip
+          - deflate
+          - br
+        type: string
+  requestBody:
     description: ""
-    headers:
-      Location:
-        content:
-          text/plain:
-            schema:
-              type: string
-            example: >-
-              https://api.apify.com/v2/key-value-stores/WkzbQMuFYuamGv3YF/records/some-key
     content:
       application/json:
         schema:
-          type: object
-        example: {}
-  "400":
-    $ref: ../../responses/BadRequest.yaml
-  "401":
-    $ref: ../../responses/Unauthorized.yaml
-  "403":
-    $ref: ../../responses/Forbidden.yaml
-  "405":
-    $ref: ../../responses/MethodNotAllowed.yaml
-  "413":
-    $ref: ../../responses/PayloadTooLarge.yaml
-  "415":
-    $ref: ../../responses/UnsupportedMediaType.yaml
-  "429":
-    $ref: ../../responses/TooManyRequests.yaml
-deprecated: false
-x-js-parent: KeyValueStoreClient
-x-js-name: setRecord
-x-js-doc-url: https://docs.apify.com/api/client/js/reference/class/KeyValueStoreClient#setRecord
-x-py-parent: KeyValueStoreClientAsync
-x-py-name: set_record
-x-py-doc-url: https://docs.apify.com/api/client/python/reference/class/KeyValueStoreClientAsync#set_record
+          $ref: ../../schemas/key-value-stores/PutRecordRequest.yaml
+      "*/*":
+        schema: {}
+    required: true
+  responses:
+    "201":
+      description: ""
+      headers:
+        Location:
+          content:
+            text/plain:
+              schema:
+                type: string
+              example: >-
+                https://api.apify.com/v2/key-value-stores/WkzbQMuFYuamGv3YF/records/some-key
+      content:
+        application/json:
+          schema:
+            type: object
+          example: {}
+    "400":
+      $ref: ../../responses/BadRequest.yaml
+    "401":
+      $ref: ../../responses/Unauthorized.yaml
+    "403":
+      $ref: ../../responses/Forbidden.yaml
+    "405":
+      $ref: ../../responses/MethodNotAllowed.yaml
+    "413":
+      $ref: ../../responses/PayloadTooLarge.yaml
+    "415":
+      $ref: ../../responses/UnsupportedMediaType.yaml
+    "429":
+      $ref: ../../responses/TooManyRequests.yaml
+  deprecated: false
+  x-js-parent: KeyValueStoreClient
+  x-js-name: setRecord
+  x-js-doc-url: https://docs.apify.com/api/client/js/reference/class/KeyValueStoreClient#setRecord
+  x-py-parent: KeyValueStoreClientAsync
+  x-py-name: set_record
+  x-py-doc-url: https://docs.apify.com/api/client/python/reference/class/KeyValueStoreClientAsync#set_record
+
+put:
+  <<: *shared
+  summary: Store record
+  description: |
+    Stores a value under a specific key to the key-value store.
+
+    The value is passed as the PUT payload and it is stored with a MIME content
+    type defined by the `Content-Type` header and with encoding defined by the
+    `Content-Encoding` header.
+
+    To save bandwidth, storage, and speed up your upload, send the request
+    payload compressed with Gzip compression and add the `Content-Encoding: gzip`
+    header. It is possible to set up another compression type with `Content-Encoding`
+    request header.
+
+    Below is a list of supported `Content-Encoding` types.
+
+    * Gzip compression: `Content-Encoding: gzip`
+    * Deflate compression: `Content-Encoding: deflate`
+    * Brotli compression: `Content-Encoding: br`
+  operationId: keyValueStore_record_put
+  x-legacy-doc-urls:
+    - https://docs.apify.com/api/v2#/reference/key-value-stores/record/put-record
+    - https://docs.apify.com/api/v2#/reference/key-value-stores/put-record
+    - https://docs.apify.com/api/v2#tag/Key-value-storesRecord/operation/keyValueStore_record_put
+
+post:
+  <<: *shared
+  summary: Store record (POST)
+  description: |
+    Stores a value under a specific key to the key-value store.
+    This endpoint is an alias for the [`PUT` record](#tag/Key-value-storesRecord/operation/keyValueStore_record_put) method and behaves identically.
+  operationId: keyValueStore_record_post
+  x-legacy-doc-urls:
+    - https://docs.apify.com/api/v2#/reference/key-value-stores/record/put-record
+    - https://docs.apify.com/api/v2#/reference/key-value-stores/put-record
+    - https://docs.apify.com/api/v2#tag/Key-value-storesRecord/operation/keyValueStore_record_post

--- a/apify-api/openapi/components/objects/key-value-stores/key-value-stores@{storeId}@records@{recordKey}put.yaml
+++ b/apify-api/openapi/components/objects/key-value-stores/key-value-stores@{storeId}@records@{recordKey}put.yaml
@@ -1,0 +1,62 @@
+tags:
+  - Storage/Key-value stores
+parameters:
+  - $ref: "../../parameters/storageParameters.yaml#/storeId"
+  - $ref: "../../parameters/storageParameters.yaml#/recordKey"
+  - name: Content-Encoding
+    in: header
+    description: ""
+    required: false
+    style: simple
+    schema:
+      enum:
+        - gzip
+        - deflate
+        - br
+      type: string
+requestBody:
+  description: ""
+  content:
+    application/json:
+      schema:
+        $ref: ../../schemas/key-value-stores/PutRecordRequest.yaml
+    "*/*":
+      schema: {}
+  required: true
+responses:
+  "201":
+    description: ""
+    headers:
+      Location:
+        content:
+          text/plain:
+            schema:
+              type: string
+            example: >-
+              https://api.apify.com/v2/key-value-stores/WkzbQMuFYuamGv3YF/records/some-key
+    content:
+      application/json:
+        schema:
+          type: object
+        example: {}
+  "400":
+    $ref: ../../responses/BadRequest.yaml
+  "401":
+    $ref: ../../responses/Unauthorized.yaml
+  "403":
+    $ref: ../../responses/Forbidden.yaml
+  "405":
+    $ref: ../../responses/MethodNotAllowed.yaml
+  "413":
+    $ref: ../../responses/PayloadTooLarge.yaml
+  "415":
+    $ref: ../../responses/UnsupportedMediaType.yaml
+  "429":
+    $ref: ../../responses/TooManyRequests.yaml
+deprecated: false
+x-js-parent: KeyValueStoreClient
+x-js-name: setRecord
+x-js-doc-url: https://docs.apify.com/api/client/js/reference/class/KeyValueStoreClient#setRecord
+x-py-parent: KeyValueStoreClientAsync
+x-py-name: set_record
+x-py-doc-url: https://docs.apify.com/api/client/python/reference/class/KeyValueStoreClientAsync#set_record

--- a/apify-api/openapi/components/schemas/datasets/Dataset.yaml
+++ b/apify-api/openapi/components/schemas/datasets/Dataset.yaml
@@ -14,7 +14,7 @@ properties:
     type: string
     examples: [WkzbQMuFYuamGv3YF]
   name:
-    type: string
+    type: [string, "null"]
     examples: [d7b9MDYsbtX5L7XAj]
   userId:
     type: string

--- a/apify-api/openapi/components/schemas/datasets/UpdateDatasetRequest.yaml
+++ b/apify-api/openapi/components/schemas/datasets/UpdateDatasetRequest.yaml
@@ -2,7 +2,7 @@ title: UpdateDatasetRequest
 type: object
 properties:
   name:
-    type: string
+    type: [string, "null"]
   generalAccess:
     $ref: ../common/GeneralAccess.yaml
 example:

--- a/apify-api/openapi/components/schemas/key-value-stores/KeyValueStore.yaml
+++ b/apify-api/openapi/components/schemas/key-value-stores/KeyValueStore.yaml
@@ -10,7 +10,7 @@ properties:
     type: string
     examples: [WkzbQMuFYuamGv3YF]
   name:
-    type: string
+    type: [string, "null"]
     examples: [d7b9MDYsbtX5L7XAj]
   userId:
     type: [string, "null"]

--- a/apify-api/openapi/components/schemas/key-value-stores/ListOfKeys.yaml
+++ b/apify-api/openapi/components/schemas/key-value-stores/ListOfKeys.yaml
@@ -18,11 +18,11 @@ properties:
     type: integer
     examples: [2]
   exclusiveStartKey:
-    type: string
+    type: [string, "null"]
     examples: [some-key]
   isTruncated:
     type: boolean
     examples: [true]
   nextExclusiveStartKey:
-    type: string
+    type: [string, "null"]
     examples: [third-key]

--- a/apify-api/openapi/components/schemas/request-queues/AddedRequest.yaml
+++ b/apify-api/openapi/components/schemas/request-queues/AddedRequest.yaml
@@ -8,18 +8,10 @@ required:
 type: object
 properties:
   requestId:
-    type: string
-    description: A unique identifier assigned to the request.
-    examples: [sbJ7klsdf7ujN9l]
+    $ref: ./SharedProperties.yaml#/RequestItemId
   uniqueKey:
-    type: string
-    description: A unique key used for request de-duplication. Requests with the same unique key are considered identical.
-    examples: [GET|60d83e70|e3b0c442|https://apify.com]
+    $ref: ./SharedProperties.yaml#/UniqueKey
   wasAlreadyPresent:
-    type: boolean
-    description: Indicates whether a request with the same unique key already existed in the request queue. If true, no new request was created.
-    examples: [false]
+    $ref: ./SharedProperties.yaml#/WasAlreadyPresent
   wasAlreadyHandled:
-    type: boolean
-    description: Indicates whether a request with the same unique key has already been processed by the request queue.
-    examples: [false]
+    $ref: ./SharedProperties.yaml#/WasAlreadyHandled

--- a/apify-api/openapi/components/schemas/request-queues/AddedRequest.yaml
+++ b/apify-api/openapi/components/schemas/request-queues/AddedRequest.yaml
@@ -8,7 +8,7 @@ required:
 type: object
 properties:
   requestId:
-    $ref: ./SharedProperties.yaml#/RequestItemId
+    $ref: ./SharedProperties.yaml#/RequestId
   uniqueKey:
     $ref: ./SharedProperties.yaml#/UniqueKey
   wasAlreadyPresent:

--- a/apify-api/openapi/components/schemas/request-queues/DeletedRequest.yaml
+++ b/apify-api/openapi/components/schemas/request-queues/DeletedRequest.yaml
@@ -6,10 +6,6 @@ anyOf:
   - required: [uniqueKey]
 properties:
   uniqueKey:
-    type: string
-    description: A unique key used for request de-duplication. Requests with the same unique key are considered identical.
-    examples: [GET|60d83e70|e3b0c442|https://apify.com]
+    $ref: ./SharedProperties.yaml#/UniqueKey
   id:
-    type: string
-    description: A unique identifier assigned to the request.
-    examples: [sbJ7klsdf7ujN9l]
+    $ref: ./SharedProperties.yaml#/RequestItemId

--- a/apify-api/openapi/components/schemas/request-queues/DeletedRequest.yaml
+++ b/apify-api/openapi/components/schemas/request-queues/DeletedRequest.yaml
@@ -8,4 +8,4 @@ properties:
   uniqueKey:
     $ref: ./SharedProperties.yaml#/UniqueKey
   id:
-    $ref: ./SharedProperties.yaml#/RequestItemId
+    $ref: ./SharedProperties.yaml#/RequestId

--- a/apify-api/openapi/components/schemas/request-queues/DeletedRequest.yaml
+++ b/apify-api/openapi/components/schemas/request-queues/DeletedRequest.yaml
@@ -1,8 +1,9 @@
 title: DeletedRequest
 description: Confirmation of a request that was successfully deleted from a request queue.
-required:
-  - uniqueKey
 type: object
+anyOf:
+  - required: [id]
+  - required: [uniqueKey]
 properties:
   uniqueKey:
     type: string

--- a/apify-api/openapi/components/schemas/request-queues/HeadRequest.yaml
+++ b/apify-api/openapi/components/schemas/request-queues/HeadRequest.yaml
@@ -7,23 +7,12 @@ required:
   - url
 properties:
   id:
-    type: string
-    description: A unique identifier assigned to the request.
-    examples: [8OamqXBCpPHxyH9]
+    $ref: ./SharedProperties.yaml#/RequestItemId
   uniqueKey:
-    type: string
-    description: A unique key used for request de-duplication. Requests with the same unique key are considered identical.
-    examples: [GET|60d83e70|e3b0c442|https://apify.com]
+    $ref: ./SharedProperties.yaml#/UniqueKey
   url:
-    type: string
-    format: uri
-    description: The URL of the request.
-    examples: [https://apify.com]
+    $ref: ./SharedProperties.yaml#/RequestUrl
   method:
-    type: string
-    description: The HTTP method of the request.
-    examples: [GET]
+    $ref: ./SharedProperties.yaml#/RequestMethod
   retryCount:
-    type: integer
-    description: The number of times this request has been retried.
-    examples: [0]
+    $ref: ./SharedProperties.yaml#/RetryCount

--- a/apify-api/openapi/components/schemas/request-queues/HeadRequest.yaml
+++ b/apify-api/openapi/components/schemas/request-queues/HeadRequest.yaml
@@ -7,7 +7,7 @@ required:
   - url
 properties:
   id:
-    $ref: ./SharedProperties.yaml#/RequestItemId
+    $ref: ./SharedProperties.yaml#/RequestId
   uniqueKey:
     $ref: ./SharedProperties.yaml#/UniqueKey
   url:

--- a/apify-api/openapi/components/schemas/request-queues/ListOfRequests.yaml
+++ b/apify-api/openapi/components/schemas/request-queues/ListOfRequests.yaml
@@ -19,6 +19,7 @@ properties:
     description: The maximum number of requests returned in this response.
     examples: [2]
   exclusiveStartId:
+    deprecated: true
     type: string
     description: The ID of the last request from the previous page, used for pagination.
     examples: [Ihnsp8YrvJ8102Kj]

--- a/apify-api/openapi/components/schemas/request-queues/ListOfRequests.yaml
+++ b/apify-api/openapi/components/schemas/request-queues/ListOfRequests.yaml
@@ -22,3 +22,11 @@ properties:
     type: string
     description: The ID of the last request from the previous page, used for pagination.
     examples: [Ihnsp8YrvJ8102Kj]
+  cursor:
+    type: string
+    description: A cursor string used for current page of results.
+    examples: [eyJyZXF1ZXN0SWQiOiI0SVlLUWFXZ2FKUUlWNlMifQ]
+  nextCursor:
+    type: string
+    description: A cursor string to be used to continue pagination.
+    examples: [eyJyZXF1ZXN0SWQiOiI5eFNNc1BrN1J6VUxTNXoifQ]

--- a/apify-api/openapi/components/schemas/request-queues/LockedHeadRequest.yaml
+++ b/apify-api/openapi/components/schemas/request-queues/LockedHeadRequest.yaml
@@ -8,7 +8,7 @@ required:
   - lockExpiresAt
 properties:
   id:
-    $ref: ./SharedProperties.yaml#/RequestItemId
+    $ref: ./SharedProperties.yaml#/RequestId
   uniqueKey:
     $ref: ./SharedProperties.yaml#/UniqueKey
   url:

--- a/apify-api/openapi/components/schemas/request-queues/LockedHeadRequest.yaml
+++ b/apify-api/openapi/components/schemas/request-queues/LockedHeadRequest.yaml
@@ -8,28 +8,14 @@ required:
   - lockExpiresAt
 properties:
   id:
-    type: string
-    description: A unique identifier assigned to the request.
-    examples: [8OamqXBCpPHxyH9]
+    $ref: ./SharedProperties.yaml#/RequestItemId
   uniqueKey:
-    type: string
-    description: A unique key used for request de-duplication. Requests with the same unique key are considered identical.
-    examples: [GET|60d83e70|e3b0c442|https://apify.com]
+    $ref: ./SharedProperties.yaml#/UniqueKey
   url:
-    type: string
-    format: uri
-    description: The URL of the request.
-    examples: [https://apify.com]
+    $ref: ./SharedProperties.yaml#/RequestUrl
   method:
-    type: string
-    description: The HTTP method of the request.
-    examples: [GET]
+    $ref: ./SharedProperties.yaml#/RequestMethod
   retryCount:
-    type: integer
-    description: The number of times this request has been retried.
-    examples: [0]
+    $ref: ./SharedProperties.yaml#/RetryCount
   lockExpiresAt:
-    type: string
-    format: date-time
-    description: The timestamp when the lock on this request expires.
-    examples: ["2022-06-14T23:00:00.000Z"]
+    $ref: ./SharedProperties.yaml#/LockExpiresAt

--- a/apify-api/openapi/components/schemas/request-queues/LockedRequestQueueHead.yaml
+++ b/apify-api/openapi/components/schemas/request-queues/LockedRequestQueueHead.yaml
@@ -9,14 +9,9 @@ required:
   - items
 properties:
   limit:
-    type: integer
-    description: The maximum number of requests returned.
-    examples: [1000]
+    $ref: ./SharedProperties.yaml#/HeadLimit
   queueModifiedAt:
-    type: string
-    format: date-time
-    description: The timestamp when the request queue was last modified. Modifications include adding, updating, or removing requests, as well as locking or unlocking requests.
-    examples: ["2018-03-14T23:00:00.000Z"]
+    $ref: ./SharedProperties.yaml#/QueueModifiedAt
   queueHasLockedRequests:
     type: boolean
     description: Whether the request queue contains requests locked by any client (either the one calling the endpoint or a different one).
@@ -26,9 +21,7 @@ properties:
     description: The client key used for locking the requests.
     examples: [client-one]
   hadMultipleClients:
-    type: boolean
-    description: Whether the request queue has been accessed by multiple different clients.
-    examples: [true]
+    $ref: ./SharedProperties.yaml#/HadMultipleClients
   lockSecs:
     type: integer
     description: The number of seconds the locks will be held.

--- a/apify-api/openapi/components/schemas/request-queues/Request.yaml
+++ b/apify-api/openapi/components/schemas/request-queues/Request.yaml
@@ -2,10 +2,10 @@ title: Request
 description: A request stored in the request queue, including its metadata and processing state.
 allOf:
   - $ref: ./RequestBase.yaml
-  - properties:
-      id:
-        $ref: ./SharedProperties.yaml#/RequestId
-  - required:
+    required:
       - id
       - uniqueKey
       - url
+  - properties:
+      id:
+        $ref: ./SharedProperties.yaml#/RequestId

--- a/apify-api/openapi/components/schemas/request-queues/Request.yaml
+++ b/apify-api/openapi/components/schemas/request-queues/Request.yaml
@@ -7,26 +7,15 @@ required:
 type: object
 properties:
   id:
-    type: string
-    description: A unique identifier assigned to the request.
-    examples: [dnjkDMKLmdlkmlkmld]
+    $ref: ./SharedProperties.yaml#/RequestItemId
   uniqueKey:
-    type: string
-    description: A unique key used for request de-duplication. Requests with the same unique key are considered identical.
-    examples: [GET|60d83e70|e3b0c442|https://apify.com/career]
+    $ref: ./SharedProperties.yaml#/UniqueKey
   url:
-    type: string
-    format: uri
-    description: The URL of the request.
-    examples: [https://apify.com/career]
+    $ref: ./SharedProperties.yaml#/RequestUrl
   method:
-    type: string
-    description: The HTTP method of the request.
-    examples: [GET]
+    $ref: ./SharedProperties.yaml#/RequestMethod
   retryCount:
-    type: integer
-    description: The number of times this request has been retried.
-    examples: [0]
+    $ref: ./SharedProperties.yaml#/RetryCount
   loadedUrl:
     type: [string, "null"]
     format: uri

--- a/apify-api/openapi/components/schemas/request-queues/Request.yaml
+++ b/apify-api/openapi/components/schemas/request-queues/Request.yaml
@@ -1,60 +1,11 @@
 title: Request
 description: A request stored in the request queue, including its metadata and processing state.
-required:
-  - id
-  - uniqueKey
-  - url
-type: object
-properties:
-  id:
-    $ref: ./SharedProperties.yaml#/RequestItemId
-  uniqueKey:
-    $ref: ./SharedProperties.yaml#/UniqueKey
-  url:
-    $ref: ./SharedProperties.yaml#/RequestUrl
-  method:
-    $ref: ./SharedProperties.yaml#/RequestMethod
-  retryCount:
-    $ref: ./SharedProperties.yaml#/RetryCount
-  loadedUrl:
-    type: [string, "null"]
-    format: uri
-    description: The final URL that was loaded, after redirects (if any).
-    examples: [https://apify.com/jobs]
-  payload:
-    type: [object, "null"]
-    description: The request payload, typically used with POST or PUT requests.
-  headers:
-    type: [object, "null"]
-    description: HTTP headers sent with the request.
-  userData:
-    $ref: ./RequestUserData.yaml
-  noRetry:
-    type: [boolean, "null"]
-    description: Indicates whether the request should not be retried if processing fails.
-    examples: [false]
-  errorMessages:
-    type: [array, "null"]
-    description: Error messages recorded from failed processing attempts.
-    items:
-      type: string
-  handledAt:
-    type: [string, "null"]
-    format: date-time
-    description: The timestamp when the request was marked as handled, if applicable.
-    examples: ["2019-06-16T10:23:31.607Z"]
-example:
-  id: dnjkDMKLmdlkmlkmld
-  retryCount: 0
-  uniqueKey: "http://example.com"
-  url: "http://example.com"
-  method: GET
-  loadedUrl: "http://example.com/example-1"
-  payload: null
-  noRetry: false
-  errorMessages: null
-  headers: null
-  userData:
-    label: DETAIL
-    image: "https://picserver1.eu"
-  handledAt: "2019-06-16T10:23:31.607Z"
+allOf:
+  - $ref: ./RequestBase.yaml
+  - properties:
+      id:
+        $ref: ./SharedProperties.yaml#/RequestId
+  - required:
+      - id
+      - uniqueKey
+      - url

--- a/apify-api/openapi/components/schemas/request-queues/RequestBase.yaml
+++ b/apify-api/openapi/components/schemas/request-queues/RequestBase.yaml
@@ -1,0 +1,41 @@
+title: RequestBase
+type: object
+properties:
+  uniqueKey:
+    $ref: ./SharedProperties.yaml#/UniqueKey
+  url:
+    $ref: ./SharedProperties.yaml#/RequestUrl
+  method:
+    $ref: ./SharedProperties.yaml#/RequestMethod
+  retryCount:
+    $ref: ./SharedProperties.yaml#/RetryCount
+  loadedUrl:
+    type: [string, "null"]
+    format: uri
+    description: The final URL that was loaded, after redirects (if any).
+    examples: [https://apify.com/jobs]
+  payload:
+    type: [object, "null"]
+    description: The request payload, typically used with POST or PUT requests.
+    examples: [null]
+  headers:
+    type: [object, "null"]
+    description: HTTP headers sent with the request.
+    examples: [null]
+  userData:
+    $ref: ./RequestUserData.yaml
+  noRetry:
+    type: [boolean, "null"]
+    description: Indicates whether the request should not be retried if processing fails.
+    examples: [false]
+  errorMessages:
+    type: [array, "null"]
+    description: Error messages recorded from failed processing attempts.
+    items:
+      type: string
+    examples: [null]
+  handledAt:
+    type: [string, "null"]
+    format: date-time
+    description: The timestamp when the request was marked as handled, if applicable.
+    examples: ["2019-06-16T10:23:31.607Z"]

--- a/apify-api/openapi/components/schemas/request-queues/RequestDraft.yaml
+++ b/apify-api/openapi/components/schemas/request-queues/RequestDraft.yaml
@@ -3,7 +3,6 @@ description: A request that failed to be processed during a request queue operat
 required:
   - uniqueKey
   - url
-  - method
 type: object
 properties:
   id:

--- a/apify-api/openapi/components/schemas/request-queues/RequestDraft.yaml
+++ b/apify-api/openapi/components/schemas/request-queues/RequestDraft.yaml
@@ -6,7 +6,7 @@ required:
 type: object
 properties:
   id:
-    $ref: ./SharedProperties.yaml#/RequestItemId
+    $ref: ./SharedProperties.yaml#/RequestId
   uniqueKey:
     $ref: ./SharedProperties.yaml#/UniqueKey
   url:

--- a/apify-api/openapi/components/schemas/request-queues/RequestDraft.yaml
+++ b/apify-api/openapi/components/schemas/request-queues/RequestDraft.yaml
@@ -6,19 +6,10 @@ required:
 type: object
 properties:
   id:
-    type: string
-    description: A unique identifier assigned to the request.
-    examples: [sbJ7klsdf7ujN9l]
+    $ref: ./SharedProperties.yaml#/RequestItemId
   uniqueKey:
-    type: string
-    description: A unique key used for request de-duplication. Requests with the same unique key are considered identical.
-    examples: [GET|60d83e70|e3b0c442|https://apify.com]
+    $ref: ./SharedProperties.yaml#/UniqueKey
   url:
-    type: string
-    format: uri
-    description: The URL of the request.
-    examples: [https://apify.com]
+    $ref: ./SharedProperties.yaml#/RequestUrl
   method:
-    type: string
-    description: The HTTP method of the request.
-    examples: [GET]
+    $ref: ./SharedProperties.yaml#/RequestMethod

--- a/apify-api/openapi/components/schemas/request-queues/RequestDraftDelete.yaml
+++ b/apify-api/openapi/components/schemas/request-queues/RequestDraftDelete.yaml
@@ -6,6 +6,6 @@ anyOf:
   - required: [uniqueKey]
 properties:
   id:
-    $ref: ./SharedProperties.yaml#/RequestItemId
+    $ref: ./SharedProperties.yaml#/RequestId
   uniqueKey:
     $ref: ./SharedProperties.yaml#/UniqueKey

--- a/apify-api/openapi/components/schemas/request-queues/RequestDraftDelete.yaml
+++ b/apify-api/openapi/components/schemas/request-queues/RequestDraftDelete.yaml
@@ -6,10 +6,6 @@ anyOf:
   - required: [uniqueKey]
 properties:
   id:
-    type: string
-    description: A unique identifier assigned to the request.
-    examples: [sbJ7klsdf7ujN9l]
+    $ref: ./SharedProperties.yaml#/RequestItemId
   uniqueKey:
-    type: string
-    description: A unique key used for request de-duplication. Requests with the same unique key are considered identical.
-    examples: [GET|60d83e70|e3b0c442|https://apify.com]
+    $ref: ./SharedProperties.yaml#/UniqueKey

--- a/apify-api/openapi/components/schemas/request-queues/RequestLockInfo.yaml
+++ b/apify-api/openapi/components/schemas/request-queues/RequestLockInfo.yaml
@@ -5,7 +5,4 @@ required:
   - lockExpiresAt
 properties:
   lockExpiresAt:
-    type: string
-    format: date-time
-    description: The timestamp when the lock expires.
-    examples: ["2022-01-01T00:00:00.000Z"]
+    $ref: ./SharedProperties.yaml#/LockExpiresAt

--- a/apify-api/openapi/components/schemas/request-queues/RequestQueue.yaml
+++ b/apify-api/openapi/components/schemas/request-queues/RequestQueue.yaml
@@ -18,7 +18,7 @@ properties:
     description: A unique identifier assigned to the request queue.
     examples: [WkzbQMuFYuamGv3YF]
   name:
-    type: string
+    type: [string, "null"]
     description: The name of the request queue.
     examples: [some-name]
   userId:

--- a/apify-api/openapi/components/schemas/request-queues/RequestQueue.yaml
+++ b/apify-api/openapi/components/schemas/request-queues/RequestQueue.yaml
@@ -14,51 +14,27 @@ required:
 type: object
 properties:
   id:
-    type: string
-    description: A unique identifier assigned to the request queue.
-    examples: [WkzbQMuFYuamGv3YF]
+    $ref: ./SharedProperties.yaml#/QueueId
   name:
     type: [string, "null"]
     description: The name of the request queue.
     examples: [some-name]
   userId:
-    type: string
-    description: The ID of the user who owns the request queue.
-    examples: [wRsJZtadYvn4mBZmm]
+    $ref: ./SharedProperties.yaml#/QueueUserId
   createdAt:
-    type: string
-    format: date-time
-    description: The timestamp when the request queue was created.
-    examples: ["2019-12-12T07:34:14.202Z"]
+    $ref: ./SharedProperties.yaml#/QueueCreatedAt
   modifiedAt:
-    type: string
-    format: date-time
-    description: The timestamp when the request queue was last modified. Modifications include adding, updating, or removing requests, as well as locking or unlocking requests in the request queue.
-    examples: ["2030-12-13T08:36:13.202Z"]
+    $ref: ./SharedProperties.yaml#/QueueModifiedAt
   accessedAt:
-    type: string
-    format: date-time
-    description: The timestamp when the request queue was last accessed.
-    examples: ["2019-12-14T08:36:13.202Z"]
+    $ref: ./SharedProperties.yaml#/QueueAccessedAt
   totalRequestCount:
-    type: integer
-    description: The total number of requests in the request queue.
-    minimum: 0
-    examples: [870]
+    $ref: ./SharedProperties.yaml#/TotalRequestCount
   handledRequestCount:
-    type: integer
-    description: The number of requests that have been handled.
-    minimum: 0
-    examples: [100]
+    $ref: ./SharedProperties.yaml#/HandledRequestCount
   pendingRequestCount:
-    type: integer
-    description: The number of requests that are pending and have not been handled yet.
-    minimum: 0
-    examples: [670]
+    $ref: ./SharedProperties.yaml#/PendingRequestCount
   hadMultipleClients:
-    type: boolean
-    description: Whether the request queue has been accessed by multiple different clients.
-    examples: [true]
+    $ref: ./SharedProperties.yaml#/HadMultipleClients
   consoleUrl:
     type: string
     description: The URL to view the request queue in the Apify console.

--- a/apify-api/openapi/components/schemas/request-queues/RequestQueueHead.yaml
+++ b/apify-api/openapi/components/schemas/request-queues/RequestQueueHead.yaml
@@ -8,18 +8,11 @@ required:
   - items
 properties:
   limit:
-    type: integer
-    description: The maximum number of requests returned.
-    examples: [1000]
+    $ref: ./SharedProperties.yaml#/HeadLimit
   queueModifiedAt:
-    type: string
-    format: date-time
-    description: The timestamp when the request queue was last modified.
-    examples: ["2018-03-14T23:00:00.000Z"]
+    $ref: ./SharedProperties.yaml#/QueueModifiedAt
   hadMultipleClients:
-    type: boolean
-    description: Whether the request queue has been accessed by multiple different clients.
-    examples: [false]
+    $ref: ./SharedProperties.yaml#/HadMultipleClients
   items:
     type: array
     items:

--- a/apify-api/openapi/components/schemas/request-queues/RequestQueueShort.yaml
+++ b/apify-api/openapi/components/schemas/request-queues/RequestQueueShort.yaml
@@ -15,53 +15,34 @@ required:
 type: object
 properties:
   id:
-    type: string
-    description: A unique identifier assigned to the request queue.
-    examples: [WkzbQMuFYuamGv3YF]
+    $ref: ./SharedProperties.yaml#/QueueId
   name:
     type: string
     description: The name of the request queue.
     examples: [some-name]
   userId:
-    type: string
-    description: The ID of the user who owns the request queue.
-    examples: [wRsJZtadYvn4mBZmm]
+    $ref: ./SharedProperties.yaml#/QueueUserId
   username:
     type: string
     description: The username of the user who owns the request queue.
     examples: [janedoe]
   createdAt:
-    type: string
-    format: date-time
-    description: The timestamp when the request queue was created.
-    examples: ["2019-12-12T07:34:14.202Z"]
+    $ref: ./SharedProperties.yaml#/QueueCreatedAt
   modifiedAt:
-    type: string
-    format: date-time
-    description: The timestamp when the request queue was last modified.
-    examples: ["2019-12-13T08:36:13.202Z"]
+    $ref: ./SharedProperties.yaml#/QueueModifiedAt
   accessedAt:
-    type: string
-    format: date-time
-    description: The timestamp when the request queue was last accessed.
-    examples: ["2019-12-14T08:36:13.202Z"]
+    $ref: ./SharedProperties.yaml#/QueueAccessedAt
   expireAt:
     type: string
     format: date-time
     description: The timestamp when the request queue will expire and be deleted.
     examples: ["2019-06-02T17:15:06.751Z"]
   totalRequestCount:
-    type: integer
-    description: The total number of requests in the request queue.
-    examples: [100]
+    $ref: ./SharedProperties.yaml#/TotalRequestCount
   handledRequestCount:
-    type: integer
-    description: The number of requests that have been handled.
-    examples: [50]
+    $ref: ./SharedProperties.yaml#/HandledRequestCount
   pendingRequestCount:
-    type: integer
-    description: The number of requests that are pending and have not been handled yet.
-    examples: [50]
+    $ref: ./SharedProperties.yaml#/PendingRequestCount
   actId:
     type: [string, "null"]
     description: The ID of the Actor that created this request queue.
@@ -69,6 +50,4 @@ properties:
     type: [string, "null"]
     description: The ID of the Actor run that created this request queue.
   hadMultipleClients:
-    type: boolean
-    description: Whether the request queue has been accessed by multiple different clients.
-    examples: [true]
+    $ref: ./SharedProperties.yaml#/HadMultipleClients

--- a/apify-api/openapi/components/schemas/request-queues/RequestRegistration.yaml
+++ b/apify-api/openapi/components/schemas/request-queues/RequestRegistration.yaml
@@ -7,14 +7,8 @@ required:
 type: object
 properties:
   requestId:
-    type: string
-    description: A unique identifier assigned to the request.
-    examples: [YiKoxjkaS9gjGTqhF]
+    $ref: ./SharedProperties.yaml#/RequestItemId
   wasAlreadyPresent:
-    type: boolean
-    description: Indicates whether a request with the same unique key already existed in the request queue. If true, no new request was created.
-    examples: [false]
+    $ref: ./SharedProperties.yaml#/WasAlreadyPresent
   wasAlreadyHandled:
-    type: boolean
-    description: Indicates whether a request with the same unique key has already been processed by the request queue.
-    examples: [false]
+    $ref: ./SharedProperties.yaml#/WasAlreadyHandled

--- a/apify-api/openapi/components/schemas/request-queues/RequestRegistration.yaml
+++ b/apify-api/openapi/components/schemas/request-queues/RequestRegistration.yaml
@@ -7,7 +7,7 @@ required:
 type: object
 properties:
   requestId:
-    $ref: ./SharedProperties.yaml#/RequestItemId
+    $ref: ./SharedProperties.yaml#/RequestId
   wasAlreadyPresent:
     $ref: ./SharedProperties.yaml#/WasAlreadyPresent
   wasAlreadyHandled:

--- a/apify-api/openapi/components/schemas/request-queues/RequestWithoutId.yaml
+++ b/apify-api/openapi/components/schemas/request-queues/RequestWithoutId.yaml
@@ -1,0 +1,7 @@
+title: RequestWithoutId
+description: A request stored in the request queue, including its metadata and processing state, without the assigned ID.
+allOf:
+  - $ref: ./RequestBase.yaml
+  - required:
+      - uniqueKey
+      - url

--- a/apify-api/openapi/components/schemas/request-queues/RequestWithoutId.yaml
+++ b/apify-api/openapi/components/schemas/request-queues/RequestWithoutId.yaml
@@ -1,7 +1,6 @@
 title: RequestWithoutId
 description: A request stored in the request queue, including its metadata and processing state, without the assigned ID.
-allOf:
-  - $ref: ./RequestBase.yaml
-  - required:
-      - uniqueKey
-      - url
+$ref: ./RequestBase.yaml
+required:
+  - uniqueKey
+  - url

--- a/apify-api/openapi/components/schemas/request-queues/SharedProperties.yaml
+++ b/apify-api/openapi/components/schemas/request-queues/SharedProperties.yaml
@@ -1,0 +1,96 @@
+RequestItemId:
+  type: string
+  description: A unique identifier assigned to the request.
+  examples: [sbJ7klsdf7ujN9l]
+
+QueueId:
+  type: string
+  description: A unique identifier assigned to the request queue.
+  examples: [WkzbQMuFYuamGv3YF]
+
+UniqueKey:
+  type: string
+  description: A unique key used for request de-duplication. Requests with the same unique key are considered identical.
+  examples: [GET|60d83e70|e3b0c442|https://apify.com]
+
+RequestUrl:
+  type: string
+  format: uri
+  description: The URL of the request.
+  examples: [https://apify.com]
+
+RequestMethod:
+  description: The HTTP method of the request.
+  $ref: ../common/HttpMethod.yaml
+
+RetryCount:
+  type: integer
+  description: The number of times this request has been retried.
+  examples: [0]
+
+WasAlreadyPresent:
+  type: boolean
+  description: Indicates whether a request with the same unique key already existed in the request queue. If true, no new request was created.
+  examples: [false]
+
+WasAlreadyHandled:
+  type: boolean
+  description: Indicates whether a request with the same unique key has already been processed by the request queue.
+  examples: [false]
+
+HadMultipleClients:
+  type: boolean
+  description: Whether the request queue has been accessed by multiple different clients.
+  examples: [true]
+
+HeadLimit:
+  type: integer
+  description: The maximum number of requests returned.
+  examples: [1000]
+
+QueueUserId:
+  type: string
+  description: The ID of the user who owns the request queue.
+  examples: [wRsJZtadYvn4mBZmm]
+
+QueueCreatedAt:
+  type: string
+  format: date-time
+  description: The timestamp when the request queue was created.
+  examples: ["2019-12-12T07:34:14.202Z"]
+
+QueueAccessedAt:
+  type: string
+  format: date-time
+  description: The timestamp when the request queue was last accessed.
+  examples: ["2019-12-14T08:36:13.202Z"]
+
+TotalRequestCount:
+  type: integer
+  description: The total number of requests in the request queue.
+  minimum: 0
+  examples: [870]
+
+HandledRequestCount:
+  type: integer
+  description: The number of requests that have been handled.
+  minimum: 0
+  examples: [100]
+
+PendingRequestCount:
+  type: integer
+  description: The number of requests that are pending and have not been handled yet.
+  minimum: 0
+  examples: [670]
+
+QueueModifiedAt:
+  type: string
+  format: date-time
+  description: The timestamp when the request queue was last modified. Modifications include adding, updating, or removing requests, as well as locking or unlocking requests in the request queue.
+  examples: ["2019-12-13T08:36:13.202Z"]
+
+LockExpiresAt:
+  type: string
+  format: date-time
+  description: The timestamp when the lock on this request expires.
+  examples: ["2022-06-14T23:00:00.000Z"]

--- a/apify-api/openapi/components/schemas/request-queues/SharedProperties.yaml
+++ b/apify-api/openapi/components/schemas/request-queues/SharedProperties.yaml
@@ -1,4 +1,4 @@
-RequestItemId:
+RequestId:
   type: string
   description: A unique identifier assigned to the request.
   examples: [sbJ7klsdf7ujN9l]

--- a/apify-api/openapi/components/schemas/request-queues/UpdateRequestQueueRequest.yaml
+++ b/apify-api/openapi/components/schemas/request-queues/UpdateRequestQueueRequest.yaml
@@ -3,7 +3,7 @@ description: Request object for updating a request queue.
 type: object
 properties:
   name:
-    type: string
+    type: [string, "null"]
     description: The new name for the request queue.
   generalAccess:
     $ref: ../common/GeneralAccess.yaml

--- a/apify-api/openapi/components/schemas/store/UpdateStoreRequest.yaml
+++ b/apify-api/openapi/components/schemas/store/UpdateStoreRequest.yaml
@@ -2,7 +2,7 @@ title: UpdateStoreRequest
 type: object
 properties:
   name:
-    type: string
+    type: [string, "null"]
   generalAccess:
     $ref: ../common/GeneralAccess.yaml
 example:

--- a/apify-api/openapi/openapi.yaml
+++ b/apify-api/openapi/openapi.yaml
@@ -566,6 +566,8 @@ paths:
     $ref: "paths/key-value-stores/key-value-stores@{storeId}.yaml"
   "/v2/key-value-stores/{storeId}/keys":
     $ref: "paths/key-value-stores/key-value-stores@{storeId}@keys.yaml"
+  "/v2/key-value-stores/{storeId}/records":
+    $ref: "paths/key-value-stores/key-value-stores@{storeId}@records.yaml"
   "/v2/key-value-stores/{storeId}/records/{recordKey}":
     $ref: "paths/key-value-stores/key-value-stores@{storeId}@records@{recordKey}.yaml"
   /v2/datasets:

--- a/apify-api/openapi/paths/actor-tasks/actor-tasks@{actorTaskId}@run-sync-get-dataset-items.yaml
+++ b/apify-api/openapi/paths/actor-tasks/actor-tasks@{actorTaskId}@run-sync-get-dataset-items.yaml
@@ -54,30 +54,7 @@ get:
     "201":
       description: ""
       headers:
-        X-Apify-Pagination-Offset:
-          content:
-            text/plain:
-              schema:
-                type: string
-              example: "0"
-        X-Apify-Pagination-Limit:
-          content:
-            text/plain:
-              schema:
-                type: string
-              example: "100"
-        X-Apify-Pagination-Count:
-          content:
-            text/plain:
-              schema:
-                type: string
-              example: "100"
-        X-Apify-Pagination-Total:
-          content:
-            text/plain:
-              schema:
-                type: string
-              example: "10204"
+        $ref: ../../components/headers/ApifyPaginationHeaders.yaml
       content:
         application/json:
           schema:
@@ -184,30 +161,7 @@ post:
     "201":
       description: ""
       headers:
-        X-Apify-Pagination-Offset:
-          content:
-            text/plain:
-              schema:
-                type: string
-              example: "0"
-        X-Apify-Pagination-Limit:
-          content:
-            text/plain:
-              schema:
-                type: string
-              example: "100"
-        X-Apify-Pagination-Count:
-          content:
-            text/plain:
-              schema:
-                type: string
-              example: "100"
-        X-Apify-Pagination-Total:
-          content:
-            text/plain:
-              schema:
-                type: string
-              example: "10204"
+        $ref: ../../components/headers/ApifyPaginationHeaders.yaml
       content:
         application/json:
           schema:

--- a/apify-api/openapi/paths/actors/acts@{actorId}@run-sync-get-dataset-items.yaml
+++ b/apify-api/openapi/paths/actors/acts@{actorId}@run-sync-get-dataset-items.yaml
@@ -69,30 +69,7 @@ post:
     "201":
       description: ""
       headers:
-        X-Apify-Pagination-Offset:
-          content:
-            text/plain:
-              schema:
-                type: string
-              example: "0"
-        X-Apify-Pagination-Limit:
-          content:
-            text/plain:
-              schema:
-                type: string
-              example: "100"
-        X-Apify-Pagination-Count:
-          content:
-            text/plain:
-              schema:
-                type: string
-              example: "100"
-        X-Apify-Pagination-Total:
-          content:
-            text/plain:
-              schema:
-                type: string
-              example: "10204"
+        $ref: ../../components/headers/ApifyPaginationHeaders.yaml
       content:
         application/json:
           schema:
@@ -184,30 +161,7 @@ get:
     "201":
       description: ""
       headers:
-        X-Apify-Pagination-Offset:
-          content:
-            text/plain:
-              schema:
-                type: string
-              example: "0"
-        X-Apify-Pagination-Limit:
-          content:
-            text/plain:
-              schema:
-                type: string
-              example: "100"
-        X-Apify-Pagination-Count:
-          content:
-            text/plain:
-              schema:
-                type: string
-              example: "100"
-        X-Apify-Pagination-Total:
-          content:
-            text/plain:
-              schema:
-                type: string
-              example: "10204"
+        $ref: ../../components/headers/ApifyPaginationHeaders.yaml
       content:
         application/json:
           schema:

--- a/apify-api/openapi/paths/actors/acts@{actorId}@versions@{versionNumber}.yaml
+++ b/apify-api/openapi/paths/actors/acts@{actorId}@versions@{versionNumber}.yaml
@@ -121,6 +121,67 @@ put:
   x-py-parent: ActorVersionClientAsync
   x-py-name: update
   x-py-doc-url: https://docs.apify.com/api/client/python/reference/class/ActorVersionClientAsync#update
+post:
+  tags:
+    - Actors/Actor versions
+  summary: Update version (POST)
+  description: |
+    Updates Actor version using values specified by a [Version object](#/reference/actors/version-object) passed as JSON in the POST payload.
+    This endpoint is an alias for the [`PUT` update version](#tag/ActorsVersion-object/operation/act_version_put) method and behaves identically.
+
+  operationId: act_version_post
+  parameters:
+    - $ref: "../../components/parameters/runAndBuildParameters.yaml#/actorId"
+    - $ref: "../../components/parameters/runAndBuildParameters.yaml#/versionNumber"
+  requestBody:
+    description: ""
+    content:
+      application/json:
+        schema:
+          $ref: ../../components/schemas/actors/CreateOrUpdateVersionRequest.yaml
+        example:
+          versionNumber: "0.0"
+          sourceType: SOURCE_FILES
+          envVars:
+            - name: DOMAIN
+              value: http://example.com
+              isSecret: false
+            - name: SECRET_PASSWORD
+              value: MyTopSecretPassword123
+              isSecret: true
+          applyEnvVarsToBuild: false
+          buildTag: latest
+          sourceFiles: []
+    required: true
+  responses:
+    "200":
+      description: ""
+      headers: {}
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas/actors/VersionResponse.yaml
+    "400":
+      $ref: ../../components/responses/BadRequest.yaml
+    "401":
+      $ref: ../../components/responses/Unauthorized.yaml
+    "403":
+      $ref: ../../components/responses/Forbidden.yaml
+    "404":
+      description: Not found - the requested resource was not found.
+      content:
+        application/json:
+          schema:
+            $ref: "../../components/schemas/common/errors/ActorErrors.yaml#/ActorNotFoundError"
+    "405":
+      $ref: ../../components/responses/MethodNotAllowed.yaml
+    "413":
+      $ref: ../../components/responses/PayloadTooLarge.yaml
+    "415":
+      $ref: ../../components/responses/UnsupportedMediaType.yaml
+    "429":
+      $ref: ../../components/responses/TooManyRequests.yaml
+  deprecated: false
 delete:
   tags:
     - Actors/Actor versions

--- a/apify-api/openapi/paths/actors/acts@{actorId}@versions@{versionNumber}.yaml
+++ b/apify-api/openapi/paths/actors/acts@{actorId}@versions@{versionNumber}.yaml
@@ -43,39 +43,9 @@ get:
   x-py-name: get
   x-py-doc-url: https://docs.apify.com/api/client/python/reference/class/ActorVersionClientAsync#get
 put:
-  summary: Update version
-  operationId: act_version_put
-  description: |
-    Updates Actor version using values specified by a [Version object](#/reference/actors/version-object) passed as JSON in the POST payload.
-
-    If the object does not define a specific property, its value will not be
-    updated.
-
-    The request needs to specify the `Content-Type: application/json` HTTP
-    header!
-
-    When providing your API authentication token, we recommend using the
-    request's `Authorization` header, rather than the URL. ([More
-    info](#/introduction/authentication)).
-
-    The response is the [Version object](#/reference/actors/version-object) as
-    returned by the [Get version](#/reference/actors/version-object/get-version) endpoint.
-  x-legacy-doc-urls:
-    - https://docs.apify.com/api/v2#/reference/actors/version-object/update-version
-    - https://docs.apify.com/api/v2#/reference/actors/update-version
-    - https://docs.apify.com/api/v2#tag/ActorsVersion-object/operation/act_version_put
-  $ref: "../../components/objects/actors/acts@{actorId}@versions@{versionNumber}put.yaml"
+  $ref: "../../components/objects/actors/acts@{actorId}@versions@{versionNumber}put.yaml#/put"
 post:
-  summary: Update version (POST)
-  operationId: act_version_post
-  description: |
-    Updates Actor version using values specified by a [Version object](#/reference/actors/version-object) passed as JSON in the POST payload.
-    This endpoint is an alias for the [`PUT` update version](#tag/ActorsVersion-object/operation/act_version_put) method and behaves identically.
-  x-legacy-doc-urls:
-    - https://docs.apify.com/api/v2#/reference/actors/version-object/update-version
-    - https://docs.apify.com/api/v2#/reference/actors/update-version
-    - https://docs.apify.com/api/v2#tag/ActorsVersion-object/operation/act_version_post
-  $ref: "../../components/objects/actors/acts@{actorId}@versions@{versionNumber}put.yaml"
+  $ref: "../../components/objects/actors/acts@{actorId}@versions@{versionNumber}put.yaml#/post"
 delete:
   tags:
     - Actors/Actor versions

--- a/apify-api/openapi/paths/actors/acts@{actorId}@versions@{versionNumber}.yaml
+++ b/apify-api/openapi/paths/actors/acts@{actorId}@versions@{versionNumber}.yaml
@@ -43,9 +43,8 @@ get:
   x-py-name: get
   x-py-doc-url: https://docs.apify.com/api/client/python/reference/class/ActorVersionClientAsync#get
 put:
-  tags:
-    - Actors/Actor versions
   summary: Update version
+  operationId: act_version_put
   description: |
     Updates Actor version using values specified by a [Version object](#/reference/actors/version-object) passed as JSON in the POST payload.
 
@@ -61,127 +60,22 @@ put:
 
     The response is the [Version object](#/reference/actors/version-object) as
     returned by the [Get version](#/reference/actors/version-object/get-version) endpoint.
-  operationId: act_version_put
-  parameters:
-    - $ref: "../../components/parameters/runAndBuildParameters.yaml#/actorId"
-    - $ref: "../../components/parameters/runAndBuildParameters.yaml#/versionNumber"
-  requestBody:
-    description: ""
-    content:
-      application/json:
-        schema:
-          $ref: ../../components/schemas/actors/CreateOrUpdateVersionRequest.yaml
-        example:
-          versionNumber: "0.0"
-          sourceType: SOURCE_FILES
-          envVars:
-            - name: DOMAIN
-              value: http://example.com
-              isSecret: false
-            - name: SECRET_PASSWORD
-              value: MyTopSecretPassword123
-              isSecret: true
-          applyEnvVarsToBuild: false
-          buildTag: latest
-          sourceFiles: []
-    required: true
-  responses:
-    "200":
-      description: ""
-      headers: {}
-      content:
-        application/json:
-          schema:
-            $ref: ../../components/schemas/actors/VersionResponse.yaml
-    "400":
-      $ref: ../../components/responses/BadRequest.yaml
-    "401":
-      $ref: ../../components/responses/Unauthorized.yaml
-    "403":
-      $ref: ../../components/responses/Forbidden.yaml
-    "404":
-      description: Not found - the requested resource was not found.
-      content:
-        application/json:
-          schema:
-            $ref: "../../components/schemas/common/errors/ActorErrors.yaml#/ActorNotFoundError"
-    "405":
-      $ref: ../../components/responses/MethodNotAllowed.yaml
-    "413":
-      $ref: ../../components/responses/PayloadTooLarge.yaml
-    "415":
-      $ref: ../../components/responses/UnsupportedMediaType.yaml
-    "429":
-      $ref: ../../components/responses/TooManyRequests.yaml
-  deprecated: false
   x-legacy-doc-urls:
     - https://docs.apify.com/api/v2#/reference/actors/version-object/update-version
     - https://docs.apify.com/api/v2#/reference/actors/update-version
     - https://docs.apify.com/api/v2#tag/ActorsVersion-object/operation/act_version_put
-  x-py-parent: ActorVersionClientAsync
-  x-py-name: update
-  x-py-doc-url: https://docs.apify.com/api/client/python/reference/class/ActorVersionClientAsync#update
+  $ref: "../../components/objects/actors/acts@{actorId}@versions@{versionNumber}put.yaml"
 post:
-  tags:
-    - Actors/Actor versions
   summary: Update version (POST)
+  operationId: act_version_post
   description: |
     Updates Actor version using values specified by a [Version object](#/reference/actors/version-object) passed as JSON in the POST payload.
     This endpoint is an alias for the [`PUT` update version](#tag/ActorsVersion-object/operation/act_version_put) method and behaves identically.
-
-  operationId: act_version_post
-  parameters:
-    - $ref: "../../components/parameters/runAndBuildParameters.yaml#/actorId"
-    - $ref: "../../components/parameters/runAndBuildParameters.yaml#/versionNumber"
-  requestBody:
-    description: ""
-    content:
-      application/json:
-        schema:
-          $ref: ../../components/schemas/actors/CreateOrUpdateVersionRequest.yaml
-        example:
-          versionNumber: "0.0"
-          sourceType: SOURCE_FILES
-          envVars:
-            - name: DOMAIN
-              value: http://example.com
-              isSecret: false
-            - name: SECRET_PASSWORD
-              value: MyTopSecretPassword123
-              isSecret: true
-          applyEnvVarsToBuild: false
-          buildTag: latest
-          sourceFiles: []
-    required: true
-  responses:
-    "200":
-      description: ""
-      headers: {}
-      content:
-        application/json:
-          schema:
-            $ref: ../../components/schemas/actors/VersionResponse.yaml
-    "400":
-      $ref: ../../components/responses/BadRequest.yaml
-    "401":
-      $ref: ../../components/responses/Unauthorized.yaml
-    "403":
-      $ref: ../../components/responses/Forbidden.yaml
-    "404":
-      description: Not found - the requested resource was not found.
-      content:
-        application/json:
-          schema:
-            $ref: "../../components/schemas/common/errors/ActorErrors.yaml#/ActorNotFoundError"
-    "405":
-      $ref: ../../components/responses/MethodNotAllowed.yaml
-    "413":
-      $ref: ../../components/responses/PayloadTooLarge.yaml
-    "415":
-      $ref: ../../components/responses/UnsupportedMediaType.yaml
-    "429":
-      $ref: ../../components/responses/TooManyRequests.yaml
-  deprecated: false
+  x-legacy-doc-urls:
+    - https://docs.apify.com/api/v2#/reference/actors/version-object/update-version
+    - https://docs.apify.com/api/v2#/reference/actors/update-version
+    - https://docs.apify.com/api/v2#tag/ActorsVersion-object/operation/act_version_post
+  $ref: "../../components/objects/actors/acts@{actorId}@versions@{versionNumber}put.yaml"
 delete:
   tags:
     - Actors/Actor versions

--- a/apify-api/openapi/paths/actors/acts@{actorId}@versions@{versionNumber}@env-vars@{envVarName}.yaml
+++ b/apify-api/openapi/paths/actors/acts@{actorId}@versions@{versionNumber}@env-vars@{envVarName}.yaml
@@ -60,8 +60,6 @@ get:
   x-py-name: get
   x-py-doc-url: https://docs.apify.com/api/client/python/reference/class/ActorEnvVarClientAsync#get
 put:
-  tags:
-    - Actors/Actor versions
   summary: Update environment variable
   description: |
     Updates Actor environment variable using values specified by a [EnvVar
@@ -81,75 +79,12 @@ put:
     [Get environment variable](#/reference/actors/environment-variable-object/get-environment-variable)
     endpoint.
   operationId: act_version_envVar_put
-  parameters:
-    - $ref: "../../components/parameters/runAndBuildParameters.yaml#/actorId"
-    - $ref: "../../components/parameters/runAndBuildParameters.yaml#/versionNumber"
-    - name: envVarName
-      in: path
-      description: The name of the environment variable
-      required: true
-      style: simple
-      schema:
-        type: string
-        example: MY_ENV_VAR
-  requestBody:
-    description: ""
-    content:
-      application/json:
-        schema:
-          $ref: ../../components/schemas/actors/EnvVar.yaml
-        example:
-          name: MY_ENV_VAR
-          value: my-new-value
-          isSecret: false
-    required: true
-  responses:
-    "200":
-      description: ""
-      headers: {}
-      content:
-        application/json:
-          schema:
-            $ref: ../../components/schemas/actors/EnvVarResponse.yaml
-          example:
-            data:
-              name: MY_ENV_VAR
-              value: my-value
-              isSecret: false
-    "400":
-      $ref: ../../components/responses/BadRequest.yaml
-    "401":
-      $ref: ../../components/responses/Unauthorized.yaml
-    "403":
-      $ref: ../../components/responses/Forbidden.yaml
-    "404":
-      description: Not found - the requested resource was not found.
-      content:
-        application/json:
-          schema:
-            oneOf:
-              - $ref: "../../components/schemas/common/errors/ActorErrors.yaml#/ActorNotFoundError"
-              - $ref: "../../components/schemas/common/errors/ActorErrors.yaml#/ActorVersionNotFoundError"
-              - $ref: "../../components/schemas/common/errors/EnvVariableErrors.yaml#/EnvironmentVariableNotFoundError"
-    "405":
-      $ref: ../../components/responses/MethodNotAllowed.yaml
-    "413":
-      $ref: ../../components/responses/PayloadTooLarge.yaml
-    "415":
-      $ref: ../../components/responses/UnsupportedMediaType.yaml
-    "429":
-      $ref: ../../components/responses/TooManyRequests.yaml
-  deprecated: false
   x-legacy-doc-urls:
     - https://docs.apify.com/api/v2#/reference/actors/environment-variable-object/update-environment-variable
     - https://docs.apify.com/api/v2#/reference/actors/update-environment-variable
     - https://docs.apify.com/api/v2#tag/ActorsEnvironment-variable-object/operation/act_version_envVar_put
-  x-py-parent: ActorEnvVarClientAsync
-  x-py-name: update
-  x-py-doc-url: https://docs.apify.com/api/client/python/reference/class/ActorEnvVarClientAsync#update
+  $ref: "../../components/objects/actors/acts@{actorId}@versions@{versionNumber}@env-vars@{envVarName}put.yaml"
 post:
-  tags:
-    - Actors/Actor versions
   summary: Update environment variable (POST)
   description: |
     Updates Actor environment variable using values specified by a [EnvVar
@@ -157,65 +92,11 @@ post:
     passed as JSON in the POST payload.
     This endpoint is an alias for the [`PUT` update environment variable](#tag/ActorsEnvironment-variable-object/operation/act_version_envVar_put) method and behaves identically.
   operationId: act_version_envVar_post
-  parameters:
-    - $ref: "../../components/parameters/runAndBuildParameters.yaml#/actorId"
-    - $ref: "../../components/parameters/runAndBuildParameters.yaml#/versionNumber"
-    - name: envVarName
-      in: path
-      description: The name of the environment variable
-      required: true
-      style: simple
-      schema:
-        type: string
-        example: MY_ENV_VAR
-  requestBody:
-    description: ""
-    content:
-      application/json:
-        schema:
-          $ref: ../../components/schemas/actors/EnvVar.yaml
-        example:
-          name: MY_ENV_VAR
-          value: my-new-value
-          isSecret: false
-    required: true
-  responses:
-    "200":
-      description: ""
-      headers: {}
-      content:
-        application/json:
-          schema:
-            $ref: ../../components/schemas/actors/EnvVarResponse.yaml
-          example:
-            data:
-              name: MY_ENV_VAR
-              value: my-value
-              isSecret: false
-    "400":
-      $ref: ../../components/responses/BadRequest.yaml
-    "401":
-      $ref: ../../components/responses/Unauthorized.yaml
-    "403":
-      $ref: ../../components/responses/Forbidden.yaml
-    "404":
-      description: Not found - the requested resource was not found.
-      content:
-        application/json:
-          schema:
-            oneOf:
-              - $ref: "../../components/schemas/common/errors/ActorErrors.yaml#/ActorNotFoundError"
-              - $ref: "../../components/schemas/common/errors/ActorErrors.yaml#/ActorVersionNotFoundError"
-              - $ref: "../../components/schemas/common/errors/EnvVariableErrors.yaml#/EnvironmentVariableNotFoundError"
-    "405":
-      $ref: ../../components/responses/MethodNotAllowed.yaml
-    "413":
-      $ref: ../../components/responses/PayloadTooLarge.yaml
-    "415":
-      $ref: ../../components/responses/UnsupportedMediaType.yaml
-    "429":
-      $ref: ../../components/responses/TooManyRequests.yaml
-  deprecated: false
+  x-legacy-doc-urls:
+    - https://docs.apify.com/api/v2#/reference/actors/environment-variable-object/update-environment-variable
+    - https://docs.apify.com/api/v2#/reference/actors/update-environment-variable
+    - https://docs.apify.com/api/v2#tag/ActorsEnvironment-variable-object/operation/act_version_envVar_post
+  $ref: "../../components/objects/actors/acts@{actorId}@versions@{versionNumber}@env-vars@{envVarName}put.yaml"
 delete:
   tags:
     - Actors/Actor versions

--- a/apify-api/openapi/paths/actors/acts@{actorId}@versions@{versionNumber}@env-vars@{envVarName}.yaml
+++ b/apify-api/openapi/paths/actors/acts@{actorId}@versions@{versionNumber}@env-vars@{envVarName}.yaml
@@ -147,6 +147,75 @@ put:
   x-py-parent: ActorEnvVarClientAsync
   x-py-name: update
   x-py-doc-url: https://docs.apify.com/api/client/python/reference/class/ActorEnvVarClientAsync#update
+post:
+  tags:
+    - Actors/Actor versions
+  summary: Update environment variable (POST)
+  description: |
+    Updates Actor environment variable using values specified by a [EnvVar
+    object](#/reference/actors/environment-variable-object)
+    passed as JSON in the POST payload.
+    This endpoint is an alias for the [`PUT` update environment variable](#tag/ActorsEnvironment-variable-object/operation/act_version_envVar_put) method and behaves identically.
+  operationId: act_version_envVar_post
+  parameters:
+    - $ref: "../../components/parameters/runAndBuildParameters.yaml#/actorId"
+    - $ref: "../../components/parameters/runAndBuildParameters.yaml#/versionNumber"
+    - name: envVarName
+      in: path
+      description: The name of the environment variable
+      required: true
+      style: simple
+      schema:
+        type: string
+        example: MY_ENV_VAR
+  requestBody:
+    description: ""
+    content:
+      application/json:
+        schema:
+          $ref: ../../components/schemas/actors/EnvVar.yaml
+        example:
+          name: MY_ENV_VAR
+          value: my-new-value
+          isSecret: false
+    required: true
+  responses:
+    "200":
+      description: ""
+      headers: {}
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas/actors/EnvVarResponse.yaml
+          example:
+            data:
+              name: MY_ENV_VAR
+              value: my-value
+              isSecret: false
+    "400":
+      $ref: ../../components/responses/BadRequest.yaml
+    "401":
+      $ref: ../../components/responses/Unauthorized.yaml
+    "403":
+      $ref: ../../components/responses/Forbidden.yaml
+    "404":
+      description: Not found - the requested resource was not found.
+      content:
+        application/json:
+          schema:
+            oneOf:
+              - $ref: "../../components/schemas/common/errors/ActorErrors.yaml#/ActorNotFoundError"
+              - $ref: "../../components/schemas/common/errors/ActorErrors.yaml#/ActorVersionNotFoundError"
+              - $ref: "../../components/schemas/common/errors/EnvVariableErrors.yaml#/EnvironmentVariableNotFoundError"
+    "405":
+      $ref: ../../components/responses/MethodNotAllowed.yaml
+    "413":
+      $ref: ../../components/responses/PayloadTooLarge.yaml
+    "415":
+      $ref: ../../components/responses/UnsupportedMediaType.yaml
+    "429":
+      $ref: ../../components/responses/TooManyRequests.yaml
+  deprecated: false
 delete:
   tags:
     - Actors/Actor versions

--- a/apify-api/openapi/paths/actors/acts@{actorId}@versions@{versionNumber}@env-vars@{envVarName}.yaml
+++ b/apify-api/openapi/paths/actors/acts@{actorId}@versions@{versionNumber}@env-vars@{envVarName}.yaml
@@ -60,43 +60,9 @@ get:
   x-py-name: get
   x-py-doc-url: https://docs.apify.com/api/client/python/reference/class/ActorEnvVarClientAsync#get
 put:
-  summary: Update environment variable
-  description: |
-    Updates Actor environment variable using values specified by a [EnvVar
-    object](#/reference/actors/environment-variable-object)
-    passed as JSON in the POST payload.
-    If the object does not define a specific property, its value will not be
-    updated.
-
-    The request needs to specify the `Content-Type: application/json` HTTP
-    header!
-
-    When providing your API authentication token, we recommend using the
-    request's `Authorization` header, rather than the URL. ([More
-    info](#/introduction/authentication)).
-
-    The response is the [EnvVar object](#/reference/actors/environment-variable-object) as returned by the
-    [Get environment variable](#/reference/actors/environment-variable-object/get-environment-variable)
-    endpoint.
-  operationId: act_version_envVar_put
-  x-legacy-doc-urls:
-    - https://docs.apify.com/api/v2#/reference/actors/environment-variable-object/update-environment-variable
-    - https://docs.apify.com/api/v2#/reference/actors/update-environment-variable
-    - https://docs.apify.com/api/v2#tag/ActorsEnvironment-variable-object/operation/act_version_envVar_put
-  $ref: "../../components/objects/actors/acts@{actorId}@versions@{versionNumber}@env-vars@{envVarName}put.yaml"
+  $ref: "../../components/objects/actors/acts@{actorId}@versions@{versionNumber}@env-vars@{envVarName}put.yaml#/put"
 post:
-  summary: Update environment variable (POST)
-  description: |
-    Updates Actor environment variable using values specified by a [EnvVar
-    object](#/reference/actors/environment-variable-object)
-    passed as JSON in the POST payload.
-    This endpoint is an alias for the [`PUT` update environment variable](#tag/ActorsEnvironment-variable-object/operation/act_version_envVar_put) method and behaves identically.
-  operationId: act_version_envVar_post
-  x-legacy-doc-urls:
-    - https://docs.apify.com/api/v2#/reference/actors/environment-variable-object/update-environment-variable
-    - https://docs.apify.com/api/v2#/reference/actors/update-environment-variable
-    - https://docs.apify.com/api/v2#tag/ActorsEnvironment-variable-object/operation/act_version_envVar_post
-  $ref: "../../components/objects/actors/acts@{actorId}@versions@{versionNumber}@env-vars@{envVarName}put.yaml"
+  $ref: "../../components/objects/actors/acts@{actorId}@versions@{versionNumber}@env-vars@{envVarName}put.yaml#/post"
 delete:
   tags:
     - Actors/Actor versions

--- a/apify-api/openapi/paths/datasets/datasets@{datasetId}@items.yaml
+++ b/apify-api/openapi/paths/datasets/datasets@{datasetId}@items.yaml
@@ -188,30 +188,7 @@ get:
     "200":
       description: ""
       headers:
-        X-Apify-Pagination-Offset:
-          content:
-            text/plain:
-              schema:
-                type: string
-              example: "0"
-        X-Apify-Pagination-Limit:
-          content:
-            text/plain:
-              schema:
-                type: string
-              example: "100"
-        X-Apify-Pagination-Count:
-          content:
-            text/plain:
-              schema:
-                type: string
-              example: "100"
-        X-Apify-Pagination-Total:
-          content:
-            text/plain:
-              schema:
-                type: string
-              example: "10204"
+        $ref: ../../components/headers/ApifyPaginationHeaders.yaml
       content:
         application/json:
           schema:
@@ -269,6 +246,54 @@ get:
   x-py-parent: DatasetClientAsync
   x-py-name: stream_items
   x-py-doc-url: https://docs.apify.com/api/client/python/reference/class/DatasetClientAsync#stream_items
+head:
+  tags:
+    - Storage/Datasets
+  summary: Get dataset items headers
+  description: |
+    Returns only the HTTP headers for the dataset items endpoint, without the response body.
+    This is useful to check pagination metadata or verify access without downloading the full dataset.
+  operationId: dataset_items_head
+  parameters:
+    - $ref: "../../components/parameters/storageParameters.yaml#/datasetId"
+    - $ref: "../../components/parameters/datasetItemsParameters.yaml#/format"
+    - $ref: "../../components/parameters/datasetItemsParameters.yaml#/clean"
+    - $ref: "../../components/parameters/paginationParameters.yaml#/offset"
+    - $ref: "../../components/parameters/datasetItemsParameters.yaml#/limit"
+    - $ref: "../../components/parameters/datasetItemsParameters.yaml#/fields"
+    - $ref: "../../components/parameters/datasetItemsParameters.yaml#/omit"
+    - $ref: "../../components/parameters/datasetItemsParameters.yaml#/unwind"
+    - $ref: "../../components/parameters/datasetItemsParameters.yaml#/flatten"
+    - $ref: "../../components/parameters/datasetItemsParameters.yaml#/descDataset"
+    - $ref: "../../components/parameters/datasetItemsParameters.yaml#/attachment"
+    - $ref: "../../components/parameters/datasetItemsParameters.yaml#/delimiter"
+    - $ref: "../../components/parameters/datasetItemsParameters.yaml#/bom"
+    - $ref: "../../components/parameters/datasetItemsParameters.yaml#/xmlRoot"
+    - $ref: "../../components/parameters/datasetItemsParameters.yaml#/xmlRow"
+    - $ref: "../../components/parameters/datasetItemsParameters.yaml#/skipHeaderRow"
+    - $ref: "../../components/parameters/datasetItemsParameters.yaml#/skipHidden"
+    - $ref: "../../components/parameters/datasetItemsParameters.yaml#/skipEmpty"
+    - $ref: "../../components/parameters/datasetItemsParameters.yaml#/simplified"
+    - name: view
+      in: query
+      description: |
+        Defines the view configuration for dataset items based on the schema definition.
+        This parameter determines how the data will be filtered and presented.
+        For complete specification details, see the [dataset schema documentation](/platform/actors/development/actor-definition/dataset-schema).
+      schema:
+        type: string
+        example: overview
+    - $ref: "../../components/parameters/datasetItemsParameters.yaml#/skipFailedPages"
+    - $ref: "../../components/parameters/storageParameters.yaml#/signature"
+  responses:
+    "200":
+      description: ""
+      headers:
+        $ref: ../../components/headers/ApifyPaginationHeaders.yaml
+      content: {}
+    "400":
+      $ref: ../../components/responses/BadRequest.yaml
+  deprecated: false
 post:
   tags:
     - Storage/Datasets
@@ -289,9 +314,11 @@ post:
     content:
       application/json:
         schema:
-          type: array
-          items:
-            $ref: ../../components/schemas/datasets/PutItemsRequest.yaml
+          oneOf:
+            - $ref: ../../components/schemas/datasets/PutItemsRequest.yaml
+            - type: array
+              items:
+                $ref: ../../components/schemas/datasets/PutItemsRequest.yaml
           description: ""
     required: true
   responses:
@@ -316,6 +343,8 @@ post:
         application/json:
           schema:
             $ref: ../../components/schemas/datasets/PutItemResponseError.yaml
+    "403":
+      $ref: ../../components/responses/Forbidden.yaml
     "404":
       description: Not found - the requested resource was not found.
       content:

--- a/apify-api/openapi/paths/key-value-stores/key-value-stores@{storeId}@records.yaml
+++ b/apify-api/openapi/paths/key-value-stores/key-value-stores@{storeId}@records.yaml
@@ -1,0 +1,57 @@
+get:
+  tags:
+    - Storage/Key-value stores
+  summary: Download records
+  description: |
+    Downloads all records from the key-value store as a ZIP archive.
+    Each record is stored as a separate file in the archive, with the filename equal to the record key.
+
+    You can optionally filter the records by `collection` or `prefix` to download only a subset of the store.
+  operationId: keyValueStore_records_get
+  parameters:
+    - $ref: "../../components/parameters/storageParameters.yaml#/storeId"
+    - name: collection
+      in: query
+      description: |
+        If specified, only records belonging to a specific collection from the key-value store schema. The key-value store need to have a schema defined for this parameter to work.
+      required: false
+      style: form
+      schema:
+        type: string
+        example: my-collection
+    - name: prefix
+      in: query
+      description: |
+        If specified, only records whose key starts with the given prefix are included in the archive.
+      required: false
+      style: form
+      schema:
+        type: string
+        example: my-prefix/
+    - $ref: "../../components/parameters/storageParameters.yaml#/signature"
+  responses:
+    "200":
+      description: A ZIP archive containing the requested records.
+      headers: {}
+      content:
+        application/zip:
+          schema:
+            type: string
+            format: binary
+    "400":
+      $ref: ../../components/responses/BadRequest.yaml
+    "401":
+      $ref: ../../components/responses/Unauthorized.yaml
+    "403":
+      $ref: ../../components/responses/Forbidden.yaml
+    "404":
+      description: Not found - the requested resource was not found.
+      content:
+        application/json:
+          schema:
+            $ref: "../../components/schemas/common/errors/StorageErrors.yaml#/KeyValueStoreNotFoundError"
+    "405":
+      $ref: ../../components/responses/MethodNotAllowed.yaml
+    "429":
+      $ref: ../../components/responses/TooManyRequests.yaml
+  deprecated: false

--- a/apify-api/openapi/paths/key-value-stores/key-value-stores@{storeId}@records@{recordKey}.yaml
+++ b/apify-api/openapi/paths/key-value-stores/key-value-stores@{storeId}@records@{recordKey}.yaml
@@ -108,8 +108,6 @@ head:
   x-py-name: record_exists
   x-py-doc-url: https://docs.apify.com/api/client/python/reference/class/KeyValueStoreClientAsync#record_exists
 put:
-  tags:
-    - Storage/Key-value stores
   summary: Store record
   description: |
     Stores a value under a specific key to the key-value store.
@@ -129,133 +127,22 @@ put:
     * Deflate compression: `Content-Encoding: deflate`
     * Brotli compression: `Content-Encoding: br`
   operationId: keyValueStore_record_put
-  parameters:
-    - $ref: "../../components/parameters/storageParameters.yaml#/storeId"
-    - $ref: "../../components/parameters/storageParameters.yaml#/recordKey"
-    - name: Content-Encoding
-      in: header
-      description: ""
-      required: false
-      style: simple
-      schema:
-        enum:
-          - gzip
-          - deflate
-          - br
-        type: string
-  requestBody:
-    description: ""
-    content:
-      application/json:
-        schema:
-          $ref: ../../components/schemas/key-value-stores/PutRecordRequest.yaml
-      "*/*":
-        schema: {}
-    required: true
-  responses:
-    "201":
-      description: ""
-      headers:
-        Location:
-          content:
-            text/plain:
-              schema:
-                type: string
-              example: >-
-                https://api.apify.com/v2/key-value-stores/WkzbQMuFYuamGv3YF/records/some-key
-      content:
-        application/json:
-          schema:
-            type: object
-          example: {}
-    "400":
-      $ref: ../../components/responses/BadRequest.yaml
-    "401":
-      $ref: ../../components/responses/Unauthorized.yaml
-    "403":
-      $ref: ../../components/responses/Forbidden.yaml
-    "405":
-      $ref: ../../components/responses/MethodNotAllowed.yaml
-    "413":
-      $ref: ../../components/responses/PayloadTooLarge.yaml
-    "415":
-      $ref: ../../components/responses/UnsupportedMediaType.yaml
-    "429":
-      $ref: ../../components/responses/TooManyRequests.yaml
-  deprecated: false
   x-legacy-doc-urls:
     - https://docs.apify.com/api/v2#/reference/key-value-stores/record/put-record
     - https://docs.apify.com/api/v2#/reference/key-value-stores/put-record
     - https://docs.apify.com/api/v2#tag/Key-value-storesRecord/operation/keyValueStore_record_put
-  x-js-parent: KeyValueStoreClient
-  x-js-name: setRecord
-  x-js-doc-url: https://docs.apify.com/api/client/js/reference/class/KeyValueStoreClient#setRecord
-  x-py-parent: KeyValueStoreClientAsync
-  x-py-name: set_record
-  x-py-doc-url: https://docs.apify.com/api/client/python/reference/class/KeyValueStoreClientAsync#set_record
+  $ref: "../../components/objects/key-value-stores/key-value-stores@{storeId}@records@{recordKey}put.yaml"
 post:
-  tags:
-    - Storage/Key-value stores
   summary: Store record (POST)
   description: |
     Stores a value under a specific key to the key-value store.
     This endpoint is an alias for the [`PUT` record](#tag/Key-value-storesRecord/operation/keyValueStore_record_put) method and behaves identically.
-
   operationId: keyValueStore_record_post
-  parameters:
-    - $ref: "../../components/parameters/storageParameters.yaml#/storeId"
-    - $ref: "../../components/parameters/storageParameters.yaml#/recordKey"
-    - name: Content-Encoding
-      in: header
-      description: ""
-      required: false
-      style: simple
-      schema:
-        enum:
-          - gzip
-          - deflate
-          - br
-        type: string
-  requestBody:
-    description: ""
-    content:
-      application/json:
-        schema:
-          $ref: ../../components/schemas/key-value-stores/PutRecordRequest.yaml
-      "*/*":
-        schema: {}
-    required: true
-  responses:
-    "201":
-      description: ""
-      headers:
-        Location:
-          content:
-            text/plain:
-              schema:
-                type: string
-              example: >-
-                https://api.apify.com/v2/key-value-stores/WkzbQMuFYuamGv3YF/records/some-key
-      content:
-        application/json:
-          schema:
-            type: object
-          example: {}
-    "400":
-      $ref: ../../components/responses/BadRequest.yaml
-    "401":
-      $ref: ../../components/responses/Unauthorized.yaml
-    "403":
-      $ref: ../../components/responses/Forbidden.yaml
-    "405":
-      $ref: ../../components/responses/MethodNotAllowed.yaml
-    "413":
-      $ref: ../../components/responses/PayloadTooLarge.yaml
-    "415":
-      $ref: ../../components/responses/UnsupportedMediaType.yaml
-    "429":
-      $ref: ../../components/responses/TooManyRequests.yaml
-  deprecated: false
+  x-legacy-doc-urls:
+    - https://docs.apify.com/api/v2#/reference/key-value-stores/record/put-record
+    - https://docs.apify.com/api/v2#/reference/key-value-stores/put-record
+    - https://docs.apify.com/api/v2#tag/Key-value-storesRecord/operation/keyValueStore_record_post
+  $ref: "../../components/objects/key-value-stores/key-value-stores@{storeId}@records@{recordKey}put.yaml"
 delete:
   tags:
     - Storage/Key-value stores

--- a/apify-api/openapi/paths/key-value-stores/key-value-stores@{storeId}@records@{recordKey}.yaml
+++ b/apify-api/openapi/paths/key-value-stores/key-value-stores@{storeId}@records@{recordKey}.yaml
@@ -108,41 +108,9 @@ head:
   x-py-name: record_exists
   x-py-doc-url: https://docs.apify.com/api/client/python/reference/class/KeyValueStoreClientAsync#record_exists
 put:
-  summary: Store record
-  description: |
-    Stores a value under a specific key to the key-value store.
-
-    The value is passed as the PUT payload and it is stored with a MIME content
-    type defined by the `Content-Type` header and with encoding defined by the
-    `Content-Encoding` header.
-
-    To save bandwidth, storage, and speed up your upload, send the request
-    payload compressed with Gzip compression and add the `Content-Encoding: gzip`
-    header. It is possible to set up another compression type with `Content-Encoding`
-    request header.
-
-    Below is a list of supported `Content-Encoding` types.
-
-    * Gzip compression: `Content-Encoding: gzip`
-    * Deflate compression: `Content-Encoding: deflate`
-    * Brotli compression: `Content-Encoding: br`
-  operationId: keyValueStore_record_put
-  x-legacy-doc-urls:
-    - https://docs.apify.com/api/v2#/reference/key-value-stores/record/put-record
-    - https://docs.apify.com/api/v2#/reference/key-value-stores/put-record
-    - https://docs.apify.com/api/v2#tag/Key-value-storesRecord/operation/keyValueStore_record_put
-  $ref: "../../components/objects/key-value-stores/key-value-stores@{storeId}@records@{recordKey}put.yaml"
+  $ref: "../../components/objects/key-value-stores/key-value-stores@{storeId}@records@{recordKey}put.yaml#/put"
 post:
-  summary: Store record (POST)
-  description: |
-    Stores a value under a specific key to the key-value store.
-    This endpoint is an alias for the [`PUT` record](#tag/Key-value-storesRecord/operation/keyValueStore_record_put) method and behaves identically.
-  operationId: keyValueStore_record_post
-  x-legacy-doc-urls:
-    - https://docs.apify.com/api/v2#/reference/key-value-stores/record/put-record
-    - https://docs.apify.com/api/v2#/reference/key-value-stores/put-record
-    - https://docs.apify.com/api/v2#tag/Key-value-storesRecord/operation/keyValueStore_record_post
-  $ref: "../../components/objects/key-value-stores/key-value-stores@{storeId}@records@{recordKey}put.yaml"
+  $ref: "../../components/objects/key-value-stores/key-value-stores@{storeId}@records@{recordKey}put.yaml#/post"
 delete:
   tags:
     - Storage/Key-value stores

--- a/apify-api/openapi/paths/key-value-stores/key-value-stores@{storeId}@records@{recordKey}.yaml
+++ b/apify-api/openapi/paths/key-value-stores/key-value-stores@{storeId}@records@{recordKey}.yaml
@@ -54,6 +54,8 @@ get:
         application/json:
           schema:
             $ref: ../../components/schemas/key-value-stores/RecordResponse.yaml
+        "*/*":
+          schema: {}
     "302":
       description: ""
       headers:
@@ -204,6 +206,69 @@ put:
   x-py-parent: KeyValueStoreClientAsync
   x-py-name: set_record
   x-py-doc-url: https://docs.apify.com/api/client/python/reference/class/KeyValueStoreClientAsync#set_record
+post:
+  tags:
+    - Storage/Key-value stores
+  summary: Store record (POST)
+  description: |
+    Stores a value under a specific key to the key-value store.
+    This endpoint is an alias for the [`PUT` record](#tag/Key-value-storesRecord/operation/keyValueStore_record_put) method and behaves identically.
+
+  operationId: keyValueStore_record_post
+  parameters:
+    - $ref: "../../components/parameters/storageParameters.yaml#/storeId"
+    - $ref: "../../components/parameters/storageParameters.yaml#/recordKey"
+    - name: Content-Encoding
+      in: header
+      description: ""
+      required: false
+      style: simple
+      schema:
+        enum:
+          - gzip
+          - deflate
+          - br
+        type: string
+  requestBody:
+    description: ""
+    content:
+      application/json:
+        schema:
+          $ref: ../../components/schemas/key-value-stores/PutRecordRequest.yaml
+      "*/*":
+        schema: {}
+    required: true
+  responses:
+    "201":
+      description: ""
+      headers:
+        Location:
+          content:
+            text/plain:
+              schema:
+                type: string
+              example: >-
+                https://api.apify.com/v2/key-value-stores/WkzbQMuFYuamGv3YF/records/some-key
+      content:
+        application/json:
+          schema:
+            type: object
+          example: {}
+    "400":
+      $ref: ../../components/responses/BadRequest.yaml
+    "401":
+      $ref: ../../components/responses/Unauthorized.yaml
+    "403":
+      $ref: ../../components/responses/Forbidden.yaml
+    "405":
+      $ref: ../../components/responses/MethodNotAllowed.yaml
+    "413":
+      $ref: ../../components/responses/PayloadTooLarge.yaml
+    "415":
+      $ref: ../../components/responses/UnsupportedMediaType.yaml
+    "429":
+      $ref: ../../components/responses/TooManyRequests.yaml
+  deprecated: false
 delete:
   tags:
     - Storage/Key-value stores

--- a/apify-api/openapi/paths/key-value-stores/key-value-stores@{storeId}@records@{recordKey}.yaml
+++ b/apify-api/openapi/paths/key-value-stores/key-value-stores@{storeId}@records@{recordKey}.yaml
@@ -33,6 +33,19 @@ get:
       schema:
         type: boolean
         example: true
+    - name: disableRedirect
+      in: query
+      description: |
+        If `true` or `1`, the API returns the record content directly in the response body with status
+        code `200` instead of redirecting to a signed S3 URL with status code `302`.
+        Use this parameter when your HTTP client does not follow redirects automatically, or when
+        you want to avoid an additional round-trip to S3. Note that large records may increase
+        response time compared to the redirect approach.
+      required: false
+      style: form
+      schema:
+        type: boolean
+        example: true
   responses:
     "200":
       description: ""
@@ -147,6 +160,8 @@ put:
       application/json:
         schema:
           $ref: ../../components/schemas/key-value-stores/PutRecordRequest.yaml
+      "*/*":
+        schema: {}
     required: true
   responses:
     "201":

--- a/apify-api/openapi/paths/key-value-stores/key-value-stores@{storeId}@records@{recordKey}.yaml
+++ b/apify-api/openapi/paths/key-value-stores/key-value-stores@{storeId}@records@{recordKey}.yaml
@@ -33,19 +33,6 @@ get:
       schema:
         type: boolean
         example: true
-    - name: disableRedirect
-      in: query
-      description: |
-        If `true` or `1`, the API returns the record content directly in the response body with status
-        code `200` instead of redirecting to a signed S3 URL with status code `302`.
-        Use this parameter when your HTTP client does not follow redirects automatically, or when
-        you want to avoid an additional round-trip to S3. Note that large records may increase
-        response time compared to the redirect approach.
-      required: false
-      style: form
-      schema:
-        type: boolean
-        example: true
   responses:
     "200":
       description: ""

--- a/apify-api/openapi/paths/request-queues/request-queues@{queueId}@head@lock.yaml
+++ b/apify-api/openapi/paths/request-queues/request-queues@{queueId}@head@lock.yaml
@@ -28,7 +28,7 @@ post:
         maximum: 25
     - $ref: "../../components/parameters/storageParameters.yaml#/clientKey"
   responses:
-    "200":
+    "201":
       description: ""
       headers: {}
       content:

--- a/apify-api/openapi/paths/request-queues/request-queues@{queueId}@requests.yaml
+++ b/apify-api/openapi/paths/request-queues/request-queues@{queueId}@requests.yaml
@@ -4,7 +4,7 @@ get:
   summary: List requests
   description: |
     Returns a list of requests. This endpoint is paginated using
-    cursor (pagination by exclusiveStartId is deprecated) and limit parameters.
+    cursor (pagination by `exclusiveStartId` is deprecated) and limit parameters.
   operationId: requestQueue_requests_get
   parameters:
     - $ref: "../../components/parameters/storageParameters.yaml#/queueId"

--- a/apify-api/openapi/paths/request-queues/request-queues@{queueId}@requests.yaml
+++ b/apify-api/openapi/paths/request-queues/request-queues@{queueId}@requests.yaml
@@ -11,7 +11,7 @@ get:
     - $ref: "../../components/parameters/storageParameters.yaml#/clientKey"
     - name: exclusiveStartId
       in: query
-      description: All requests up to this one (including) are skipped from the result.
+      description: All requests up to this one (including) are skipped from the result. Using this argument will add `nextCursor` to response to be able to get next page of requests if needed.
       style: form
       explode: true
       schema:
@@ -26,6 +26,25 @@ get:
         type: number
         format: double
         example: 100
+    - name: cursor
+      in: query
+      description: A cursor string for pagination, returned in the previous response as `nextCursor`. Use this to retrieve the next page of requests.
+      style: form
+      explode: true
+      schema:
+        type: string
+        example: eyJyZXF1ZXN0SWQiOiI2OFRqQ2RaTDNvM2hiUU0ifQ
+    - name: filter
+      in: query
+      description: Filter requests by their state. Possible values are `locked` and `pending`.
+      style: form
+      explode: true
+      schema:
+        type: string
+        enum:
+          - locked
+          - pending
+        example: locked
   responses:
     "200":
       description: ""

--- a/apify-api/openapi/paths/request-queues/request-queues@{queueId}@requests.yaml
+++ b/apify-api/openapi/paths/request-queues/request-queues@{queueId}@requests.yaml
@@ -4,14 +4,15 @@ get:
   summary: List requests
   description: |
     Returns a list of requests. This endpoint is paginated using
-    exclusiveStartId and limit parameters.
+    cursor (pagination by exclusiveStartId is deprecated) and limit parameters.
   operationId: requestQueue_requests_get
   parameters:
     - $ref: "../../components/parameters/storageParameters.yaml#/queueId"
     - $ref: "../../components/parameters/storageParameters.yaml#/clientKey"
     - name: exclusiveStartId
       in: query
-      description: All requests up to this one (including) are skipped from the result. Using this argument will add `nextCursor` to response to be able to get next page of requests if needed.
+      description: All requests up to this one (including) are skipped from the result. (Deprecated, use `cursor` instead.)
+      deprecated: true
       style: form
       explode: true
       schema:
@@ -36,7 +37,7 @@ get:
         example: eyJyZXF1ZXN0SWQiOiI2OFRqQ2RaTDNvM2hiUU0ifQ
     - name: filter
       in: query
-      description: Filter requests by their state. Possible values are `locked` and `pending`.
+      description: Filter requests by their state. Possible values are `locked` and `pending`. (Is not compatible with deprecated `exclusiveStartId` parameter.)
       style: form
       explode: true
       schema:
@@ -100,7 +101,7 @@ post:
     content:
       application/json:
         schema:
-          $ref: ../../components/schemas/request-queues/RequestDraft.yaml
+          $ref: ../../components/schemas/request-queues/RequestWithoutId.yaml
     required: true
   responses:
     "201":

--- a/apify-api/openapi/paths/request-queues/request-queues@{queueId}@requests@batch.yaml
+++ b/apify-api/openapi/paths/request-queues/request-queues@{queueId}@requests@batch.yaml
@@ -25,7 +25,7 @@ post:
         schema:
           type: array
           items:
-            $ref: ../../components/schemas/request-queues/RequestDraft.yaml
+            $ref: ../../components/schemas/request-queues/RequestWithoutId.yaml
           description: ""
     required: true
   responses:

--- a/apify-api/openapi/paths/request-queues/request-queues@{queueId}@requests@{requestId}@lock.yaml
+++ b/apify-api/openapi/paths/request-queues/request-queues@{queueId}@requests@{requestId}@lock.yaml
@@ -69,16 +69,6 @@ delete:
   parameters:
     - $ref: "../../components/parameters/storageParameters.yaml#/queueId"
     - $ref: "../../components/parameters/storageParameters.yaml#/requestId"
-    - name: Content-Type
-      in: header
-      description: ""
-      required: true
-      style: simple
-      schema:
-        enum:
-          - application/json
-        type: string
-        example: application/json
     - $ref: "../../components/parameters/storageParameters.yaml#/clientKeyLock"
     - name: forefront
       in: query


### PR DESCRIPTION
## Summary

### Dataset
- name field can be null (unnamed storage)
- POST `v2/datasets/:datasetId/items` can push both individual object or list of objects
- Add missing 403 to POST `v2/datasets/:datasetId/items`
- Extract and re-use pagination headers
- Document HEAD `v2/datasets/:datasetId/items` that returns pagination headers


### KVS
- name field can be null (unnamed storage)
- content type of record can be `*/*`, not just `application/json`
- Document `/v2/key-value-stores/:storeId/records`

### RQ
- name field can be null (unnamed storage)
- Extract and re-use shared properties
- Request that are added can't have have ID (both single and batch)
- deprecate `exclusiveStartId`
- document `filter`, `cursor`, `nextCursor` and related pagination

### Others
- Correct the OpenAPI specification version mentioned in docs
- Add some undocumented alias PUT/POST endpoints
  - `v2/acts/:actorId/versions/:versionNumber`
  - `v2/acts/:actorId/versions/:versionNumber/env-vars/:envVarName`
  - `v2/key-value-stores/:storeId/records/:recordKey`


## Motivation

- Solve OpenAPI validation errors

## Issues

Partially implements: https://github.com/apify/apify-docs/issues/2286