### PR TITLE
feat: Making clearer that env vars are shared along with source code

### DIFF
--- a/sources/platform/actors/development/programming_interface/environment_variables.md
+++ b/sources/platform/actors/development/programming_interface/environment_variables.md
@@ -120,7 +120,7 @@ For sensitive data like API keys or passwords, enable the **Secret** option. Thi
 
 :::caution Visibility of environment variables in public Actors
 
-When you [publish your Actor](/platform/actors/publishing/publish), non-secret environment variables are visible to anyone on the Actor detail page along with the source code. If you enable **Hide source files from Actor detail** in the Actor's **Settings**, non-secret environment variables are hidden as well.
+When you [publish your Actor](/platform/actors/publishing/publish), environment variables not marked as **Secret** in Apify Console are visible to anyone on the Actor detail page along with the source code. If you enable **Hide source files from Actor detail** in the Actor's **Settings**, environment variables not marked as **Secret** in Apify Console are hidden as well.
 
 Secret environment variables are never exposed on the Actor detail page regardless of this setting. Always mark sensitive values as **Secret**.
 

--- a/sources/platform/actors/development/programming_interface/environment_variables.md
+++ b/sources/platform/actors/development/programming_interface/environment_variables.md
@@ -118,6 +118,14 @@ Actor owners can define custom environment variables to pass additional configur
 
 For sensitive data like API keys or passwords, enable the **Secret** option. This will encrypt the value and redact it from logs to prevent accidental exposure.
 
+:::caution Visibility of environment variables in public Actors
+
+When you [publish your Actor](/platform/actors/publishing/publish), non-secret environment variables are visible to anyone on the Actor detail page along with the source code. If you enable **Hide source files from Actor detail** in the Actor's **Settings**, non-secret environment variables are hidden as well.
+
+Secret environment variables are never exposed on the Actor detail page regardless of this setting. Always mark sensitive values as **Secret**.
+
+:::
+
 :::info Build-time variables
 
 Once you start a build, you cannot change its environment variables. To use different variables, you must create a new build.

--- a/sources/platform/actors/development/programming_interface/environment_variables.md
+++ b/sources/platform/actors/development/programming_interface/environment_variables.md
@@ -120,7 +120,7 @@ For sensitive data like API keys or passwords, enable the **Secret** option. Thi
 
 :::caution Visibility of environment variables in public Actors
 
-When you [publish your Actor](/platform/actors/publishing/publish), environment variables not marked as **Secret** in Apify Console are visible to anyone on the Actor detail page along with the source code. If you enable **Hide source files from Actor detail** in the Actor's **Settings**, environment variables not marked as **Secret** in Apify Console are hidden as well.
+When you [publish your Actor](/platform/actors/publishing/publish), environment variables not marked as **Secret** in Apify Console are visible to anyone on the Actor detail page alongside the source code. Enable **Hide source files from Actor detail** in the Actor's **Settings** to hide both.
 
 Secret environment variables are never exposed on the Actor detail page regardless of this setting. Always mark sensitive values as **Secret**.
 

--- a/sources/platform/actors/publishing/publish.mdx
+++ b/sources/platform/actors/publishing/publish.mdx
@@ -56,3 +56,9 @@ To save time when writing your Actor's README, you can use the following templat
 https://github.com/zpelechova/readme-template
 
 Note that the complexity of your README should match the complexity of your Actor. Feel free to adapt the template to fit your Actor's specific requirements.
+
+## Source code visibility
+
+When you publish an Actor, its source code files and non-secret [environment variables](/platform/actors/development/programming-interface/environment-variables) are **publicly visible** by default on the Actor detail page.
+
+To hide them, go to your Actor's **Settings** tab in Apify Console and check **Hide source files from Actor detail**. Secret environment variables are never exposed regardless of this setting.

--- a/sources/platform/actors/publishing/publish.mdx
+++ b/sources/platform/actors/publishing/publish.mdx
@@ -59,6 +59,6 @@ Note that the complexity of your README should match the complexity of your Acto
 
 ## Source code visibility
 
-When you publish an Actor, its source code files and non-secret [environment variables](/platform/actors/development/programming-interface/environment-variables) are **publicly visible** by default on the Actor detail page.
+When you publish an Actor, its source code files and non-secret [environment variables](/platform/actors/development/programming-interface/environment-variables) are publicly visible by default on the Actor detail page.
 
 To hide them, go to your Actor's **Settings** tab in Apify Console and check **Hide source files from Actor detail**. Secret environment variables are never exposed regardless of this setting.


### PR DESCRIPTION
This was not mentioned at the right places, so adding it to the publication and env vars sections.