### PR TITLE
chore(deps): bump @apify/eslint-config to ^2.0.0

### DIFF
--- a/apify-docs-theme/src/config.js
+++ b/apify-docs-theme/src/config.js
@@ -1,4 +1,3 @@
-/* eslint-disable global-require */
 const { absoluteUrl } = require('./absoluteUrl');
 
 const noIndex = ['true', '1'].includes(process.env.NO_INDEX ?? '');

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
                 "unist-util-visit": "^5.0.0"
             },
             "devDependencies": {
-                "@apify/eslint-config": "^1.0.0",
+                "@apify/eslint-config": "^2.0.0",
                 "@apify/tsconfig": "^0.1.0",
                 "@stoplight/spectral-cli": "^6.15.0",
                 "@types/react": "^19.0.0",
@@ -740,24 +740,30 @@
             "link": true
         },
         "node_modules/@apify/eslint-config": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@apify/eslint-config/-/eslint-config-1.1.0.tgz",
-            "integrity": "sha512-3rVBzGcRP13aN8pcYz8qkbJ7ji4oJ/haabaiRiI43ytKBwasMA4rAcH0ZifVKm2qOAOj5Zd0e9YSuiqlTPDoDg==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@apify/eslint-config/-/eslint-config-2.0.0.tgz",
+            "integrity": "sha512-5g6uAC7JG3aLPflvLPBuDld5y4CpRUP/9Pm9eqOkdnZk5OwP4tVHeoyTxBxxoXTai2SLPyuqZ5ZMR2fdpbFBEw==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
-                "@eslint/compat": "^1.2.6",
-                "eslint-config-airbnb-base": "^15.0.0",
                 "eslint-plugin-import": "^2.32.0",
                 "eslint-plugin-simple-import-sort": "^12.1.1",
                 "globals": "^15.14.0"
             },
             "peerDependencies": {
+                "@stylistic/eslint-plugin": "^5.0.0",
+                "@vitest/eslint-plugin": "^1.6.14",
                 "eslint": "^9.19.0",
                 "eslint-plugin-jest": "^28.11.0",
                 "typescript-eslint": "^8.23.0"
             },
             "peerDependenciesMeta": {
+                "@stylistic/eslint-plugin": {
+                    "optional": true
+                },
+                "@vitest/eslint-plugin": {
+                    "optional": true
+                },
                 "eslint-plugin-jest": {
                     "optional": true
                 },
@@ -7027,27 +7033,6 @@
             "license": "MIT",
             "engines": {
                 "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
-            }
-        },
-        "node_modules/@eslint/compat": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/@eslint/compat/-/compat-1.4.1.tgz",
-            "integrity": "sha512-cfO82V9zxxGBxcQDr1lfaYB7wykTa0b00mGa36FrJl7iTFd0Z2cHfEYuxcBRP/iNijCsWsEkA+jzT8hGYmv33w==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@eslint/core": "^0.17.0"
-            },
-            "engines": {
-                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-            },
-            "peerDependencies": {
-                "eslint": "^8.40 || 9"
-            },
-            "peerDependenciesMeta": {
-                "eslint": {
-                    "optional": true
-                }
             }
         },
         "node_modules/@eslint/config-array": {
@@ -14311,13 +14296,6 @@
                 "url": "https://github.com/yeoman/configstore?sponsor=1"
             }
         },
-        "node_modules/confusing-browser-globals": {
-            "version": "1.0.11",
-            "resolved": "https://registry.npmjs.org/confusing-browser-globals/-/confusing-browser-globals-1.0.11.tgz",
-            "integrity": "sha512-JsPKdmh8ZkmnHxDk55FZ1TqVLvEQTvoByJZRN9jzI0UjxK/QgAmsphz7PGtqgPieQZ/CQcHWXCR7ATDNhGe+YA==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/connect-history-api-fallback": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-2.0.0.tgz",
@@ -16724,36 +16702,6 @@
                 "jiti": {
                     "optional": true
                 }
-            }
-        },
-        "node_modules/eslint-config-airbnb-base": {
-            "version": "15.0.0",
-            "resolved": "https://registry.npmjs.org/eslint-config-airbnb-base/-/eslint-config-airbnb-base-15.0.0.tgz",
-            "integrity": "sha512-xaX3z4ZZIcFLvh2oUNvcX5oEofXda7giYmuplVxoOg5A7EXJMrUyqRgR+mhDhPK8LZ4PttFOBvCYDbX3sUoUig==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "confusing-browser-globals": "^1.0.10",
-                "object.assign": "^4.1.2",
-                "object.entries": "^1.1.5",
-                "semver": "^6.3.0"
-            },
-            "engines": {
-                "node": "^10.12.0 || >=12.0.0"
-            },
-            "peerDependencies": {
-                "eslint": "^7.32.0 || ^8.2.0",
-                "eslint-plugin-import": "^2.25.2"
-            }
-        },
-        "node_modules/eslint-config-airbnb-base/node_modules/semver": {
-            "version": "6.3.1",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-            "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-            "dev": true,
-            "license": "ISC",
-            "bin": {
-                "semver": "bin/semver.js"
             }
         },
         "node_modules/eslint-import-resolver-node": {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
         "postbuild": "node ./scripts/joinLlmsFiles.mjs && node ./scripts/indentLlmsFile.mjs"
     },
     "devDependencies": {
-        "@apify/eslint-config": "^1.0.0",
+        "@apify/eslint-config": "^2.0.0",
         "@apify/tsconfig": "^0.1.0",
         "@stoplight/spectral-cli": "^6.15.0",
         "@types/react": "^19.0.0",

--- a/tools/utils/collectSlugs.js
+++ b/tools/utils/collectSlugs.js
@@ -7,7 +7,6 @@ function collectSlugs(pathname) {
 
     let direntry;
 
-    // eslint-disable-next-line no-cond-assign
     while ((direntry = dir.readSync()) !== null) {
         if (direntry.isFile() && direntry.name.endsWith('.md')) {
             const mdContent = readFileSync(join(pathname, direntry.name), { encoding: 'utf-8' });


### PR DESCRIPTION
## Summary

Bumps `@apify/eslint-config` from `^1.0.0` to `^2.0.0`. v2.0.0 ([apify/apify-eslint-config#35](https://github.com/apify/apify-eslint-config/pull/35)):
- drops the unmaintained `eslint-config-airbnb-base` dep
- preserves the meaningful airbnb rules inline
- moves stylistic rules to an opt-in `@apify/eslint-config/style` export

## Lint impact

`npm run lint:code` against this branch: **0 errors, 0 warnings.**

The bump surfaced 2 dead `// eslint-disable` directives — comments for rules the new config no longer enables:

- `apify-docs-theme/src/config.js` — removed `/* eslint-disable global-require */`
- `tools/utils/collectSlugs.js` — removed `// eslint-disable-next-line no-cond-assign`

Zero real new lint findings.

## Test plan

- [x] `npm install`
- [x] `npm run lint:code` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)