### PR TITLE
docs(openapi): Autofix OpenAPI spec validation errors

### DIFF
--- a/apify-api/openapi/components/tags.yaml
+++ b/apify-api/openapi/components/tags.yaml
@@ -125,6 +125,30 @@
     has been used for computation of this dollar equivalent, and hence it should be used only for informative purposes.
 
     You can learn more about platform usage in the [documentation](https://docs.apify.com/platform/actors/running/usage-and-resources#usage).
+- name: Actor runs/Dataset
+  x-displayName: Default dataset
+  x-parent-tag-name: Actor runs
+  x-trait: "true"
+  description: |
+    These endpoints provide shortcuts to access the default dataset of an Actor run.
+    They resolve the run's `defaultDatasetId` and proxy requests to the corresponding
+    [Datasets](/api/v2/datasets) endpoints.
+- name: Actor runs/Key-value store
+  x-displayName: Default key-value store
+  x-parent-tag-name: Actor runs
+  x-trait: "true"
+  description: |
+    These endpoints provide shortcuts to access the default key-value store of an Actor run.
+    They resolve the run's `defaultKeyValueStoreId` and proxy requests to the corresponding
+    [Key-value stores](/api/v2/key-value-stores) endpoints.
+- name: Actor runs/Request queue
+  x-displayName: Default request queue
+  x-parent-tag-name: Actor runs
+  x-trait: "true"
+  description: |
+    These endpoints provide shortcuts to access the default request queue of an Actor run.
+    They resolve the run's `defaultRequestQueueId` and proxy requests to the corresponding
+    [Request queues](/api/v2/request-queues) endpoints.
 - name: Actor tasks
   x-displayName: Actor tasks - Introduction
   x-legacy-doc-urls:

--- a/apify-api/openapi/openapi.yaml
+++ b/apify-api/openapi/openapi.yaml
@@ -520,6 +520,8 @@ paths:
     $ref: "paths/actors/acts@{actorId}@runs@{runId}@abort.yaml"
   "/v2/acts/{actorId}/runs/{runId}/metamorph":
     $ref: "paths/actors/acts@{actorId}@runs@{runId}@metamorph.yaml"
+  "/v2/acts/{actorId}/validate-input":
+    $ref: "paths/actors/acts@{actorId}@validate-input.yaml"
   /v2/actor-tasks:
     $ref: paths/actor-tasks/actor-tasks.yaml
   "/v2/actor-tasks/{actorTaskId}":
@@ -550,6 +552,14 @@ paths:
     $ref: paths/actor-runs/actor-runs@{runId}@resurrect.yaml
   "/v2/actor-runs/{runId}/charge":
     $ref: paths/actor-runs/actor-runs@{runId}@charge.yaml
+  "/v2/actor-runs/{runId}/dataset":
+    $ref: paths/actor-runs/actor-runs@{runId}@dataset.yaml
+  "/v2/actor-runs/{runId}/key-value-store":
+    $ref: paths/actor-runs/actor-runs@{runId}@key-value-store.yaml
+  "/v2/actor-runs/{runId}/log":
+    $ref: paths/actor-runs/actor-runs@{runId}@log.yaml
+  "/v2/actor-runs/{runId}/request-queue":
+    $ref: paths/actor-runs/actor-runs@{runId}@request-queue.yaml
   /v2/actor-builds:
     $ref: paths/actor-builds/actor-builds.yaml
   "/v2/actor-builds/{buildId}":

--- a/apify-api/openapi/openapi.yaml
+++ b/apify-api/openapi/openapi.yaml
@@ -560,6 +560,30 @@ paths:
     $ref: paths/actor-runs/actor-runs@{runId}@log.yaml
   "/v2/actor-runs/{runId}/request-queue":
     $ref: paths/actor-runs/actor-runs@{runId}@request-queue.yaml
+  "/v2/actor-runs/{runId}/dataset/items":
+    $ref: paths/actor-runs/actor-runs@{runId}@dataset@items.yaml
+  "/v2/actor-runs/{runId}/dataset/statistics":
+    $ref: paths/actor-runs/actor-runs@{runId}@dataset@statistics.yaml
+  "/v2/actor-runs/{runId}/key-value-store/keys":
+    $ref: paths/actor-runs/actor-runs@{runId}@key-value-store@keys.yaml
+  "/v2/actor-runs/{runId}/key-value-store/records":
+    $ref: paths/actor-runs/actor-runs@{runId}@key-value-store@records.yaml
+  "/v2/actor-runs/{runId}/key-value-store/records/{recordKey}":
+    $ref: "paths/actor-runs/actor-runs@{runId}@key-value-store@records@{recordKey}.yaml"
+  "/v2/actor-runs/{runId}/request-queue/requests":
+    $ref: paths/actor-runs/actor-runs@{runId}@request-queue@requests.yaml
+  "/v2/actor-runs/{runId}/request-queue/requests/batch":
+    $ref: paths/actor-runs/actor-runs@{runId}@request-queue@requests@batch.yaml
+  "/v2/actor-runs/{runId}/request-queue/requests/unlock":
+    $ref: paths/actor-runs/actor-runs@{runId}@request-queue@requests@unlock.yaml
+  "/v2/actor-runs/{runId}/request-queue/requests/{requestId}":
+    $ref: "paths/actor-runs/actor-runs@{runId}@request-queue@requests@{requestId}.yaml"
+  "/v2/actor-runs/{runId}/request-queue/requests/{requestId}/lock":
+    $ref: "paths/actor-runs/actor-runs@{runId}@request-queue@requests@{requestId}@lock.yaml"
+  "/v2/actor-runs/{runId}/request-queue/head":
+    $ref: paths/actor-runs/actor-runs@{runId}@request-queue@head.yaml
+  "/v2/actor-runs/{runId}/request-queue/head/lock":
+    $ref: paths/actor-runs/actor-runs@{runId}@request-queue@head@lock.yaml
   /v2/actor-builds:
     $ref: paths/actor-builds/actor-builds.yaml
   "/v2/actor-builds/{buildId}":

--- a/apify-api/openapi/paths/actor-runs/actor-runs@{runId}@dataset.yaml
+++ b/apify-api/openapi/paths/actor-runs/actor-runs@{runId}@dataset.yaml
@@ -1,0 +1,35 @@
+get:
+  tags:
+    - Actor runs
+  summary: Get default dataset
+  description: |
+    Returns the default dataset associated with an Actor run.
+
+    This endpoint is a shortcut for getting the run's `defaultDatasetId` and then using the
+    [Get dataset](/api/v2/dataset-get) endpoint.
+
+    This endpoint has the same response as the [Get dataset](/api/v2/dataset-get) endpoint.
+  operationId: actorRun_dataset_get
+  parameters:
+    - $ref: "../../components/parameters/runAndBuildParameters.yaml#/runId"
+  responses:
+    "200":
+      description: ""
+      headers: {}
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas/datasets/DatasetResponse.yaml
+    "400":
+      $ref: ../../components/responses/BadRequest.yaml
+    "401":
+      $ref: ../../components/responses/Unauthorized.yaml
+    "403":
+      $ref: ../../components/responses/Forbidden.yaml
+    "404":
+      $ref: ../../components/responses/NotFound.yaml
+    "405":
+      $ref: ../../components/responses/MethodNotAllowed.yaml
+    "429":
+      $ref: ../../components/responses/TooManyRequests.yaml
+  deprecated: false

--- a/apify-api/openapi/paths/actor-runs/actor-runs@{runId}@dataset@items.yaml
+++ b/apify-api/openapi/paths/actor-runs/actor-runs@{runId}@dataset@items.yaml
@@ -1,0 +1,197 @@
+get:
+  tags:
+    - Actor runs/Dataset
+  summary: Get dataset items
+  description: |
+    Returns data stored in the default dataset of the Actor run in the desired format.
+
+    This endpoint is a shortcut that resolves the run's `defaultDatasetId` and proxies to the
+    [Get dataset items](/api/v2/dataset-items-get) endpoint.
+  operationId: actorRun_dataset_items_get
+  parameters:
+    - $ref: "../../components/parameters/runAndBuildParameters.yaml#/runId"
+    - $ref: "../../components/parameters/datasetItemsParameters.yaml#/format"
+    - $ref: "../../components/parameters/datasetItemsParameters.yaml#/clean"
+    - $ref: "../../components/parameters/paginationParameters.yaml#/offset"
+    - $ref: "../../components/parameters/datasetItemsParameters.yaml#/limit"
+    - $ref: "../../components/parameters/datasetItemsParameters.yaml#/fields"
+    - $ref: "../../components/parameters/datasetItemsParameters.yaml#/omit"
+    - $ref: "../../components/parameters/datasetItemsParameters.yaml#/unwind"
+    - $ref: "../../components/parameters/datasetItemsParameters.yaml#/flatten"
+    - $ref: "../../components/parameters/datasetItemsParameters.yaml#/descDataset"
+    - $ref: "../../components/parameters/datasetItemsParameters.yaml#/attachment"
+    - $ref: "../../components/parameters/datasetItemsParameters.yaml#/delimiter"
+    - $ref: "../../components/parameters/datasetItemsParameters.yaml#/bom"
+    - $ref: "../../components/parameters/datasetItemsParameters.yaml#/xmlRoot"
+    - $ref: "../../components/parameters/datasetItemsParameters.yaml#/xmlRow"
+    - $ref: "../../components/parameters/datasetItemsParameters.yaml#/skipHeaderRow"
+    - $ref: "../../components/parameters/datasetItemsParameters.yaml#/skipHidden"
+    - $ref: "../../components/parameters/datasetItemsParameters.yaml#/skipEmpty"
+    - $ref: "../../components/parameters/datasetItemsParameters.yaml#/simplified"
+    - name: view
+      in: query
+      description: |
+        Defines the view configuration for dataset items based on the schema definition.
+        This parameter determines how the data will be filtered and presented.
+        For complete specification details, see the [dataset schema documentation](/platform/actors/development/actor-definition/dataset-schema).
+      schema:
+        type: string
+        example: overview
+    - $ref: "../../components/parameters/datasetItemsParameters.yaml#/skipFailedPages"
+  responses:
+    "200":
+      description: ""
+      headers:
+        $ref: ../../components/headers/ApifyPaginationHeaders.yaml
+      content:
+        application/json:
+          schema:
+            type: array
+            items:
+              type: object
+            example: [foo: bar, foo2: bar2]
+        application/jsonl:
+          schema:
+            type: string
+          example: '{"foo":"bar"}\n{"foo2":"bar2"}\n'
+        text/csv:
+          schema:
+            type: string
+          example: 'foo,bar\nfoo2,bar2\n'
+        text/html:
+          schema:
+            type: string
+          example: <table><tr><th>foo</th><th>bar</th></tr><tr><td>foo</td><td>bar</td></tr><tr><td>foo2</td><td>bar2</td></tr></table>
+        application/vnd.openxmlformats-officedocument.spreadsheetml.sheet:
+          schema:
+            type: string
+        application/rss+xml:
+          schema:
+            type: string
+          example: <rss><channel><item><foo>bar</foo></item><item><foo2>bar2</foo2></item></channel></rss>
+        application/xml:
+          schema:
+            type: string
+          example: <items><item><foo>bar</foo></item><item><foo2>bar2</foo2></item></items>
+    "400":
+      $ref: ../../components/responses/BadRequest.yaml
+    "401":
+      $ref: ../../components/responses/Unauthorized.yaml
+    "403":
+      $ref: ../../components/responses/Forbidden.yaml
+    "404":
+      description: Not found - the requested resource was not found.
+      content:
+        application/json:
+          schema:
+            $ref: "../../components/schemas/common/errors/StorageErrors.yaml#/DatasetNotFoundError"
+    "405":
+      $ref: ../../components/responses/MethodNotAllowed.yaml
+    "429":
+      $ref: ../../components/responses/TooManyRequests.yaml
+  deprecated: false
+head:
+  tags:
+    - Actor runs/Dataset
+  summary: Get dataset items headers
+  description: |
+    Returns only the HTTP headers for the dataset items endpoint of the Actor run's default dataset,
+    without the response body.
+  operationId: actorRun_dataset_items_head
+  parameters:
+    - $ref: "../../components/parameters/runAndBuildParameters.yaml#/runId"
+    - $ref: "../../components/parameters/datasetItemsParameters.yaml#/format"
+    - $ref: "../../components/parameters/datasetItemsParameters.yaml#/clean"
+    - $ref: "../../components/parameters/paginationParameters.yaml#/offset"
+    - $ref: "../../components/parameters/datasetItemsParameters.yaml#/limit"
+    - $ref: "../../components/parameters/datasetItemsParameters.yaml#/fields"
+    - $ref: "../../components/parameters/datasetItemsParameters.yaml#/omit"
+    - $ref: "../../components/parameters/datasetItemsParameters.yaml#/unwind"
+    - $ref: "../../components/parameters/datasetItemsParameters.yaml#/flatten"
+    - $ref: "../../components/parameters/datasetItemsParameters.yaml#/descDataset"
+    - $ref: "../../components/parameters/datasetItemsParameters.yaml#/attachment"
+    - $ref: "../../components/parameters/datasetItemsParameters.yaml#/delimiter"
+    - $ref: "../../components/parameters/datasetItemsParameters.yaml#/bom"
+    - $ref: "../../components/parameters/datasetItemsParameters.yaml#/xmlRoot"
+    - $ref: "../../components/parameters/datasetItemsParameters.yaml#/xmlRow"
+    - $ref: "../../components/parameters/datasetItemsParameters.yaml#/skipHeaderRow"
+    - $ref: "../../components/parameters/datasetItemsParameters.yaml#/skipHidden"
+    - $ref: "../../components/parameters/datasetItemsParameters.yaml#/skipEmpty"
+    - $ref: "../../components/parameters/datasetItemsParameters.yaml#/simplified"
+    - name: view
+      in: query
+      description: |
+        Defines the view configuration for dataset items based on the schema definition.
+        This parameter determines how the data will be filtered and presented.
+        For complete specification details, see the [dataset schema documentation](/platform/actors/development/actor-definition/dataset-schema).
+      schema:
+        type: string
+        example: overview
+    - $ref: "../../components/parameters/datasetItemsParameters.yaml#/skipFailedPages"
+  responses:
+    "200":
+      description: ""
+      headers:
+        $ref: ../../components/headers/ApifyPaginationHeaders.yaml
+      content: {}
+    "400":
+      $ref: ../../components/responses/BadRequest.yaml
+  deprecated: false
+post:
+  tags:
+    - Actor runs/Dataset
+  summary: Store items
+  description: |
+    Appends an item or an array of items to the end of the Actor run's default dataset.
+
+    This endpoint is a shortcut that resolves the run's `defaultDatasetId` and proxies to the
+    [Store items](/api/v2/dataset-items-post) endpoint.
+
+    **IMPORTANT:** The limit of request payload size for the dataset is 5 MB.
+    If the array exceeds the size, you'll need to split it into a number of smaller arrays.
+  operationId: actorRun_dataset_items_post
+  parameters:
+    - $ref: "../../components/parameters/runAndBuildParameters.yaml#/runId"
+  requestBody:
+    description: ""
+    content:
+      application/json:
+        schema:
+          oneOf:
+            - $ref: ../../components/schemas/datasets/PutItemsRequest.yaml
+            - type: array
+              items:
+                $ref: ../../components/schemas/datasets/PutItemsRequest.yaml
+          description: ""
+    required: true
+  responses:
+    "201":
+      description: ""
+      headers:
+        Location:
+          content:
+            text/plain:
+              schema:
+                type: string
+              example: https://api.apify.com/v2/datasets/WkzbQMuFYuamGv3YF/items
+      content:
+        application/json:
+          schema:
+            type: object
+          example: {}
+    "400":
+      description: ""
+      headers: {}
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas/datasets/PutItemResponseError.yaml
+    "403":
+      $ref: ../../components/responses/Forbidden.yaml
+    "404":
+      description: Not found - the requested resource was not found.
+      content:
+        application/json:
+          schema:
+            $ref: "../../components/schemas/common/errors/StorageErrors.yaml#/DatasetNotFoundError"
+  deprecated: false

--- a/apify-api/openapi/paths/actor-runs/actor-runs@{runId}@dataset@statistics.yaml
+++ b/apify-api/openapi/paths/actor-runs/actor-runs@{runId}@dataset@statistics.yaml
@@ -1,0 +1,35 @@
+get:
+  tags:
+    - Actor runs/Dataset
+  summary: Get dataset statistics
+  description: |
+    Returns statistics for the Actor run's default dataset.
+
+    This endpoint is a shortcut that resolves the run's `defaultDatasetId` and proxies to the
+    [Get dataset statistics](/api/v2/dataset-statistics-get) endpoint.
+  operationId: actorRun_dataset_statistics_get
+  parameters:
+    - $ref: "../../components/parameters/runAndBuildParameters.yaml#/runId"
+  responses:
+    "200":
+      description: ""
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas/datasets/DatasetStatisticsResponse.yaml
+    "400":
+      $ref: ../../components/responses/BadRequest.yaml
+    "401":
+      $ref: ../../components/responses/Unauthorized.yaml
+    "403":
+      $ref: ../../components/responses/Forbidden.yaml
+    "404":
+      description: Not found - the requested resource was not found.
+      content:
+        application/json:
+          schema:
+            $ref: "../../components/schemas/common/errors/StorageErrors.yaml#/DatasetNotFoundError"
+    "405":
+      $ref: ../../components/responses/MethodNotAllowed.yaml
+    "429":
+      $ref: ../../components/responses/TooManyRequests.yaml

--- a/apify-api/openapi/paths/actor-runs/actor-runs@{runId}@key-value-store.yaml
+++ b/apify-api/openapi/paths/actor-runs/actor-runs@{runId}@key-value-store.yaml
@@ -1,0 +1,35 @@
+get:
+  tags:
+    - Actor runs
+  summary: Get default key-value store
+  description: |
+    Returns the default key-value store associated with an Actor run.
+
+    This endpoint is a shortcut for getting the run's `defaultKeyValueStoreId` and then using the
+    [Get store](/api/v2/keyValueStore-get) endpoint.
+
+    This endpoint has the same response as the [Get store](/api/v2/keyValueStore-get) endpoint.
+  operationId: actorRun_keyValueStore_get
+  parameters:
+    - $ref: "../../components/parameters/runAndBuildParameters.yaml#/runId"
+  responses:
+    "200":
+      description: ""
+      headers: {}
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas/key-value-stores/KeyValueStoreResponse.yaml
+    "400":
+      $ref: ../../components/responses/BadRequest.yaml
+    "401":
+      $ref: ../../components/responses/Unauthorized.yaml
+    "403":
+      $ref: ../../components/responses/Forbidden.yaml
+    "404":
+      $ref: ../../components/responses/NotFound.yaml
+    "405":
+      $ref: ../../components/responses/MethodNotAllowed.yaml
+    "429":
+      $ref: ../../components/responses/TooManyRequests.yaml
+  deprecated: false

--- a/apify-api/openapi/paths/actor-runs/actor-runs@{runId}@key-value-store@keys.yaml
+++ b/apify-api/openapi/paths/actor-runs/actor-runs@{runId}@key-value-store@keys.yaml
@@ -1,0 +1,66 @@
+get:
+  tags:
+    - Actor runs/Key-value store
+  summary: Get list of keys
+  description: |
+    Returns a list of objects describing keys of the Actor run's default key-value store.
+
+    This endpoint is a shortcut that resolves the run's `defaultKeyValueStoreId` and proxies to the
+    [Get list of keys](/api/v2/keyValueStore-keys-get) endpoint.
+  operationId: actorRun_keyValueStore_keys_get
+  parameters:
+    - $ref: "../../components/parameters/runAndBuildParameters.yaml#/runId"
+    - name: exclusiveStartKey
+      in: query
+      description: All keys up to this one (including) are skipped from the result.
+      style: form
+      explode: true
+      schema:
+        type: string
+        example: Ihnsp8YrvJ8102Kj
+    - name: limit
+      in: query
+      description: Number of keys to be returned. Maximum value is `1000`.
+      style: form
+      explode: true
+      schema:
+        type: number
+        format: double
+        example: 100
+    - name: collection
+      in: query
+      description: Limit the results to keys that belong to a specific collection from the key-value store schema. The key-value store need to have a schema defined for this parameter to work.
+      schema:
+        type: string
+        example: postImages
+    - name: prefix
+      in: query
+      description: Limit the results to keys that start with a specific prefix.
+      schema:
+        type: string
+        example: post-images-
+  responses:
+    "200":
+      description: ""
+      headers: {}
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas/key-value-stores/ListOfKeysResponse.yaml
+    "400":
+      $ref: ../../components/responses/BadRequest.yaml
+    "401":
+      $ref: ../../components/responses/Unauthorized.yaml
+    "403":
+      $ref: ../../components/responses/Forbidden.yaml
+    "404":
+      description: Not found - the requested resource was not found.
+      content:
+        application/json:
+          schema:
+            $ref: "../../components/schemas/common/errors/StorageErrors.yaml#/KeyValueStoreNotFoundError"
+    "405":
+      $ref: ../../components/responses/MethodNotAllowed.yaml
+    "429":
+      $ref: ../../components/responses/TooManyRequests.yaml
+  deprecated: false

--- a/apify-api/openapi/paths/actor-runs/actor-runs@{runId}@key-value-store@records.yaml
+++ b/apify-api/openapi/paths/actor-runs/actor-runs@{runId}@key-value-store@records.yaml
@@ -1,0 +1,56 @@
+get:
+  tags:
+    - Actor runs/Key-value store
+  summary: Download records
+  description: |
+    Downloads all records from the Actor run's default key-value store as a ZIP archive.
+
+    This endpoint is a shortcut that resolves the run's `defaultKeyValueStoreId` and proxies to the
+    [Download records](/api/v2/keyValueStore-records-get) endpoint.
+  operationId: actorRun_keyValueStore_records_get
+  parameters:
+    - $ref: "../../components/parameters/runAndBuildParameters.yaml#/runId"
+    - name: collection
+      in: query
+      description: |
+        If specified, only records belonging to a specific collection from the key-value store schema. The key-value store need to have a schema defined for this parameter to work.
+      required: false
+      style: form
+      schema:
+        type: string
+        example: my-collection
+    - name: prefix
+      in: query
+      description: |
+        If specified, only records whose key starts with the given prefix are included in the archive.
+      required: false
+      style: form
+      schema:
+        type: string
+        example: my-prefix/
+  responses:
+    "200":
+      description: A ZIP archive containing the requested records.
+      headers: {}
+      content:
+        application/zip:
+          schema:
+            type: string
+            format: binary
+    "400":
+      $ref: ../../components/responses/BadRequest.yaml
+    "401":
+      $ref: ../../components/responses/Unauthorized.yaml
+    "403":
+      $ref: ../../components/responses/Forbidden.yaml
+    "404":
+      description: Not found - the requested resource was not found.
+      content:
+        application/json:
+          schema:
+            $ref: "../../components/schemas/common/errors/StorageErrors.yaml#/KeyValueStoreNotFoundError"
+    "405":
+      $ref: ../../components/responses/MethodNotAllowed.yaml
+    "429":
+      $ref: ../../components/responses/TooManyRequests.yaml
+  deprecated: false

--- a/apify-api/openapi/paths/actor-runs/actor-runs@{runId}@key-value-store@records@{recordKey}.yaml
+++ b/apify-api/openapi/paths/actor-runs/actor-runs@{runId}@key-value-store@records@{recordKey}.yaml
@@ -1,0 +1,231 @@
+get:
+  tags:
+    - Actor runs/Key-value store
+  summary: Get record
+  description: |
+    Gets a value stored in the Actor run's default key-value store under a specific key.
+
+    This endpoint is a shortcut that resolves the run's `defaultKeyValueStoreId` and proxies to the
+    [Get record](/api/v2/keyValueStore-record-get) endpoint.
+  operationId: actorRun_keyValueStore_record_get
+  parameters:
+    - $ref: "../../components/parameters/runAndBuildParameters.yaml#/runId"
+    - $ref: "../../components/parameters/storageParameters.yaml#/recordKey"
+    - name: attachment
+      in: query
+      description: |
+        If `true` or `1`, the response will be served with `Content-Disposition: attachment` header,
+        causing web browsers to offer downloading HTML records instead of displaying them.
+      required: false
+      style: form
+      schema:
+        type: boolean
+        example: true
+  responses:
+    "200":
+      description: ""
+      headers: {}
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas/key-value-stores/RecordResponse.yaml
+        "*/*":
+          schema: {}
+    "302":
+      description: ""
+      headers:
+        Location:
+          content:
+            text/plain:
+              schema:
+                type: string
+              example: >-
+                https://apifier-key-value-store-prod.s3.amazonaws.com/tqx6jeMia43gYY6eE/INPUT?AWSAccessKeyId=NKDOUN&Expires=1502720992&Signature=DKLVPI4lDDKC
+      content: {}
+    "400":
+      $ref: ../../components/responses/BadRequest.yaml
+    "401":
+      $ref: ../../components/responses/Unauthorized.yaml
+    "403":
+      $ref: ../../components/responses/Forbidden.yaml
+    "404":
+      description: Not found - the requested resource was not found.
+      content:
+        application/json:
+          schema:
+            oneOf:
+              - $ref: "../../components/schemas/common/errors/StorageErrors.yaml#/KeyValueStoreNotFoundError"
+              - $ref: "../../components/schemas/common/errors/StorageErrors.yaml#/RecordNotFoundError"
+    "405":
+      $ref: ../../components/responses/MethodNotAllowed.yaml
+    "429":
+      $ref: ../../components/responses/TooManyRequests.yaml
+  deprecated: false
+head:
+  tags:
+    - Actor runs/Key-value store
+  summary: Check if a record exists
+  description: |
+    Check if a value is stored in the Actor run's default key-value store under a specific key.
+  operationId: actorRun_keyValueStore_record_head
+  parameters:
+    - $ref: "../../components/parameters/runAndBuildParameters.yaml#/runId"
+    - $ref: "../../components/parameters/storageParameters.yaml#/recordKey"
+  responses:
+    "200":
+      description: The record exists
+      headers: {}
+    "404":
+      description: The record does not exist
+      headers: {}
+  deprecated: false
+put:
+  tags:
+    - Actor runs/Key-value store
+  summary: Store record
+  description: |
+    Stores a value under a specific key to the Actor run's default key-value store.
+
+    This endpoint is a shortcut that resolves the run's `defaultKeyValueStoreId` and proxies to the
+    [Store record](/api/v2/keyValueStore-record-put) endpoint.
+  operationId: actorRun_keyValueStore_record_put
+  parameters:
+    - $ref: "../../components/parameters/runAndBuildParameters.yaml#/runId"
+    - $ref: "../../components/parameters/storageParameters.yaml#/recordKey"
+    - name: Content-Encoding
+      in: header
+      description: ""
+      required: false
+      style: simple
+      schema:
+        enum:
+          - gzip
+          - deflate
+          - br
+        type: string
+  requestBody:
+    description: ""
+    content:
+      application/json:
+        schema:
+          $ref: ../../components/schemas/key-value-stores/PutRecordRequest.yaml
+      "*/*":
+        schema: {}
+    required: true
+  responses:
+    "201":
+      description: ""
+      headers:
+        Location:
+          content:
+            text/plain:
+              schema:
+                type: string
+              example: >-
+                https://api.apify.com/v2/key-value-stores/WkzbQMuFYuamGv3YF/records/some-key
+      content:
+        application/json:
+          schema:
+            type: object
+          example: {}
+    "400":
+      $ref: ../../components/responses/BadRequest.yaml
+    "401":
+      $ref: ../../components/responses/Unauthorized.yaml
+    "403":
+      $ref: ../../components/responses/Forbidden.yaml
+    "405":
+      $ref: ../../components/responses/MethodNotAllowed.yaml
+    "413":
+      $ref: ../../components/responses/PayloadTooLarge.yaml
+    "415":
+      $ref: ../../components/responses/UnsupportedMediaType.yaml
+    "429":
+      $ref: ../../components/responses/TooManyRequests.yaml
+  deprecated: false
+post:
+  tags:
+    - Actor runs/Key-value store
+  summary: Store record (POST)
+  description: |
+    Stores a value under a specific key to the Actor run's default key-value store.
+    This endpoint is an alias for the PUT record method and behaves identically.
+  operationId: actorRun_keyValueStore_record_post
+  parameters:
+    - $ref: "../../components/parameters/runAndBuildParameters.yaml#/runId"
+    - $ref: "../../components/parameters/storageParameters.yaml#/recordKey"
+    - name: Content-Encoding
+      in: header
+      description: ""
+      required: false
+      style: simple
+      schema:
+        enum:
+          - gzip
+          - deflate
+          - br
+        type: string
+  requestBody:
+    description: ""
+    content:
+      application/json:
+        schema:
+          $ref: ../../components/schemas/key-value-stores/PutRecordRequest.yaml
+      "*/*":
+        schema: {}
+    required: true
+  responses:
+    "201":
+      description: ""
+      headers:
+        Location:
+          content:
+            text/plain:
+              schema:
+                type: string
+              example: >-
+                https://api.apify.com/v2/key-value-stores/WkzbQMuFYuamGv3YF/records/some-key
+      content:
+        application/json:
+          schema:
+            type: object
+          example: {}
+    "400":
+      $ref: ../../components/responses/BadRequest.yaml
+    "401":
+      $ref: ../../components/responses/Unauthorized.yaml
+    "403":
+      $ref: ../../components/responses/Forbidden.yaml
+    "405":
+      $ref: ../../components/responses/MethodNotAllowed.yaml
+    "413":
+      $ref: ../../components/responses/PayloadTooLarge.yaml
+    "415":
+      $ref: ../../components/responses/UnsupportedMediaType.yaml
+    "429":
+      $ref: ../../components/responses/TooManyRequests.yaml
+  deprecated: false
+delete:
+  tags:
+    - Actor runs/Key-value store
+  summary: Delete record
+  description: |
+    Removes a record specified by a key from the Actor run's default key-value store.
+  operationId: actorRun_keyValueStore_record_delete
+  parameters:
+    - $ref: "../../components/parameters/runAndBuildParameters.yaml#/runId"
+    - $ref: "../../components/parameters/storageParameters.yaml#/recordKey"
+  responses:
+    "204":
+      $ref: ../../components/responses/NoContent.yaml
+    "400":
+      $ref: ../../components/responses/BadRequest.yaml
+    "401":
+      $ref: ../../components/responses/Unauthorized.yaml
+    "403":
+      $ref: ../../components/responses/Forbidden.yaml
+    "405":
+      $ref: ../../components/responses/MethodNotAllowed.yaml
+    "429":
+      $ref: ../../components/responses/TooManyRequests.yaml
+  deprecated: false

--- a/apify-api/openapi/paths/actor-runs/actor-runs@{runId}@log.yaml
+++ b/apify-api/openapi/paths/actor-runs/actor-runs@{runId}@log.yaml
@@ -1,0 +1,56 @@
+get:
+  tags:
+    - Actor runs
+  summary: Get log
+  description: |
+    Returns the log for an Actor run.
+
+    This endpoint is a shortcut for getting the run's log using the
+    [Get log](/api/v2/log-get) endpoint with the run ID.
+
+    This endpoint has the same response as the [Get log](/api/v2/log-get) endpoint.
+  operationId: actorRun_log_get
+  parameters:
+    - $ref: "../../components/parameters/runAndBuildParameters.yaml#/runId"
+    - $ref: "../../components/parameters/logOptions.yaml#/stream"
+    - $ref: "../../components/parameters/logOptions.yaml#/download"
+    - name: raw
+      in: query
+      description: |
+        If `true` or `1`, the logs will be kept verbatim. By default, the API removes
+        ANSI escape codes from the logs, keeping only printable characters.
+      required: false
+      style: form
+      explode: true
+      schema:
+        type: boolean
+        example: false
+  responses:
+    "200":
+      description: ""
+      headers: {}
+      content:
+        text/plain:
+          schema:
+            type: string
+            example: |
+              2017-07-14T06:00:49.733Z Application started.
+              2017-07-14T06:00:49.741Z Input: { test: 123 }
+              2017-07-14T06:00:49.752Z Some useful debug information follows.
+          example: |
+            2017-07-14T06:00:49.733Z Application started.
+            2017-07-14T06:00:49.741Z Input: { test: 123 }
+            2017-07-14T06:00:49.752Z Some useful debug information follows.
+    "400":
+      $ref: ../../components/responses/BadRequest.yaml
+    "401":
+      $ref: ../../components/responses/Unauthorized.yaml
+    "403":
+      $ref: ../../components/responses/Forbidden.yaml
+    "404":
+      $ref: ../../components/responses/NotFound.yaml
+    "405":
+      $ref: ../../components/responses/MethodNotAllowed.yaml
+    "429":
+      $ref: ../../components/responses/TooManyRequests.yaml
+  deprecated: false

--- a/apify-api/openapi/paths/actor-runs/actor-runs@{runId}@request-queue.yaml
+++ b/apify-api/openapi/paths/actor-runs/actor-runs@{runId}@request-queue.yaml
@@ -1,0 +1,35 @@
+get:
+  tags:
+    - Actor runs
+  summary: Get default request queue
+  description: |
+    Returns the default request queue associated with an Actor run.
+
+    This endpoint is a shortcut for getting the run's `defaultRequestQueueId` and then using the
+    [Get request queue](/api/v2/requestQueue-get) endpoint.
+
+    This endpoint has the same response as the [Get request queue](/api/v2/requestQueue-get) endpoint.
+  operationId: actorRun_requestQueue_get
+  parameters:
+    - $ref: "../../components/parameters/runAndBuildParameters.yaml#/runId"
+  responses:
+    "200":
+      description: ""
+      headers: {}
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas/request-queues/RequestQueueResponse.yaml
+    "400":
+      $ref: ../../components/responses/BadRequest.yaml
+    "401":
+      $ref: ../../components/responses/Unauthorized.yaml
+    "403":
+      $ref: ../../components/responses/Forbidden.yaml
+    "404":
+      $ref: ../../components/responses/NotFound.yaml
+    "405":
+      $ref: ../../components/responses/MethodNotAllowed.yaml
+    "429":
+      $ref: ../../components/responses/TooManyRequests.yaml
+  deprecated: false

--- a/apify-api/openapi/paths/actor-runs/actor-runs@{runId}@request-queue@head.yaml
+++ b/apify-api/openapi/paths/actor-runs/actor-runs@{runId}@request-queue@head.yaml
@@ -1,0 +1,47 @@
+get:
+  tags:
+    - Actor runs/Request queue
+  summary: Get head
+  description: |
+    Returns given number of first requests from the Actor run's default request queue.
+
+    This endpoint is a shortcut that resolves the run's `defaultRequestQueueId` and proxies to the
+    [Get head](/api/v2/requestQueue-head-get) endpoint.
+  operationId: actorRun_requestQueue_head_get
+  parameters:
+    - $ref: "../../components/parameters/runAndBuildParameters.yaml#/runId"
+    - name: limit
+      in: query
+      description: How many items from queue should be returned.
+      style: form
+      explode: true
+      schema:
+        type: number
+        format: double
+        example: 100
+    - $ref: "../../components/parameters/storageParameters.yaml#/clientKey"
+  responses:
+    "200":
+      description: ""
+      headers: {}
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas/request-queues/HeadResponse.yaml
+    "400":
+      $ref: ../../components/responses/BadRequest.yaml
+    "401":
+      $ref: ../../components/responses/Unauthorized.yaml
+    "403":
+      $ref: ../../components/responses/Forbidden.yaml
+    "404":
+      description: Not found - the requested resource was not found.
+      content:
+        application/json:
+          schema:
+            $ref: "../../components/schemas/common/errors/StorageErrors.yaml#/RequestQueueNotFoundError"
+    "405":
+      $ref: ../../components/responses/MethodNotAllowed.yaml
+    "429":
+      $ref: ../../components/responses/TooManyRequests.yaml
+  deprecated: false

--- a/apify-api/openapi/paths/actor-runs/actor-runs@{runId}@request-queue@head@lock.yaml
+++ b/apify-api/openapi/paths/actor-runs/actor-runs@{runId}@request-queue@head@lock.yaml
@@ -1,0 +1,49 @@
+post:
+  tags:
+    - Actor runs/Request queue
+  summary: Get head and lock
+  description: |
+    Returns the given number of first requests from the Actor run's default request queue and locks them.
+
+    This endpoint is a shortcut that resolves the run's `defaultRequestQueueId` and proxies to the
+    [Get head and lock](/api/v2/requestQueue-head-lock-post) endpoint.
+  operationId: actorRun_requestQueue_head_lock_post
+  parameters:
+    - $ref: "../../components/parameters/runAndBuildParameters.yaml#/runId"
+    - $ref: "../../components/parameters/storageParameters.yaml#/lockSecs"
+    - name: limit
+      in: query
+      description: How many items from the queue should be returned.
+      style: form
+      explode: true
+      schema:
+        type: number
+        format: double
+        example: 25
+        maximum: 25
+    - $ref: "../../components/parameters/storageParameters.yaml#/clientKey"
+  responses:
+    "201":
+      description: ""
+      headers: {}
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas/request-queues/HeadAndLockResponse.yaml
+    "400":
+      $ref: ../../components/responses/BadRequest.yaml
+    "401":
+      $ref: ../../components/responses/Unauthorized.yaml
+    "403":
+      $ref: ../../components/responses/Forbidden.yaml
+    "404":
+      description: Not found - the requested resource was not found.
+      content:
+        application/json:
+          schema:
+            $ref: "../../components/schemas/common/errors/StorageErrors.yaml#/RequestQueueNotFoundError"
+    "405":
+      $ref: ../../components/responses/MethodNotAllowed.yaml
+    "429":
+      $ref: ../../components/responses/TooManyRequests.yaml
+  deprecated: false

--- a/apify-api/openapi/paths/actor-runs/actor-runs@{runId}@request-queue@requests.yaml
+++ b/apify-api/openapi/paths/actor-runs/actor-runs@{runId}@request-queue@requests.yaml
@@ -1,0 +1,125 @@
+get:
+  tags:
+    - Actor runs/Request queue
+  summary: List requests
+  description: |
+    Returns a list of requests from the Actor run's default request queue.
+
+    This endpoint is a shortcut that resolves the run's `defaultRequestQueueId` and proxies to the
+    [List requests](/api/v2/requestQueue-requests-get) endpoint.
+  operationId: actorRun_requestQueue_requests_get
+  parameters:
+    - $ref: "../../components/parameters/runAndBuildParameters.yaml#/runId"
+    - $ref: "../../components/parameters/storageParameters.yaml#/clientKey"
+    - name: exclusiveStartId
+      in: query
+      description: All requests up to this one (including) are skipped from the result. (Deprecated, use `cursor` instead.)
+      deprecated: true
+      style: form
+      explode: true
+      schema:
+        type: string
+        example: Ihnsp8YrvJ8102Kj
+    - name: limit
+      in: query
+      description: Number of keys to be returned. Maximum value is `10000`.
+      style: form
+      explode: true
+      schema:
+        type: number
+        format: double
+        example: 100
+    - name: cursor
+      in: query
+      description: A cursor string for pagination, returned in the previous response as `nextCursor`. Use this to retrieve the next page of requests.
+      style: form
+      explode: true
+      schema:
+        type: string
+        example: eyJyZXF1ZXN0SWQiOiI2OFRqQ2RaTDNvM2hiUU0ifQ
+    - name: filter
+      in: query
+      description: Filter requests by their state. Possible values are `locked` and `pending`. (Is not compatible with deprecated `exclusiveStartId` parameter.)
+      style: form
+      explode: true
+      schema:
+        type: string
+        enum:
+          - locked
+          - pending
+        example: locked
+  responses:
+    "200":
+      description: ""
+      headers: {}
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas/request-queues/ListOfRequestsResponse.yaml
+    "400":
+      $ref: ../../components/responses/BadRequest.yaml
+    "401":
+      $ref: ../../components/responses/Unauthorized.yaml
+    "403":
+      $ref: ../../components/responses/Forbidden.yaml
+    "404":
+      description: Not found - the requested resource was not found.
+      content:
+        application/json:
+          schema:
+            $ref: "../../components/schemas/common/errors/StorageErrors.yaml#/RequestQueueNotFoundError"
+    "405":
+      $ref: ../../components/responses/MethodNotAllowed.yaml
+    "429":
+      $ref: ../../components/responses/TooManyRequests.yaml
+  deprecated: false
+post:
+  tags:
+    - Actor runs/Request queue
+  summary: Add request
+  description: |
+    Adds a request to the Actor run's default request queue.
+
+    This endpoint is a shortcut that resolves the run's `defaultRequestQueueId` and proxies to the
+    [Add request](/api/v2/requestQueue-requests-post) endpoint.
+  operationId: actorRun_requestQueue_requests_post
+  parameters:
+    - $ref: "../../components/parameters/runAndBuildParameters.yaml#/runId"
+    - $ref: "../../components/parameters/storageParameters.yaml#/clientKey"
+    - $ref: "../../components/parameters/storageParameters.yaml#/forefront"
+  requestBody:
+    description: ""
+    content:
+      application/json:
+        schema:
+          $ref: ../../components/schemas/request-queues/RequestWithoutId.yaml
+    required: true
+  responses:
+    "201":
+      description: ""
+      headers: {}
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas/request-queues/AddRequestResponse.yaml
+    "400":
+      $ref: ../../components/responses/BadRequest.yaml
+    "401":
+      $ref: ../../components/responses/Unauthorized.yaml
+    "403":
+      $ref: ../../components/responses/Forbidden.yaml
+    "404":
+      description: Not found - the requested resource was not found.
+      content:
+        application/json:
+          schema:
+            $ref: "../../components/schemas/common/errors/StorageErrors.yaml#/RequestQueueNotFoundError"
+    "405":
+      $ref: ../../components/responses/MethodNotAllowed.yaml
+    "413":
+      $ref: ../../components/responses/PayloadTooLarge.yaml
+    "415":
+      $ref: ../../components/responses/UnsupportedMediaType.yaml
+    "429":
+      $ref: ../../components/responses/TooManyRequests.yaml
+  deprecated: false

--- a/apify-api/openapi/paths/actor-runs/actor-runs@{runId}@request-queue@requests@batch.yaml
+++ b/apify-api/openapi/paths/actor-runs/actor-runs@{runId}@request-queue@requests@batch.yaml
@@ -1,0 +1,113 @@
+post:
+  tags:
+    - Actor runs/Request queue
+  summary: Add requests
+  description: |
+    Adds requests to the Actor run's default request queue in batch.
+
+    This endpoint is a shortcut that resolves the run's `defaultRequestQueueId` and proxies to the
+    [Add requests](/api/v2/requestQueue-requests-batch-post) endpoint.
+  operationId: actorRun_requestQueue_requests_batch_post
+  parameters:
+    - $ref: "../../components/parameters/runAndBuildParameters.yaml#/runId"
+    - $ref: "../../components/parameters/storageParameters.yaml#/clientKey"
+    - $ref: "../../components/parameters/storageParameters.yaml#/forefront"
+  requestBody:
+    description: ""
+    content:
+      application/json:
+        schema:
+          type: array
+          items:
+            $ref: ../../components/schemas/request-queues/RequestWithoutId.yaml
+          description: ""
+    required: true
+  responses:
+    "201":
+      description: ""
+      headers: {}
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas/request-queues/BatchAddResponse.yaml
+    "400":
+      $ref: ../../components/responses/BadRequest.yaml
+    "401":
+      $ref: ../../components/responses/Unauthorized.yaml
+    "403":
+      $ref: ../../components/responses/Forbidden.yaml
+    "404":
+      description: Not found - the requested resource was not found.
+      content:
+        application/json:
+          schema:
+            $ref: "../../components/schemas/common/errors/StorageErrors.yaml#/RequestQueueNotFoundError"
+    "405":
+      $ref: ../../components/responses/MethodNotAllowed.yaml
+    "413":
+      $ref: ../../components/responses/PayloadTooLarge.yaml
+    "415":
+      $ref: ../../components/responses/UnsupportedMediaType.yaml
+    "429":
+      $ref: ../../components/responses/TooManyRequests.yaml
+  deprecated: false
+delete:
+  tags:
+    - Actor runs/Request queue
+  summary: Delete requests
+  description: |
+    Batch-deletes given requests from the Actor run's default request queue.
+
+    This endpoint is a shortcut that resolves the run's `defaultRequestQueueId` and proxies to the
+    [Delete requests](/api/v2/requestQueue-requests-batch-delete) endpoint.
+  operationId: actorRun_requestQueue_requests_batch_delete
+  parameters:
+    - $ref: "../../components/parameters/runAndBuildParameters.yaml#/runId"
+    - name: Content-Type
+      in: header
+      description: ""
+      required: true
+      style: simple
+      schema:
+        enum:
+          - application/json
+        type: string
+    - $ref: "../../components/parameters/storageParameters.yaml#/clientKey"
+  requestBody:
+    description: ""
+    content:
+      application/json:
+        schema:
+          type: array
+          items:
+            $ref: ../../components/schemas/request-queues/RequestDraftDelete.yaml
+    required: true
+  responses:
+    "200":
+      description: ""
+      headers: {}
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas/request-queues/BatchDeleteResponse.yaml
+    "400":
+      $ref: ../../components/responses/BadRequest.yaml
+    "401":
+      $ref: ../../components/responses/Unauthorized.yaml
+    "403":
+      $ref: ../../components/responses/Forbidden.yaml
+    "404":
+      description: Not found - the requested resource was not found.
+      content:
+        application/json:
+          schema:
+            $ref: "../../components/schemas/common/errors/StorageErrors.yaml#/RequestQueueNotFoundError"
+    "405":
+      $ref: ../../components/responses/MethodNotAllowed.yaml
+    "413":
+      $ref: ../../components/responses/PayloadTooLarge.yaml
+    "415":
+      $ref: ../../components/responses/UnsupportedMediaType.yaml
+    "429":
+      $ref: ../../components/responses/TooManyRequests.yaml
+  deprecated: false

--- a/apify-api/openapi/paths/actor-runs/actor-runs@{runId}@request-queue@requests@unlock.yaml
+++ b/apify-api/openapi/paths/actor-runs/actor-runs@{runId}@request-queue@requests@unlock.yaml
@@ -1,0 +1,37 @@
+post:
+  tags:
+    - Actor runs/Request queue
+  summary: Unlock requests
+  description: |
+    Unlocks requests in the Actor run's default request queue that are currently locked by the client.
+
+    This endpoint is a shortcut that resolves the run's `defaultRequestQueueId` and proxies to the
+    [Unlock requests](/api/v2/requestQueue-requests-unlock-post) endpoint.
+  operationId: actorRun_requestQueue_requests_unlock_post
+  parameters:
+    - $ref: "../../components/parameters/runAndBuildParameters.yaml#/runId"
+    - $ref: "../../components/parameters/storageParameters.yaml#/clientKey"
+  responses:
+    "200":
+      description: Number of requests that were unlocked
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas/request-queues/UnlockRequestsResponse.yaml
+    "400":
+      $ref: ../../components/responses/BadRequest.yaml
+    "401":
+      $ref: ../../components/responses/Unauthorized.yaml
+    "403":
+      $ref: ../../components/responses/Forbidden.yaml
+    "404":
+      description: Not found - the requested resource was not found.
+      content:
+        application/json:
+          schema:
+            $ref: "../../components/schemas/common/errors/StorageErrors.yaml#/RequestQueueNotFoundError"
+    "405":
+      $ref: ../../components/responses/MethodNotAllowed.yaml
+    "429":
+      $ref: ../../components/responses/TooManyRequests.yaml
+  deprecated: false

--- a/apify-api/openapi/paths/actor-runs/actor-runs@{runId}@request-queue@requests@{requestId}.yaml
+++ b/apify-api/openapi/paths/actor-runs/actor-runs@{runId}@request-queue@requests@{requestId}.yaml
@@ -1,0 +1,122 @@
+get:
+  tags:
+    - Actor runs/Request queue
+  summary: Get request
+  description: |
+    Returns a request from the Actor run's default request queue.
+
+    This endpoint is a shortcut that resolves the run's `defaultRequestQueueId` and proxies to the
+    [Get request](/api/v2/requestQueue-request-get) endpoint.
+  operationId: actorRun_requestQueue_request_get
+  parameters:
+    - $ref: "../../components/parameters/runAndBuildParameters.yaml#/runId"
+    - $ref: "../../components/parameters/storageParameters.yaml#/requestId"
+  responses:
+    "200":
+      description: ""
+      headers: {}
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas/request-queues/RequestResponse.yaml
+    "400":
+      $ref: ../../components/responses/BadRequest.yaml
+    "401":
+      $ref: ../../components/responses/Unauthorized.yaml
+    "403":
+      $ref: ../../components/responses/Forbidden.yaml
+    "404":
+      description: Not found - the requested resource was not found.
+      content:
+        application/json:
+          schema:
+            oneOf:
+              - $ref: "../../components/schemas/common/errors/StorageErrors.yaml#/RequestQueueNotFoundError"
+              - $ref: "../../components/schemas/common/errors/StorageErrors.yaml#/RequestNotFoundError"
+    "405":
+      $ref: ../../components/responses/MethodNotAllowed.yaml
+    "429":
+      $ref: ../../components/responses/TooManyRequests.yaml
+  deprecated: false
+put:
+  tags:
+    - Actor runs/Request queue
+  summary: Update request
+  description: |
+    Updates a request in the Actor run's default request queue.
+
+    This endpoint is a shortcut that resolves the run's `defaultRequestQueueId` and proxies to the
+    [Update request](/api/v2/requestQueue-request-put) endpoint.
+  operationId: actorRun_requestQueue_request_put
+  parameters:
+    - $ref: "../../components/parameters/runAndBuildParameters.yaml#/runId"
+    - $ref: "../../components/parameters/storageParameters.yaml#/requestId"
+    - $ref: "../../components/parameters/storageParameters.yaml#/forefront"
+    - $ref: "../../components/parameters/storageParameters.yaml#/clientKey"
+  requestBody:
+    description: ""
+    content:
+      application/json:
+        schema:
+          $ref: ../../components/schemas/request-queues/Request.yaml
+    required: true
+  responses:
+    "200":
+      description: ""
+      headers: {}
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas/request-queues/UpdateRequestResponse.yaml
+    "400":
+      $ref: ../../components/responses/BadRequest.yaml
+    "401":
+      $ref: ../../components/responses/Unauthorized.yaml
+    "403":
+      $ref: ../../components/responses/Forbidden.yaml
+    "404":
+      description: Not found - the requested resource was not found.
+      content:
+        application/json:
+          schema:
+            $ref: "../../components/schemas/common/errors/StorageErrors.yaml#/RequestQueueNotFoundError"
+    "405":
+      $ref: ../../components/responses/MethodNotAllowed.yaml
+    "413":
+      $ref: ../../components/responses/PayloadTooLarge.yaml
+    "415":
+      $ref: ../../components/responses/UnsupportedMediaType.yaml
+    "429":
+      $ref: ../../components/responses/TooManyRequests.yaml
+  deprecated: false
+delete:
+  tags:
+    - Actor runs/Request queue
+  summary: Delete request
+  description: |
+    Deletes a request from the Actor run's default request queue.
+  operationId: actorRun_requestQueue_request_delete
+  parameters:
+    - $ref: "../../components/parameters/runAndBuildParameters.yaml#/runId"
+    - $ref: "../../components/parameters/storageParameters.yaml#/requestId"
+    - $ref: "../../components/parameters/storageParameters.yaml#/clientKey"
+  responses:
+    "204":
+      $ref: ../../components/responses/NoContent.yaml
+    "400":
+      $ref: ../../components/responses/BadRequest.yaml
+    "401":
+      $ref: ../../components/responses/Unauthorized.yaml
+    "403":
+      $ref: ../../components/responses/Forbidden.yaml
+    "404":
+      description: Not found - the requested resource was not found.
+      content:
+        application/json:
+          schema:
+            $ref: "../../components/schemas/common/errors/StorageErrors.yaml#/RequestQueueNotFoundError"
+    "405":
+      $ref: ../../components/responses/MethodNotAllowed.yaml
+    "429":
+      $ref: ../../components/responses/TooManyRequests.yaml
+  deprecated: false

--- a/apify-api/openapi/paths/actor-runs/actor-runs@{runId}@request-queue@requests@{requestId}@lock.yaml
+++ b/apify-api/openapi/paths/actor-runs/actor-runs@{runId}@request-queue@requests@{requestId}@lock.yaml
@@ -1,0 +1,94 @@
+put:
+  tags:
+    - Actor runs/Request queue
+  summary: Prolong request lock
+  description: |
+    Prolongs a request lock in the Actor run's default request queue.
+
+    This endpoint is a shortcut that resolves the run's `defaultRequestQueueId` and proxies to the
+    [Prolong request lock](/api/v2/requestQueue-request-lock-put) endpoint.
+  operationId: actorRun_requestQueue_request_lock_put
+  parameters:
+    - $ref: "../../components/parameters/runAndBuildParameters.yaml#/runId"
+    - $ref: "../../components/parameters/storageParameters.yaml#/requestId"
+    - $ref: "../../components/parameters/storageParameters.yaml#/lockSecs"
+    - $ref: "../../components/parameters/storageParameters.yaml#/clientKeyLock"
+    - name: forefront
+      in: query
+      description: |
+        Determines if request should be added to the head of the queue or to the
+        end after lock expires.
+      style: form
+      explode: true
+      schema:
+        type: string
+        example: "false"
+  responses:
+    "200":
+      description: ""
+      headers: {}
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas/request-queues/ProlongRequestLockResponse.yaml
+    "400":
+      $ref: ../../components/responses/BadRequest.yaml
+    "401":
+      $ref: ../../components/responses/Unauthorized.yaml
+    "403":
+      $ref: ../../components/responses/Forbidden.yaml
+    "404":
+      description: Not found - the requested resource was not found.
+      content:
+        application/json:
+          schema:
+            $ref: "../../components/schemas/common/errors/StorageErrors.yaml#/RequestQueueNotFoundError"
+    "405":
+      $ref: ../../components/responses/MethodNotAllowed.yaml
+    "429":
+      $ref: ../../components/responses/TooManyRequests.yaml
+  deprecated: false
+delete:
+  tags:
+    - Actor runs/Request queue
+  summary: Delete request lock
+  description: |
+    Deletes a request lock in the Actor run's default request queue.
+
+    This endpoint is a shortcut that resolves the run's `defaultRequestQueueId` and proxies to the
+    [Delete request lock](/api/v2/requestQueue-request-lock-delete) endpoint.
+  operationId: actorRun_requestQueue_request_lock_delete
+  parameters:
+    - $ref: "../../components/parameters/runAndBuildParameters.yaml#/runId"
+    - $ref: "../../components/parameters/storageParameters.yaml#/requestId"
+    - $ref: "../../components/parameters/storageParameters.yaml#/clientKeyLock"
+    - name: forefront
+      in: query
+      description: |
+        Determines if request should be added to the head of the queue or to the
+        end after lock was removed.
+      style: form
+      explode: true
+      schema:
+        type: string
+        example: "false"
+  responses:
+    "204":
+      $ref: ../../components/responses/NoContent.yaml
+    "400":
+      $ref: ../../components/responses/BadRequest.yaml
+    "401":
+      $ref: ../../components/responses/Unauthorized.yaml
+    "403":
+      $ref: ../../components/responses/Forbidden.yaml
+    "404":
+      description: Not found - the requested resource was not found.
+      content:
+        application/json:
+          schema:
+            $ref: "../../components/schemas/common/errors/StorageErrors.yaml#/RequestQueueNotFoundError"
+    "405":
+      $ref: ../../components/responses/MethodNotAllowed.yaml
+    "429":
+      $ref: ../../components/responses/TooManyRequests.yaml
+  deprecated: false

--- a/apify-api/openapi/paths/actors/acts@{actorId}@validate-input.yaml
+++ b/apify-api/openapi/paths/actors/acts@{actorId}@validate-input.yaml
@@ -1,0 +1,59 @@
+post:
+  tags:
+    - Actors
+  summary: Validate input
+  description: |
+    Validates the provided input against the Actor's input schema for the specified build.
+
+    The endpoint checks whether the JSON payload conforms to the input schema
+    defined in the Actor's build. If no `build` query parameter is provided,
+    the `latest` build tag is used by default.
+  operationId: act_validateInput_post
+  security: []
+  parameters:
+    - $ref: "../../components/parameters/runAndBuildParameters.yaml#/actorId"
+    - name: build
+      in: query
+      description: |
+        Optional tag or number of the Actor build to use for input schema validation.
+        By default, the `latest` build tag is used.
+      required: false
+      style: form
+      explode: true
+      schema:
+        type: string
+        example: latest
+  requestBody:
+    description: JSON input to validate against the Actor's input schema.
+    content:
+      application/json:
+        schema:
+          type: object
+    required: true
+  responses:
+    "200":
+      description: ""
+      headers: {}
+      content:
+        application/json:
+          schema:
+            type: object
+            required:
+              - valid
+            properties:
+              valid:
+                type: boolean
+                description: Whether the input is valid according to the Actor's input schema.
+    "400":
+      $ref: ../../components/responses/BadRequest.yaml
+    "404":
+      $ref: ../../components/responses/NotFound.yaml
+    "405":
+      $ref: ../../components/responses/MethodNotAllowed.yaml
+    "413":
+      $ref: ../../components/responses/PayloadTooLarge.yaml
+    "415":
+      $ref: ../../components/responses/UnsupportedMediaType.yaml
+    "429":
+      $ref: ../../components/responses/TooManyRequests.yaml
+  deprecated: false


### PR DESCRIPTION
## Summary
Autogenerated OpenAPI fixes suggestions based on validation errors generated from running API integration tests with OpenAPI validator turned on.

**Error log:** https://apify-pr-test-env-logs.s3.us-east-1.amazonaws.com/apify/apify-core/26280/api-e8976db3b5b2476d2f01af1a84d4268fc61e839f.log

**apify-core version:** https://github.com/apify/apify-core/tree/e8976db3b5b2476d2f01af1a84d4268fc61e839f

**Stop reason:** In progress - added 5 missing top-level endpoints and 12 storage sub-resource proxy endpoints under actor-runs.

## Detailed changes description
### Error fixes

#### 1. Add GET /v2/actor-runs/{runId}/dataset endpoint
Files: `apify-api/openapi/paths/actor-runs/actor-runs@{runId}@dataset.yaml`:1, `apify-api/openapi/openapi.yaml`:555
Error: `WARN Request OpenAPI validation error {"url":"/v2/actor-runs/{runId}/dataset","method":"GET","errors":[{"message":"not found","path":"/v2/actor-runs/{runId}/dataset"}]}`
Root cause: The endpoint exists in apify-core (`src/api/src/routes/actor_runs/run_dataset.ts`) and proxies GET requests to `/v2/datasets/{defaultDatasetId}`, but had no OpenAPI path definition. Added GET operation returning `DatasetResponse`.
Reference: https://github.com/apify/apify-core/tree/e8976db3b5b2476d2f01af1a84d4268fc61e839f/src/api/src/routes/routes_config.ts#L724

#### 2. Add GET /v2/actor-runs/{runId}/key-value-store endpoint
Files: `apify-api/openapi/paths/actor-runs/actor-runs@{runId}@key-value-store.yaml`:1, `apify-api/openapi/openapi.yaml`:557
Error: `WARN Request OpenAPI validation error {"url":"/v2/actor-runs/{runId}/key-value-store","method":"GET","errors":[{"message":"not found","path":"/v2/actor-runs/{runId}/key-value-store"}]}`
Root cause: The endpoint exists in apify-core (`src/api/src/routes/actor_runs/run_key_value_store.ts`) and proxies GET requests to `/v2/key-value-stores/{defaultKeyValueStoreId}`, but had no OpenAPI path definition. Added GET operation returning `KeyValueStoreResponse`.
Reference: https://github.com/apify/apify-core/tree/e8976db3b5b2476d2f01af1a84d4268fc61e839f/src/api/src/routes/routes_config.ts#L737

#### 3. Add GET /v2/actor-runs/{runId}/log endpoint
Files: `apify-api/openapi/paths/actor-runs/actor-runs@{runId}@log.yaml`:1, `apify-api/openapi/openapi.yaml`:559
Error: `WARN Request OpenAPI validation error {"url":"/v2/actor-runs/{runId}/log","method":"GET","errors":[{"message":"not found","path":"/v2/actor-runs/{runId}/log"}]}`
Root cause: The endpoint exists in apify-core (`src/api/src/routes/actor_runs/run_log.ts`) and proxies GET requests to `/v2/logs/{runId}`, but had no OpenAPI path definition. Added GET operation returning text/plain log content with stream, download, and raw parameters.
Reference: https://github.com/apify/apify-core/tree/e8976db3b5b2476d2f01af1a84d4268fc61e839f/src/api/src/routes/routes_config.ts#L763

#### 4. Add GET /v2/actor-runs/{runId}/request-queue endpoint
Files: `apify-api/openapi/paths/actor-runs/actor-runs@{runId}@request-queue.yaml`:1, `apify-api/openapi/openapi.yaml`:561
Error: `WARN Request OpenAPI validation error {"url":"/v2/actor-runs/{runId}/request-queue","method":"GET","errors":[{"message":"not found","path":"/v2/actor-runs/{runId}/request-queue"}]}`
Root cause: The endpoint exists in apify-core (`src/api/src/routes/actor_runs/run_request_queue.ts`) and proxies GET requests to `/v2/request-queues/{defaultRequestQueueId}`, but had no OpenAPI path definition. Added GET operation returning `RequestQueueResponse`.
Reference: https://github.com/apify/apify-core/tree/e8976db3b5b2476d2f01af1a84d4268fc61e839f/src/api/src/routes/routes_config.ts#L750

#### 5. Add POST /v2/acts/{actorId}/validate-input endpoint
Files: `apify-api/openapi/paths/actors/acts@{actorId}@validate-input.yaml`:1, `apify-api/openapi/openapi.yaml`:523
Error: `WARN Request OpenAPI validation error {"url":"/v2/acts/{actorId}/validate-input","method":"POST","errors":[{"message":"not found","path":"/v2/acts/{actorId}/validate-input"}]}`
Root cause: The endpoint exists in apify-core (`src/api/src/routes/actors/validate_input.ts`) and validates Actor input against the build's input schema. Does not require authentication (`security: []`). Returns `{ valid: boolean }`. Had no OpenAPI path definition.
Reference: https://github.com/apify/apify-core/tree/e8976db3b5b2476d2f01af1a84d4268fc61e839f/src/api/src/routes/actors/validate_input.ts#L85

#### 6. Add actor-runs dataset sub-resource endpoints
Files: `apify-api/openapi/paths/actor-runs/actor-runs@{runId}@dataset@items.yaml`:1, `apify-api/openapi/paths/actor-runs/actor-runs@{runId}@dataset@statistics.yaml`:1
Error: `WARN Request OpenAPI validation error {"url":"/v2/actor-runs/{runId}/dataset/items","method":"GET","errors":[{"message":"not found","path":"/datasets/{datasetId}/items"}]}`
Root cause: The actor-runs proxy forwards sub-resource requests via `getRunRoute()` in `controllers.ts` to `/v2/datasets/{defaultDatasetId}/...`. Added OpenAPI definitions for `dataset/items` (GET, HEAD, POST) and `dataset/statistics` (GET) mirroring the corresponding datasets endpoints.
Reference: https://github.com/apify/apify-core/tree/e8976db3b5b2476d2f01af1a84d4268fc61e839f/src/api/src/lib/controllers.ts#L37

#### 7. Add actor-runs key-value-store sub-resource endpoints
Files: `apify-api/openapi/paths/actor-runs/actor-runs@{runId}@key-value-store@keys.yaml`:1, `apify-api/openapi/paths/actor-runs/actor-runs@{runId}@key-value-store@records.yaml`:1, `apify-api/openapi/paths/actor-runs/actor-runs@{runId}@key-value-store@records@{recordKey}.yaml`:1
Error: `WARN Request OpenAPI validation error {"url":"/v2/actor-runs/{runId}/key-value-store/records/{recordKey}","method":"GET","errors":[{"message":"not found","path":"/key-value-stores/{storeId}/records/{recordKey}"}]}`
Root cause: The actor-runs proxy forwards sub-resource requests via `getRunRoute()` to `/v2/key-value-stores/{defaultKeyValueStoreId}/...`. Added OpenAPI definitions for `key-value-store/keys` (GET), `key-value-store/records` (GET), and `key-value-store/records/{recordKey}` (GET, HEAD, PUT, POST, DELETE) mirroring the corresponding key-value-stores endpoints.
Reference: https://github.com/apify/apify-core/tree/e8976db3b5b2476d2f01af1a84d4268fc61e839f/src/api/src/lib/controllers.ts#L35

#### 8. Add actor-runs request-queue sub-resource endpoints
Files: `apify-api/openapi/paths/actor-runs/actor-runs@{runId}@request-queue@requests.yaml`:1, `apify-api/openapi/paths/actor-runs/actor-runs@{runId}@request-queue@requests@batch.yaml`:1, `apify-api/openapi/paths/actor-runs/actor-runs@{runId}@request-queue@requests@unlock.yaml`:1, `apify-api/openapi/paths/actor-runs/actor-runs@{runId}@request-queue@requests@{requestId}.yaml`:1, `apify-api/openapi/paths/actor-runs/actor-runs@{runId}@request-queue@head.yaml`:1, `apify-api/openapi/paths/actor-runs/actor-runs@{runId}@request-queue@head@lock.yaml`:1, `apify-api/openapi/paths/actor-runs/actor-runs@{runId}@request-queue@requests@{requestId}@lock.yaml`:1
Error: `WARN Request OpenAPI validation error {"url":"/v2/actor-runs/{runId}/request-queue/requests/{requestId}","method":"GET","errors":[{"message":"not found","path":"/request-queues/{queueId}/requests/{requestId}"}]}`
Root cause: The actor-runs proxy forwards sub-resource requests via `getRunRoute()` to `/v2/request-queues/{defaultRequestQueueId}/...`. Added OpenAPI definitions for all request-queue sub-resources: `requests` (GET, POST), `requests/batch` (POST, DELETE), `requests/unlock` (POST), `requests/{requestId}` (GET, PUT, DELETE), `head` (GET), `head/lock` (POST), and `requests/{requestId}/lock` (PUT, DELETE) mirroring the corresponding request-queues endpoints.
Reference: https://github.com/apify/apify-core/tree/e8976db3b5b2476d2f01af1a84d4268fc61e839f/src/api/src/lib/controllers.ts#L39

### Refactoring
None.

## Unfixed errors
### False positives

#### Proxy middleware resolved paths for acts/runs/last and actor-tasks/runs/last sub-resources
**Error:** `WARN Request OpenAPI validation error {"url":"/v2/acts/{actorId}/runs/last/dataset/items","method":"GET","errors":[{"message":"not found","path":"/datasets/{datasetId}/items"}]}`
**Root cause:** The "last run" shortcut endpoints under `/v2/acts/{actorId}/runs/last/` and `/v2/actor-tasks/{taskId}/runs/last/` resolve through `getRunRoute()` and then proxy to storage/action endpoints with internal paths lacking the `/v2/` prefix. The validator checks the resolved path which doesn't match any spec path. Affects abort, metamorph, reboot, dataset/items, key-value-store/records, log, and request-queue/head operations. Total: 11 errors.
**Reference:** https://github.com/apify/apify-core/tree/e8976db3b5b2476d2f01af1a84d4268fc61e839f/src/api/src/lib/controllers.ts#L7

#### /v2/openapi.json endpoint
**Error:** `WARN Request OpenAPI validation error {"url":"/v2/openapi.json","method":"GET","errors":[{"message":"not found","path":"/openapi.json"}]}`
**Root cause:** The `/v2/openapi.json` endpoint serves the OpenAPI spec itself. The validator resolves the path to `/openapi.json` (without `/v2/` prefix), which doesn't match any spec path. This is a meta-endpoint that documents the API but isn't itself part of the API contract. Total: 2 errors.
**Reference:** https://github.com/apify/apify-core/tree/e8976db3b5b2476d2f01af1a84d4268fc61e839f/src/api/src/lib/api_server.ts

### Potential API bugs
None identified.

### Out of scope errors
None.

## Issues
Partially implements: https://github.com/apify/apify-docs/issues/2286