### PR TITLE
docs: add responseFormat and includeUnrunnableActors to store search endpoint

### DIFF
--- a/apify-api/openapi/paths/store/store.yaml
+++ b/apify-api/openapi/paths/store/store.yaml
@@ -75,6 +75,36 @@ get:
       schema:
         type: boolean
         example: true
+    - name: responseFormat
+      in: query
+      description: |
+        Controls the shape of the response. Use `full` (default) for the
+        complete response including image URLs and all fields. Use `agent`
+        for a reduced field set optimized for LLM consumers, which only
+        includes `id`, `title`, `name`, `username`, `description`, `notice`,
+        `badge`, `categories`, and minimal `stats`.
+      style: form
+      explode: true
+      schema:
+        type: string
+        enum:
+          - full
+          - agent
+        default: full
+        example: agent
+    - name: includeUnrunnableActors
+      in: query
+      description: |
+        By default, search results exclude Actors that are not safe to run
+        automatically (e.g. Actors from developers who haven't passed KYC, or
+        full-permission Actors without a large user base). Set to `true` to
+        bypass this safety filtering and include all Actors in the results.
+      style: form
+      explode: true
+      schema:
+        type: boolean
+        default: false
+        example: true
   responses:
     "200":
       description: ""


### PR DESCRIPTION
## Summary
- Add `responseFormat` query param (`full` | `agent`) for LLM-optimized responses
- Add `includeUnrunnableActors` boolean param to bypass safety filtering

Follows apify/apify-core#26566.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to the OpenAPI spec; no runtime logic is modified, so risk is low aside from potential client expectation changes.
> 
> **Overview**
> Documents two new query parameters on `GET /store`: `responseFormat` (`full`|`agent`) to request a reduced, LLM-oriented response shape, and `includeUnrunnableActors` to optionally bypass the default safety filtering that excludes automatically-unrunnable Actors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4dc776d8c600f4ea602c910114c2bd22c95bb5c2. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->