### PR TITLE
docs: Capitalize "Store" in API endpoint summary

### DIFF
--- a/apify-api/openapi/paths/store/store.yaml
+++ b/apify-api/openapi/paths/store/store.yaml
@@ -1,7 +1,7 @@
 get:
   tags:
     - Store
-  summary: Get list of Actors in store
+  summary: Get list of Actors in Store
   description: |
     Gets the list of public Actors in Apify Store. You can use `search`
     parameter to search Actors by string in title, name, description, username


### PR DESCRIPTION
## Summary
Updated the OpenAPI documentation to maintain consistent capitalization of "Store" in the API endpoint summary.

## Changes
- Capitalized "Store" in the GET `/store` endpoint summary from "Get list of Actors in store" to "Get list of Actors in Store"

## Details
This is a minor documentation improvement to ensure consistent terminology throughout the API specification, where "Store" (referring to the Apify Store) should be capitalized as a proper noun.

https://claude.ai/code/session_016gkDqsRhCVkVLDtnq4egMw