### PR TITLE
feat: residential proxy state targeting

### DIFF
--- a/sources/platform/proxy/residential_proxy.md
+++ b/sources/platform/proxy/residential_proxy.md
@@ -109,11 +109,13 @@ async def main():
 </Tabs>
 
 ### How to set a state
+
 :::note US states only
 State-level targeting is currently only supported for the United States.
 :::
 
-To use state targeting, specify the `country` parameter in the [username](./usage.md#username-parameters) using the [ISO 3166-2:US](https://en.wikipedia.org/wiki/ISO_3166-2:US) format: `country-US_XX`, where `XX` is the two-letter state abbreviation. For example, to target California when using the proxy URL directly, set the username to `groups-RESIDENTIAL,country-US-CA` 
+To use state targeting, specify the `country` parameter in the [username](./usage.md#username-parameters) using the [ISO 3166-2:US](https://en.wikipedia.org/wiki/ISO_3166-2:US) format: `country-US_XX`, where `XX` is the two-letter state abbreviation. For example, to target California when using the proxy URL directly, set the username to `groups-RESIDENTIAL,country-US-CA`
+
 
 In the [Apify SDK](/sdk) you set the state in your proxy configuration using the `countryCode`/`country_code` parameter:
 

--- a/sources/platform/proxy/residential_proxy.md
+++ b/sources/platform/proxy/residential_proxy.md
@@ -69,13 +69,7 @@ async def main():
 
 ### How to set a proxy country
 
-When using [standard libraries and languages](./datacenter_proxy.md), specify the `country` parameter in the [username](./usage.md#username-parameters) as `country-COUNTRY-CODE`.
-
-For example, your `username` parameter when using [Python 3](https://docs.python.org/3/) will look like this:
-
-```python
-username = "groups-RESIDENTIAL,country-JP"
-```
+When using [standard libraries and languages](./datacenter_proxy.md), specify the `country` parameter in the [username](./usage.md#username-parameters) as `country-COUNTRY-CODE`. For example, to target Japan, set the username to `groups-RESIDENTIAL,country-JP`.
 
 In the [Apify SDK](/sdk) you set the country in your proxy configuration using two-letter [country codes](https://laendercode.net/en/2-letter-list.html). Specify the groups as `RESIDENTIAL`, then add a `countryCode`/`country_code` parameter:
 
@@ -114,19 +108,12 @@ async def main():
 </TabItem>
 </Tabs>
 
-### How to set a state (US only)
-
+### How to set a state
 :::note US states only
 State-level targeting is currently only supported for the United States.
 :::
 
-To use state targeting, specify the `country` parameter in the [username](./usage.md#username-parameters) using the [ISO 3166-2:US](https://en.wikipedia.org/wiki/ISO_3166-2:US) format: `country-US_XX`, where `XX` is the two-letter state abbreviation.
-
-For example, your `username` parameter when targeting California will look like this:
-
-```python
-username = "groups-RESIDENTIAL,country-US_CA"
-```
+To use state targeting, specify the `country` parameter in the [username](./usage.md#username-parameters) using the [ISO 3166-2:US](https://en.wikipedia.org/wiki/ISO_3166-2:US) format: `country-US_XX`, where `XX` is the two-letter state abbreviation. For example, to target California when using the proxy URL directly, set the username to `groups-RESIDENTIAL,country-US-CA` 
 
 In the [Apify SDK](/sdk) you set the state in your proxy configuration using the `countryCode`/`country_code` parameter:
 

--- a/sources/platform/proxy/residential_proxy.md
+++ b/sources/platform/proxy/residential_proxy.md
@@ -114,6 +114,57 @@ async def main():
 </TabItem>
 </Tabs>
 
+### How to set a state (US only)
+
+:::note US states only
+State-level targeting is currently only supported for the United States.
+:::
+
+To use state targeting, specify the `country` parameter in the [username](./usage.md#username-parameters) using the [ISO 3166-2:US](https://en.wikipedia.org/wiki/ISO_3166-2:US) format: `country-US_XX`, where `XX` is the two-letter state abbreviation.
+
+For example, your `username` parameter when targeting California will look like this:
+
+```python
+username = "groups-RESIDENTIAL,country-US_CA"
+```
+
+In the [Apify SDK](/sdk) you set the state in your proxy configuration using the `countryCode`/`country_code` parameter:
+
+<Tabs groupId="main">
+<TabItem value="JavaScript" label="JavaScript">
+
+```js
+import { Actor } from 'apify';
+
+await Actor.init();
+// ...
+const proxyConfiguration = await Actor.createProxyConfiguration({
+    groups: ['RESIDENTIAL'],
+    countryCode: 'US_CA',
+});
+// ...
+await Actor.exit();
+```
+
+</TabItem>
+<TabItem value="Python" label="Python">
+
+```python
+from apify import Actor
+
+async def main():
+    async with Actor:
+        # ...
+        proxy_configuration = await Actor.create_proxy_configuration(
+            groups=['RESIDENTIAL'],
+            country_code='US_CA',
+        )
+        # ...
+```
+
+</TabItem>
+</Tabs>
+
 ## Session persistence
 
 When using residential proxy with the `session` [parameter](./usage.md#sessions) set in the [username](./usage.md#username-parameters), a single IP address is assigned to the **session ID** provided after you make the first request.


### PR DESCRIPTION
This PR adds information about US state targeting to residential proxy page.

More context about the feature here: https://github.com/apify/apify-proxy/issues/1350

