### PR TITLE
docs(openapi): Align 404 to use generic error and specific example

### DIFF
--- a/apify-api/openapi/components/objects/actors/acts@{actorId}@versions@{versionNumber}@env-vars@{envVarName}put.yaml
+++ b/apify-api/openapi/components/objects/actors/acts@{actorId}@versions@{versionNumber}@env-vars@{envVarName}put.yaml
@@ -43,14 +43,7 @@ shared: &shared
     "403":
       $ref: ../../responses/Forbidden.yaml
     "404":
-      description: Not found - the requested resource was not found.
-      content:
-        application/json:
-          schema:
-            oneOf:
-              - $ref: "../../schemas/common/errors/ActorErrors.yaml#/ActorNotFoundError"
-              - $ref: "../../schemas/common/errors/ActorErrors.yaml#/ActorVersionNotFoundError"
-              - $ref: "../../schemas/common/errors/EnvVariableErrors.yaml#/EnvironmentVariableNotFoundError"
+      $ref: ../../responses/NotFound.yaml
     "405":
       $ref: ../../responses/MethodNotAllowed.yaml
     "413":

--- a/apify-api/openapi/components/objects/actors/acts@{actorId}@versions@{versionNumber}put.yaml
+++ b/apify-api/openapi/components/objects/actors/acts@{actorId}@versions@{versionNumber}put.yaml
@@ -39,11 +39,7 @@ shared: &shared
     "403":
       $ref: ../../responses/Forbidden.yaml
     "404":
-      description: Not found - the requested resource was not found.
-      content:
-        application/json:
-          schema:
-            $ref: "../../schemas/common/errors/ActorErrors.yaml#/ActorNotFoundError"
+      $ref: ../../responses/NotFound.yaml
     "405":
       $ref: ../../responses/MethodNotAllowed.yaml
     "413":

--- a/apify-api/openapi/components/responses/RunTimeout.yaml
+++ b/apify-api/openapi/components/responses/RunTimeout.yaml
@@ -1,0 +1,9 @@
+description: The HTTP request exceeded the timeout limit
+content:
+  application/json:
+    schema:
+      $ref: ../schemas/common/ErrorResponse.yaml
+    example:
+      error:
+        type: run-timeout-exceeded
+        message: Actor run exceeded the timeout of 300 seconds for this API endpoint

--- a/apify-api/openapi/components/schemas/common/ErrorResponse.yaml
+++ b/apify-api/openapi/components/schemas/common/ErrorResponse.yaml
@@ -4,34 +4,4 @@ required:
 type: object
 properties:
   error:
-    title: ErrorDetail
-    type: object
-    properties:
-      type:
-        title: ErrorType
-        type: string
-        description: Machine-processable error type identifier.
-        enum:
-          - actor-memory-limit-exceeded
-          - actor-not-found
-          - invalid-input
-          - method-not-allowed
-          - page-not-found
-          - permission-denied
-          - rate-limit-exceeded
-          - record-not-found
-          - record-not-unique
-          - record-or-token-not-found
-          - request-id-invalid
-          - request-too-large
-          - run-failed
-          - run-timeout-exceeded
-          - schedule-actor-not-found
-          - schedule-actor-task-not-found
-          - token-not-valid
-          - unknown-build-tag
-          - unsupported-content-encoding
-          - user-not-found
-      message:
-        type: string
-        description: Human-readable error message describing what went wrong.
+    $ref: ErrorDetail.yaml

--- a/apify-api/openapi/components/schemas/common/ErrorResponse.yaml
+++ b/apify-api/openapi/components/schemas/common/ErrorResponse.yaml
@@ -16,6 +16,7 @@ properties:
           - actor-not-found
           - invalid-input
           - method-not-allowed
+          - page-not-found
           - permission-denied
           - rate-limit-exceeded
           - record-not-found
@@ -25,9 +26,12 @@ properties:
           - request-too-large
           - run-failed
           - run-timeout-exceeded
+          - schedule-actor-not-found
+          - schedule-actor-task-not-found
           - token-not-valid
           - unknown-build-tag
           - unsupported-content-encoding
+          - user-not-found
       message:
         type: string
         description: Human-readable error message describing what went wrong.

--- a/apify-api/openapi/components/schemas/common/ErrorType.yaml
+++ b/apify-api/openapi/components/schemas/common/ErrorType.yaml
@@ -6,6 +6,7 @@ enum:
   - actor-not-found
   - invalid-input
   - method-not-allowed
+  - page-not-found
   - permission-denied
   - rate-limit-exceeded
   - record-not-found
@@ -15,6 +16,9 @@ enum:
   - request-too-large
   - run-failed
   - run-timeout-exceeded
+  - schedule-actor-not-found
+  - schedule-actor-task-not-found
   - token-not-valid
   - unknown-build-tag
   - unsupported-content-encoding
+  - user-not-found

--- a/apify-api/openapi/components/schemas/common/errors/ActorErrors.yaml
+++ b/apify-api/openapi/components/schemas/common/errors/ActorErrors.yaml
@@ -1,27 +1,3 @@
-ActorNotFoundErrorDetail:
-  allOf:
-    - $ref: ../ErrorDetail.yaml
-    - type: object
-      properties:
-        type:
-          const: actor-not-found
-
-RecordNotFoundErrorDetail:
-  allOf:
-    - $ref: ../ErrorDetail.yaml
-    - type: object
-      properties:
-        type:
-          const: record-not-found
-
-RecordOrTokenNotFoundErrorDetail:
-  allOf:
-    - $ref: ../ErrorDetail.yaml
-    - type: object
-      properties:
-        type:
-          const: record-or-token-not-found
-
 RunFailedErrorDetail:
   allOf:
     - $ref: ../ErrorDetail.yaml
@@ -37,46 +13,6 @@ RunTimeoutExceededErrorDetail:
       properties:
         type:
           const: run-timeout-exceeded
-
-ActorNotFoundError:
-  type: object
-  properties:
-    error:
-      $ref: "#/ActorNotFoundErrorDetail"
-  example:
-    error:
-      type: actor-not-found
-      message: Actor was not found
-
-ActorBuildNotFoundError:
-  type: object
-  properties:
-    error:
-      $ref: "#/RecordNotFoundErrorDetail"
-  example:
-    error:
-      type: record-not-found
-      message: Actor build was not found
-
-RecordOrTokenNotFoundError:
-  type: object
-  properties:
-    error:
-      $ref: "#/RecordOrTokenNotFoundErrorDetail"
-  example:
-    error:
-      type: record-or-token-not-found
-      message: Actor was not found or access denied
-
-ActorRunNotFoundError:
-  type: object
-  properties:
-    error:
-      $ref: "#/RecordNotFoundErrorDetail"
-  example:
-    error:
-      type: record-not-found
-      message: Actor run was not found
 
 ActorRunTimeoutExceededError:
   type: object
@@ -97,13 +33,3 @@ ActorRunFailedError:
     error:
       type: run-failed
       message: "Actor run did not succeed (run ID: 55uatRrZib4xbZs, status: FAILED)"
-
-ActorVersionNotFoundError:
-  type: object
-  properties:
-    error:
-      $ref: "#/RecordNotFoundErrorDetail"
-  example:
-    error:
-      type: record-not-found
-      message: Actor version was not found

--- a/apify-api/openapi/components/schemas/common/errors/EnvVariableErrors.yaml
+++ b/apify-api/openapi/components/schemas/common/errors/EnvVariableErrors.yaml
@@ -1,9 +1,0 @@
-EnvironmentVariableNotFoundError:
-  type: object
-  properties:
-    error:
-      $ref: "./ActorErrors.yaml#/RecordNotFoundErrorDetail"
-  example:
-    error:
-      type: record-not-found
-      message: Environment variable was not found

--- a/apify-api/openapi/components/schemas/common/errors/StorageErrors.yaml
+++ b/apify-api/openapi/components/schemas/common/errors/StorageErrors.yaml
@@ -6,56 +6,6 @@ RequestIdInvalidErrorDetail:
         type:
           const: request-id-invalid
 
-DatasetNotFoundError:
-  type: object
-  properties:
-    error:
-      $ref: "./ActorErrors.yaml#/RecordNotFoundErrorDetail"
-  example:
-    error:
-      type: record-not-found
-      message: Dataset was not found
-
-KeyValueStoreNotFoundError:
-  type: object
-  properties:
-    error:
-      $ref: "./ActorErrors.yaml#/RecordNotFoundErrorDetail"
-  example:
-    error:
-      type: record-not-found
-      message: Key-value Store was not found
-
-RequestQueueNotFoundError:
-  type: object
-  properties:
-    error:
-      $ref: "./ActorErrors.yaml#/RecordNotFoundErrorDetail"
-  example:
-    error:
-      type: record-not-found
-      message: Request Queue was not found
-
-RecordNotFoundError:
-  type: object
-  properties:
-    error:
-      $ref: "./ActorErrors.yaml#/RecordNotFoundErrorDetail"
-  example:
-    error:
-      type: record-not-found
-      message: Record was not found
-
-RequestNotFoundError:
-  type: object
-  properties:
-    error:
-      $ref: "./ActorErrors.yaml#/RecordNotFoundErrorDetail"
-  example:
-    error:
-      type: record-not-found
-      message: Request was not found
-
 RequestIdInvalidError:
   type: object
   properties:

--- a/apify-api/openapi/paths/actor-builds/actor-builds@{buildId}.yaml
+++ b/apify-api/openapi/paths/actor-builds/actor-builds@{buildId}.yaml
@@ -33,11 +33,7 @@ get:
     "403":
       $ref: ../../components/responses/Forbidden.yaml
     "404":
-      description: Not found - the requested resource was not found.
-      content:
-        application/json:
-          schema:
-            $ref: "../../components/schemas/common/errors/ActorErrors.yaml#/ActorBuildNotFoundError"
+      $ref: ../../components/responses/NotFound.yaml
     "405":
       $ref: ../../components/responses/MethodNotAllowed.yaml
     "429":
@@ -76,13 +72,7 @@ delete:
     "403":
       $ref: ../../components/responses/Forbidden.yaml
     "404":
-      description: Not found - the requested resource was not found.
-      content:
-        application/json:
-          schema:
-            oneOf:
-              - $ref: "../../components/schemas/common/errors/ActorErrors.yaml#/ActorBuildNotFoundError"
-              - $ref: "../../components/schemas/common/errors/ActorErrors.yaml#/RecordOrTokenNotFoundError"
+      $ref: ../../components/responses/NotFound.yaml
     "405":
       $ref: ../../components/responses/MethodNotAllowed.yaml
     "429":

--- a/apify-api/openapi/paths/actor-builds/actor-builds@{buildId}@abort.yaml
+++ b/apify-api/openapi/paths/actor-builds/actor-builds@{buildId}@abort.yaml
@@ -27,11 +27,7 @@ post:
     "403":
       $ref: ../../components/responses/Forbidden.yaml
     "404":
-      description: Not found - the requested resource was not found.
-      content:
-        application/json:
-          schema:
-            $ref: "../../components/schemas/common/errors/ActorErrors.yaml#/ActorBuildNotFoundError"
+      $ref: ../../components/responses/NotFound.yaml
     "405":
       $ref: ../../components/responses/MethodNotAllowed.yaml
     "429":

--- a/apify-api/openapi/paths/actor-builds/actor-builds@{buildId}@log.yaml
+++ b/apify-api/openapi/paths/actor-builds/actor-builds@{buildId}@log.yaml
@@ -32,11 +32,7 @@ get:
     "403":
       $ref: ../../components/responses/Forbidden.yaml
     "404":
-      description: Not found - the requested resource was not found.
-      content:
-        application/json:
-          schema:
-            $ref: "../../components/schemas/common/errors/ActorErrors.yaml#/ActorBuildNotFoundError"
+      $ref: ../../components/responses/NotFound.yaml
     "405":
       $ref: ../../components/responses/MethodNotAllowed.yaml
     "429":

--- a/apify-api/openapi/paths/actor-builds/actor-builds@{buildId}@openapi.json.yaml
+++ b/apify-api/openapi/paths/actor-builds/actor-builds@{buildId}@openapi.json.yaml
@@ -32,11 +32,7 @@ get:
     "400":
       $ref: ../../components/responses/BadRequest.yaml
     "404":
-      description: Not found - the requested resource was not found.
-      content:
-        application/json:
-          schema:
-            $ref: "../../components/schemas/common/errors/ActorErrors.yaml#/ActorBuildNotFoundError"
+      $ref: ../../components/responses/NotFound.yaml
     "405":
       $ref: ../../components/responses/MethodNotAllowed.yaml
     "429":

--- a/apify-api/openapi/paths/actor-tasks/actor-tasks@{actorTaskId}@run-sync-get-dataset-items.yaml
+++ b/apify-api/openapi/paths/actor-tasks/actor-tasks@{actorTaskId}@run-sync-get-dataset-items.yaml
@@ -71,12 +71,7 @@ get:
     "405":
       $ref: ../../components/responses/MethodNotAllowed.yaml
     "408":
-      description: "Request Timeout: the HTTP request exceeded the 300 second limit"
-      headers: {}
-      content:
-        application/json:
-          schema:
-            $ref: ../../components/schemas/common/ErrorResponse.yaml
+      $ref: ../../components/responses/RunTimeout.yaml
     "429":
       $ref: ../../components/responses/TooManyRequests.yaml
   deprecated: false

--- a/apify-api/openapi/paths/actor-tasks/actor-tasks@{actorTaskId}@run-sync.yaml
+++ b/apify-api/openapi/paths/actor-tasks/actor-tasks@{actorTaskId}@run-sync.yaml
@@ -50,12 +50,7 @@ get:
     "405":
       $ref: ../../components/responses/MethodNotAllowed.yaml
     "408":
-      description: "Request Timeout: the HTTP request exceeded the 300 second limit"
-      headers: {}
-      content:
-        application/json:
-          schema:
-            $ref: ../../components/schemas/common/ErrorResponse.yaml
+      $ref: ../../components/responses/RunTimeout.yaml
     "429":
       $ref: ../../components/responses/TooManyRequests.yaml
   deprecated: false

--- a/apify-api/openapi/paths/actors/acts@{actorId}@builds.yaml
+++ b/apify-api/openapi/paths/actors/acts@{actorId}@builds.yaml
@@ -123,11 +123,7 @@ post:
     "403":
       $ref: ../../components/responses/Forbidden.yaml
     "404":
-      description: Not found - the requested resource was not found.
-      content:
-        application/json:
-          schema:
-            $ref: "../../components/schemas/common/errors/ActorErrors.yaml#/ActorNotFoundError"
+      $ref: ../../components/responses/NotFound.yaml
     "405":
       $ref: ../../components/responses/MethodNotAllowed.yaml
     "429":

--- a/apify-api/openapi/paths/actors/acts@{actorId}@builds@{buildId}.yaml
+++ b/apify-api/openapi/paths/actors/acts@{actorId}@builds@{buildId}.yaml
@@ -27,13 +27,7 @@ get:
     "400":
       $ref: ../../components/responses/BadRequest.yaml
     "404":
-      description: Not found - the requested resource was not found.
-      content:
-        application/json:
-          schema:
-            oneOf:
-              - $ref: "../../components/schemas/common/errors/ActorErrors.yaml#/ActorNotFoundError"
-              - $ref: "../../components/schemas/common/errors/ActorErrors.yaml#/ActorBuildNotFoundError"
+      $ref: ../../components/responses/NotFound.yaml
     "405":
       $ref: ../../components/responses/MethodNotAllowed.yaml
     "429":

--- a/apify-api/openapi/paths/actors/acts@{actorId}@builds@{buildId}@abort.yaml
+++ b/apify-api/openapi/paths/actors/acts@{actorId}@builds@{buildId}@abort.yaml
@@ -54,13 +54,7 @@ post:
     "403":
       $ref: ../../components/responses/Forbidden.yaml
     "404":
-      description: Not found - the requested resource was not found.
-      content:
-        application/json:
-          schema:
-            oneOf:
-              - $ref: "../../components/schemas/common/errors/ActorErrors.yaml#/ActorNotFoundError"
-              - $ref: "../../components/schemas/common/errors/ActorErrors.yaml#/ActorBuildNotFoundError"
+      $ref: ../../components/responses/NotFound.yaml
     "405":
       $ref: ../../components/responses/MethodNotAllowed.yaml
     "429":

--- a/apify-api/openapi/paths/actors/acts@{actorId}@builds@{buildId}@openapi.json.yaml
+++ b/apify-api/openapi/paths/actors/acts@{actorId}@builds@{buildId}@openapi.json.yaml
@@ -38,13 +38,7 @@ get:
     "403":
       $ref: ../../components/responses/Forbidden.yaml
     "404":
-      description: Not found - the requested resource was not found.
-      content:
-        application/json:
-          schema:
-            oneOf:
-              - $ref: "../../components/schemas/common/errors/ActorErrors.yaml#/ActorNotFoundError"
-              - $ref: "../../components/schemas/common/errors/ActorErrors.yaml#/ActorBuildNotFoundError"
+      $ref: ../../components/responses/NotFound.yaml
     "405":
       $ref: ../../components/responses/MethodNotAllowed.yaml
     "429":

--- a/apify-api/openapi/paths/actors/acts@{actorId}@run-sync-get-dataset-items.yaml
+++ b/apify-api/openapi/paths/actors/acts@{actorId}@run-sync-get-dataset-items.yaml
@@ -90,11 +90,7 @@ post:
           schema:
             $ref: "../../components/schemas/common/errors/ActorErrors.yaml#/ActorRunFailedError"
     "404":
-      description: Not found - the requested resource was not found.
-      content:
-        application/json:
-          schema:
-            $ref: "../../components/schemas/common/errors/ActorErrors.yaml#/ActorNotFoundError"
+      $ref: ../../components/responses/NotFound.yaml
     "408":
       description: ""
       headers: {}
@@ -183,11 +179,7 @@ get:
           schema:
             $ref: "../../components/schemas/common/errors/ActorErrors.yaml#/ActorRunFailedError"
     "404":
-      description: Not found - the requested resource was not found.
-      content:
-        application/json:
-          schema:
-            $ref: "../../components/schemas/common/errors/ActorErrors.yaml#/ActorNotFoundError"
+      $ref: ../../components/responses/NotFound.yaml
     "408":
       description: ""
       headers: {}

--- a/apify-api/openapi/paths/actors/acts@{actorId}@run-sync.yaml
+++ b/apify-api/openapi/paths/actors/acts@{actorId}@run-sync.yaml
@@ -63,11 +63,7 @@ post:
           schema:
             $ref: "../../components/schemas/common/errors/ActorErrors.yaml#/ActorRunFailedError"
     "404":
-      description: Not found - the requested resource was not found.
-      content:
-        application/json:
-          schema:
-            $ref: "../../components/schemas/common/errors/ActorErrors.yaml#/ActorNotFoundError"
+      $ref: ../../components/responses/NotFound.yaml
     "408":
       description: ""
       headers: {}
@@ -132,11 +128,7 @@ get:
           schema:
             $ref: "../../components/schemas/common/errors/ActorErrors.yaml#/ActorRunFailedError"
     "404":
-      description: Not found - the requested resource was not found.
-      content:
-        application/json:
-          schema:
-            $ref: "../../components/schemas/common/errors/ActorErrors.yaml#/ActorNotFoundError"
+      $ref: ../../components/responses/NotFound.yaml
     "408":
       description: ""
       headers: {}

--- a/apify-api/openapi/paths/actors/acts@{actorId}@runs.yaml
+++ b/apify-api/openapi/paths/actors/acts@{actorId}@runs.yaml
@@ -144,11 +144,7 @@ post:
     "403":
       $ref: ../../components/responses/Forbidden.yaml
     "404":
-      description: Not found - the requested resource was not found.
-      content:
-        application/json:
-          schema:
-            $ref: "../../components/schemas/common/errors/ActorErrors.yaml#/ActorNotFoundError"
+      $ref: ../../components/responses/NotFound.yaml
     "405":
       $ref: ../../components/responses/MethodNotAllowed.yaml
     "413":

--- a/apify-api/openapi/paths/actors/acts@{actorId}@runs@last.yaml
+++ b/apify-api/openapi/paths/actors/acts@{actorId}@runs@last.yaml
@@ -76,13 +76,7 @@ get:
     "403":
       $ref: ../../components/responses/Forbidden.yaml
     "404":
-      description: Not found - the requested resource was not found.
-      content:
-        application/json:
-          schema:
-            oneOf:
-              - $ref: "../../components/schemas/common/errors/ActorErrors.yaml#/ActorNotFoundError"
-              - $ref: "../../components/schemas/common/errors/ActorErrors.yaml#/ActorRunNotFoundError"
+      $ref: ../../components/responses/NotFound.yaml
     "405":
       $ref: ../../components/responses/MethodNotAllowed.yaml
     "429":

--- a/apify-api/openapi/paths/actors/acts@{actorId}@runs@{runId}.yaml
+++ b/apify-api/openapi/paths/actors/acts@{actorId}@runs@{runId}.yaml
@@ -35,13 +35,7 @@ get:
     "403":
       $ref: ../../components/responses/Forbidden.yaml
     "404":
-      description: Not found - the requested resource was not found.
-      content:
-        application/json:
-          schema:
-            oneOf:
-              - $ref: "../../components/schemas/common/errors/ActorErrors.yaml#/ActorNotFoundError"
-              - $ref: "../../components/schemas/common/errors/ActorErrors.yaml#/ActorRunNotFoundError"
+      $ref: ../../components/responses/NotFound.yaml
     "405":
       $ref: ../../components/responses/MethodNotAllowed.yaml
     "429":

--- a/apify-api/openapi/paths/actors/acts@{actorId}@runs@{runId}@abort.yaml
+++ b/apify-api/openapi/paths/actors/acts@{actorId}@runs@{runId}@abort.yaml
@@ -31,13 +31,7 @@ post:
     "403":
       $ref: ../../components/responses/Forbidden.yaml
     "404":
-      description: Not found - the requested resource was not found.
-      content:
-        application/json:
-          schema:
-            oneOf:
-              - $ref: "../../components/schemas/common/errors/ActorErrors.yaml#/ActorNotFoundError"
-              - $ref: "../../components/schemas/common/errors/ActorErrors.yaml#/ActorRunNotFoundError"
+      $ref: ../../components/responses/NotFound.yaml
     "405":
       $ref: ../../components/responses/MethodNotAllowed.yaml
     "429":

--- a/apify-api/openapi/paths/actors/acts@{actorId}@runs@{runId}@metamorph.yaml
+++ b/apify-api/openapi/paths/actors/acts@{actorId}@runs@{runId}@metamorph.yaml
@@ -56,13 +56,7 @@ post:
     "403":
       $ref: ../../components/responses/Forbidden.yaml
     "404":
-      description: Not found - the requested resource was not found.
-      content:
-        application/json:
-          schema:
-            oneOf:
-              - $ref: "../../components/schemas/common/errors/ActorErrors.yaml#/ActorNotFoundError"
-              - $ref: "../../components/schemas/common/errors/ActorErrors.yaml#/ActorRunNotFoundError"
+      $ref: ../../components/responses/NotFound.yaml
     "405":
       $ref: ../../components/responses/MethodNotAllowed.yaml
     "429":

--- a/apify-api/openapi/paths/actors/acts@{actorId}@runs@{runId}@resurrect.yaml
+++ b/apify-api/openapi/paths/actors/acts@{actorId}@runs@{runId}@resurrect.yaml
@@ -39,13 +39,7 @@ post:
     "403":
       $ref: ../../components/responses/Forbidden.yaml
     "404":
-      description: Not found - the requested resource was not found.
-      content:
-        application/json:
-          schema:
-            oneOf:
-              - $ref: "../../components/schemas/common/errors/ActorErrors.yaml#/ActorNotFoundError"
-              - $ref: "../../components/schemas/common/errors/ActorErrors.yaml#/ActorRunNotFoundError"
+      $ref: ../../components/responses/NotFound.yaml
     "405":
       $ref: ../../components/responses/MethodNotAllowed.yaml
     "429":

--- a/apify-api/openapi/paths/actors/acts@{actorId}@versions.yaml
+++ b/apify-api/openapi/paths/actors/acts@{actorId}@versions.yaml
@@ -134,11 +134,7 @@ post:
     "403":
       $ref: ../../components/responses/Forbidden.yaml
     "404":
-      description: Not found - the requested resource was not found.
-      content:
-        application/json:
-          schema:
-            $ref: "../../components/schemas/common/errors/ActorErrors.yaml#/ActorNotFoundError"
+      $ref: ../../components/responses/NotFound.yaml
     "405":
       $ref: ../../components/responses/MethodNotAllowed.yaml
     "413":

--- a/apify-api/openapi/paths/actors/acts@{actorId}@versions@{versionNumber}.yaml
+++ b/apify-api/openapi/paths/actors/acts@{actorId}@versions@{versionNumber}.yaml
@@ -67,13 +67,7 @@ delete:
     "403":
       $ref: ../../components/responses/Forbidden.yaml
     "404":
-      description: Not found - the requested resource was not found.
-      content:
-        application/json:
-          schema:
-            oneOf:
-              - $ref: "../../components/schemas/common/errors/ActorErrors.yaml#/RecordOrTokenNotFoundError"
-              - $ref: "../../components/schemas/common/errors/ActorErrors.yaml#/ActorVersionNotFoundError"
+      $ref: ../../components/responses/NotFound.yaml
     "405":
       $ref: ../../components/responses/MethodNotAllowed.yaml
     "429":

--- a/apify-api/openapi/paths/actors/acts@{actorId}@versions@{versionNumber}@env-vars.yaml
+++ b/apify-api/openapi/paths/actors/acts@{actorId}@versions@{versionNumber}@env-vars.yaml
@@ -24,13 +24,7 @@ get:
     "403":
       $ref: ../../components/responses/Forbidden.yaml
     "404":
-      description: Not found - the requested resource was not found.
-      content:
-        application/json:
-          schema:
-            oneOf:
-              - $ref: "../../components/schemas/common/errors/ActorErrors.yaml#/ActorNotFoundError"
-              - $ref: "../../components/schemas/common/errors/ActorErrors.yaml#/ActorVersionNotFoundError"
+      $ref: ../../components/responses/NotFound.yaml
     "405":
       $ref: ../../components/responses/MethodNotAllowed.yaml
     "429":
@@ -107,11 +101,7 @@ post:
     "403":
       $ref: ../../components/responses/Forbidden.yaml
     "404":
-      description: Not found - the requested resource was not found.
-      content:
-        application/json:
-          schema:
-            $ref: "../../components/schemas/common/errors/ActorErrors.yaml#/ActorNotFoundError"
+      $ref: ../../components/responses/NotFound.yaml
     "405":
       $ref: ../../components/responses/MethodNotAllowed.yaml
     "413":

--- a/apify-api/openapi/paths/actors/acts@{actorId}@versions@{versionNumber}@env-vars@{envVarName}.yaml
+++ b/apify-api/openapi/paths/actors/acts@{actorId}@versions@{versionNumber}@env-vars@{envVarName}.yaml
@@ -39,14 +39,7 @@ get:
     "403":
       $ref: ../../components/responses/Forbidden.yaml
     "404":
-      description: Not found - the requested resource was not found.
-      content:
-        application/json:
-          schema:
-            oneOf:
-              - $ref: "../../components/schemas/common/errors/ActorErrors.yaml#/ActorNotFoundError"
-              - $ref: "../../components/schemas/common/errors/ActorErrors.yaml#/ActorVersionNotFoundError"
-              - $ref: "../../components/schemas/common/errors/EnvVariableErrors.yaml#/EnvironmentVariableNotFoundError"
+      $ref: ../../components/responses/NotFound.yaml
     "405":
       $ref: ../../components/responses/MethodNotAllowed.yaml
     "429":
@@ -97,14 +90,7 @@ delete:
     "403":
       $ref: ../../components/responses/Forbidden.yaml
     "404":
-      description: Not found - the requested resource was not found.
-      content:
-        application/json:
-          schema:
-            oneOf:
-              - $ref: "../../components/schemas/common/errors/ActorErrors.yaml#/ActorNotFoundError"
-              - $ref: "../../components/schemas/common/errors/ActorErrors.yaml#/ActorVersionNotFoundError"
-              - $ref: "../../components/schemas/common/errors/EnvVariableErrors.yaml#/EnvironmentVariableNotFoundError"
+      $ref: ../../components/responses/NotFound.yaml
     "405":
       $ref: ../../components/responses/MethodNotAllowed.yaml
     "429":

--- a/apify-api/openapi/paths/datasets/datasets@{datasetId}.yaml
+++ b/apify-api/openapi/paths/datasets/datasets@{datasetId}.yaml
@@ -42,11 +42,7 @@ get:
     "403":
       $ref: ../../components/responses/Forbidden.yaml
     "404":
-      description: Not found - the requested resource was not found.
-      content:
-        application/json:
-          schema:
-            $ref: "../../components/schemas/common/errors/StorageErrors.yaml#/DatasetNotFoundError"
+      $ref: ../../components/responses/NotFound.yaml
     "405":
       $ref: ../../components/responses/MethodNotAllowed.yaml
     "429":
@@ -94,11 +90,7 @@ put:
     "403":
       $ref: ../../components/responses/Forbidden.yaml
     "404":
-      description: Not found - the requested resource was not found.
-      content:
-        application/json:
-          schema:
-            $ref: "../../components/schemas/common/errors/StorageErrors.yaml#/DatasetNotFoundError"
+      $ref: ../../components/responses/NotFound.yaml
     "405":
       $ref: ../../components/responses/MethodNotAllowed.yaml
     "413":
@@ -136,11 +128,7 @@ delete:
     "403":
       $ref: ../../components/responses/Forbidden.yaml
     "404":
-      description: Not found - the requested resource was not found.
-      content:
-        application/json:
-          schema:
-            $ref: "../../components/schemas/common/errors/StorageErrors.yaml#/DatasetNotFoundError"
+      $ref: ../../components/responses/NotFound.yaml
     "405":
       $ref: ../../components/responses/MethodNotAllowed.yaml
     "429":

--- a/apify-api/openapi/paths/datasets/datasets@{datasetId}@items.yaml
+++ b/apify-api/openapi/paths/datasets/datasets@{datasetId}@items.yaml
@@ -218,11 +218,7 @@ get:
     "403":
       $ref: ../../components/responses/Forbidden.yaml
     "404":
-      description: Not found - the requested resource was not found.
-      content:
-        application/json:
-          schema:
-            $ref: "../../components/schemas/common/errors/StorageErrors.yaml#/DatasetNotFoundError"
+      $ref: ../../components/responses/NotFound.yaml
     "405":
       $ref: ../../components/responses/MethodNotAllowed.yaml
     "429":
@@ -330,11 +326,7 @@ post:
     "403":
       $ref: ../../components/responses/Forbidden.yaml
     "404":
-      description: Not found - the requested resource was not found.
-      content:
-        application/json:
-          schema:
-            $ref: "../../components/schemas/common/errors/StorageErrors.yaml#/DatasetNotFoundError"
+      $ref: ../../components/responses/NotFound.yaml
   deprecated: false
   x-legacy-doc-urls:
     - https://docs.apify.com/api/v2#/reference/datasets/item-collection/put-items

--- a/apify-api/openapi/paths/datasets/datasets@{datasetId}@statistics.yaml
+++ b/apify-api/openapi/paths/datasets/datasets@{datasetId}@statistics.yaml
@@ -31,11 +31,7 @@ get:
     "403":
       $ref: ../../components/responses/Forbidden.yaml
     "404":
-      description: Not found - the requested resource was not found.
-      content:
-        application/json:
-          schema:
-            $ref: "../../components/schemas/common/errors/StorageErrors.yaml#/DatasetNotFoundError"
+      $ref: ../../components/responses/NotFound.yaml
     "405":
       $ref: ../../components/responses/MethodNotAllowed.yaml
     "429":

--- a/apify-api/openapi/paths/key-value-stores/key-value-stores@{storeId}.yaml
+++ b/apify-api/openapi/paths/key-value-stores/key-value-stores@{storeId}.yaml
@@ -23,11 +23,7 @@ get:
     "403":
       $ref: ../../components/responses/Forbidden.yaml
     "404":
-      description: Not found - the requested resource was not found.
-      content:
-        application/json:
-          schema:
-            $ref: "../../components/schemas/common/errors/StorageErrors.yaml#/KeyValueStoreNotFoundError"
+      $ref: ../../components/responses/NotFound.yaml
     "405":
       $ref: ../../components/responses/MethodNotAllowed.yaml
     "429":
@@ -80,11 +76,7 @@ put:
     "403":
       $ref: ../../components/responses/Forbidden.yaml
     "404":
-      description: Not found - the requested resource was not found.
-      content:
-        application/json:
-          schema:
-            $ref: "../../components/schemas/common/errors/StorageErrors.yaml#/KeyValueStoreNotFoundError"
+      $ref: ../../components/responses/NotFound.yaml
     "405":
       $ref: ../../components/responses/MethodNotAllowed.yaml
     "413":
@@ -122,11 +114,7 @@ delete:
     "403":
       $ref: ../../components/responses/Forbidden.yaml
     "404":
-      description: Not found - the requested resource was not found.
-      content:
-        application/json:
-          schema:
-            $ref: "../../components/schemas/common/errors/StorageErrors.yaml#/KeyValueStoreNotFoundError"
+      $ref: ../../components/responses/NotFound.yaml
     "405":
       $ref: ../../components/responses/MethodNotAllowed.yaml
     "429":

--- a/apify-api/openapi/paths/key-value-stores/key-value-stores@{storeId}@keys.yaml
+++ b/apify-api/openapi/paths/key-value-stores/key-value-stores@{storeId}@keys.yaml
@@ -56,11 +56,7 @@ get:
     "403":
       $ref: ../../components/responses/Forbidden.yaml
     "404":
-      description: Not found - the requested resource was not found.
-      content:
-        application/json:
-          schema:
-            $ref: "../../components/schemas/common/errors/StorageErrors.yaml#/KeyValueStoreNotFoundError"
+      $ref: ../../components/responses/NotFound.yaml
     "405":
       $ref: ../../components/responses/MethodNotAllowed.yaml
     "429":

--- a/apify-api/openapi/paths/key-value-stores/key-value-stores@{storeId}@records.yaml
+++ b/apify-api/openapi/paths/key-value-stores/key-value-stores@{storeId}@records.yaml
@@ -45,11 +45,7 @@ get:
     "403":
       $ref: ../../components/responses/Forbidden.yaml
     "404":
-      description: Not found - the requested resource was not found.
-      content:
-        application/json:
-          schema:
-            $ref: "../../components/schemas/common/errors/StorageErrors.yaml#/KeyValueStoreNotFoundError"
+      $ref: ../../components/responses/NotFound.yaml
     "405":
       $ref: ../../components/responses/MethodNotAllowed.yaml
     "429":

--- a/apify-api/openapi/paths/key-value-stores/key-value-stores@{storeId}@records@{recordKey}.yaml
+++ b/apify-api/openapi/paths/key-value-stores/key-value-stores@{storeId}@records@{recordKey}.yaml
@@ -61,13 +61,7 @@ get:
     "403":
       $ref: ../../components/responses/Forbidden.yaml
     "404":
-      description: Not found - the requested resource was not found.
-      content:
-        application/json:
-          schema:
-            oneOf:
-              - $ref: "../../components/schemas/common/errors/StorageErrors.yaml#/KeyValueStoreNotFoundError"
-              - $ref: "../../components/schemas/common/errors/StorageErrors.yaml#/RecordNotFoundError"
+      $ref: ../../components/responses/NotFound.yaml
     "405":
       $ref: ../../components/responses/MethodNotAllowed.yaml
     "429":
@@ -98,8 +92,7 @@ head:
       description: The record exists
       headers: {}
     "404":
-      description: The record does not exist
-      headers: {}
+      $ref: ../../components/responses/NotFound.yaml
   deprecated: false
   x-js-parent: KeyValueStoreClient
   x-js-name: recordExists

--- a/apify-api/openapi/paths/request-queues/request-queues@{queueId}.yaml
+++ b/apify-api/openapi/paths/request-queues/request-queues@{queueId}.yaml
@@ -21,11 +21,7 @@ get:
     "403":
       $ref: ../../components/responses/Forbidden.yaml
     "404":
-      description: Not found - the requested resource was not found.
-      content:
-        application/json:
-          schema:
-            $ref: "../../components/schemas/common/errors/StorageErrors.yaml#/RequestQueueNotFoundError"
+      $ref: ../../components/responses/NotFound.yaml
     "405":
       $ref: ../../components/responses/MethodNotAllowed.yaml
     "429":
@@ -81,11 +77,7 @@ put:
     "403":
       $ref: ../../components/responses/Forbidden.yaml
     "404":
-      description: Not found - the requested resource was not found.
-      content:
-        application/json:
-          schema:
-            $ref: "../../components/schemas/common/errors/StorageErrors.yaml#/RequestQueueNotFoundError"
+      $ref: ../../components/responses/NotFound.yaml
     "405":
       $ref: ../../components/responses/MethodNotAllowed.yaml
     "413":
@@ -123,11 +115,7 @@ delete:
     "403":
       $ref: ../../components/responses/Forbidden.yaml
     "404":
-      description: Not found - the requested resource was not found.
-      content:
-        application/json:
-          schema:
-            $ref: "../../components/schemas/common/errors/StorageErrors.yaml#/RequestQueueNotFoundError"
+      $ref: ../../components/responses/NotFound.yaml
     "405":
       $ref: ../../components/responses/MethodNotAllowed.yaml
     "429":

--- a/apify-api/openapi/paths/request-queues/request-queues@{queueId}@head.yaml
+++ b/apify-api/openapi/paths/request-queues/request-queues@{queueId}@head.yaml
@@ -39,11 +39,7 @@ get:
     "403":
       $ref: ../../components/responses/Forbidden.yaml
     "404":
-      description: Not found - the requested resource was not found.
-      content:
-        application/json:
-          schema:
-            $ref: "../../components/schemas/common/errors/StorageErrors.yaml#/RequestQueueNotFoundError"
+      $ref: ../../components/responses/NotFound.yaml
     "405":
       $ref: ../../components/responses/MethodNotAllowed.yaml
     "429":

--- a/apify-api/openapi/paths/request-queues/request-queues@{queueId}@head@lock.yaml
+++ b/apify-api/openapi/paths/request-queues/request-queues@{queueId}@head@lock.yaml
@@ -42,11 +42,7 @@ post:
     "403":
       $ref: ../../components/responses/Forbidden.yaml
     "404":
-      description: Not found - the requested resource was not found.
-      content:
-        application/json:
-          schema:
-            $ref: "../../components/schemas/common/errors/StorageErrors.yaml#/RequestQueueNotFoundError"
+      $ref: ../../components/responses/NotFound.yaml
     "405":
       $ref: ../../components/responses/MethodNotAllowed.yaml
     "429":

--- a/apify-api/openapi/paths/request-queues/request-queues@{queueId}@requests.yaml
+++ b/apify-api/openapi/paths/request-queues/request-queues@{queueId}@requests.yaml
@@ -63,11 +63,7 @@ get:
     "403":
       $ref: ../../components/responses/Forbidden.yaml
     "404":
-      description: Not found - the requested resource was not found.
-      content:
-        application/json:
-          schema:
-            $ref: "../../components/schemas/common/errors/StorageErrors.yaml#/RequestQueueNotFoundError"
+      $ref: ../../components/responses/NotFound.yaml
     "405":
       $ref: ../../components/responses/MethodNotAllowed.yaml
     "429":
@@ -120,11 +116,7 @@ post:
     "403":
       $ref: ../../components/responses/Forbidden.yaml
     "404":
-      description: Not found - the requested resource was not found.
-      content:
-        application/json:
-          schema:
-            $ref: "../../components/schemas/common/errors/StorageErrors.yaml#/RequestQueueNotFoundError"
+      $ref: ../../components/responses/NotFound.yaml
     "405":
       $ref: ../../components/responses/MethodNotAllowed.yaml
     "413":

--- a/apify-api/openapi/paths/request-queues/request-queues@{queueId}@requests@batch.yaml
+++ b/apify-api/openapi/paths/request-queues/request-queues@{queueId}@requests@batch.yaml
@@ -43,11 +43,7 @@ post:
     "403":
       $ref: ../../components/responses/Forbidden.yaml
     "404":
-      description: Not found - the requested resource was not found.
-      content:
-        application/json:
-          schema:
-            $ref: "../../components/schemas/common/errors/StorageErrors.yaml#/RequestQueueNotFoundError"
+      $ref: ../../components/responses/NotFound.yaml
     "405":
       $ref: ../../components/responses/MethodNotAllowed.yaml
     "413":
@@ -119,11 +115,7 @@ delete:
     "403":
       $ref: ../../components/responses/Forbidden.yaml
     "404":
-      description: Not found - the requested resource was not found.
-      content:
-        application/json:
-          schema:
-            $ref: "../../components/schemas/common/errors/StorageErrors.yaml#/RequestQueueNotFoundError"
+      $ref: ../../components/responses/NotFound.yaml
     "405":
       $ref: ../../components/responses/MethodNotAllowed.yaml
     "413":

--- a/apify-api/openapi/paths/request-queues/request-queues@{queueId}@requests@unlock.yaml
+++ b/apify-api/openapi/paths/request-queues/request-queues@{queueId}@requests@unlock.yaml
@@ -25,11 +25,7 @@ post:
     "403":
       $ref: ../../components/responses/Forbidden.yaml
     "404":
-      description: Not found - the requested resource was not found.
-      content:
-        application/json:
-          schema:
-            $ref: "../../components/schemas/common/errors/StorageErrors.yaml#/RequestQueueNotFoundError"
+      $ref: ../../components/responses/NotFound.yaml
     "405":
       $ref: ../../components/responses/MethodNotAllowed.yaml
     "429":

--- a/apify-api/openapi/paths/request-queues/request-queues@{queueId}@requests@{requestId}.yaml
+++ b/apify-api/openapi/paths/request-queues/request-queues@{queueId}@requests@{requestId}.yaml
@@ -22,13 +22,7 @@ get:
     "403":
       $ref: ../../components/responses/Forbidden.yaml
     "404":
-      description: Not found - the requested resource was not found.
-      content:
-        application/json:
-          schema:
-            oneOf:
-              - $ref: "../../components/schemas/common/errors/StorageErrors.yaml#/RequestQueueNotFoundError"
-              - $ref: "../../components/schemas/common/errors/StorageErrors.yaml#/RequestNotFoundError"
+      $ref: ../../components/responses/NotFound.yaml
     "405":
       $ref: ../../components/responses/MethodNotAllowed.yaml
     "429":
@@ -80,11 +74,7 @@ put:
     "403":
       $ref: ../../components/responses/Forbidden.yaml
     "404":
-      description: Not found - the requested resource was not found.
-      content:
-        application/json:
-          schema:
-            $ref: "../../components/schemas/common/errors/StorageErrors.yaml#/RequestQueueNotFoundError"
+      $ref: ../../components/responses/NotFound.yaml
     "405":
       $ref: ../../components/responses/MethodNotAllowed.yaml
     "413":
@@ -124,11 +114,7 @@ delete:
     "403":
       $ref: ../../components/responses/Forbidden.yaml
     "404":
-      description: Not found - the requested resource was not found.
-      content:
-        application/json:
-          schema:
-            $ref: "../../components/schemas/common/errors/StorageErrors.yaml#/RequestQueueNotFoundError"
+      $ref: ../../components/responses/NotFound.yaml
     "405":
       $ref: ../../components/responses/MethodNotAllowed.yaml
     "429":

--- a/apify-api/openapi/paths/request-queues/request-queues@{queueId}@requests@{requestId}@lock.yaml
+++ b/apify-api/openapi/paths/request-queues/request-queues@{queueId}@requests@{requestId}@lock.yaml
@@ -37,11 +37,7 @@ put:
     "403":
       $ref: ../../components/responses/Forbidden.yaml
     "404":
-      description: Not found - the requested resource was not found.
-      content:
-        application/json:
-          schema:
-            $ref: "../../components/schemas/common/errors/StorageErrors.yaml#/RequestQueueNotFoundError"
+      $ref: ../../components/responses/NotFound.yaml
     "405":
       $ref: ../../components/responses/MethodNotAllowed.yaml
     "429":
@@ -90,11 +86,7 @@ delete:
     "403":
       $ref: ../../components/responses/Forbidden.yaml
     "404":
-      description: Not found - the requested resource was not found.
-      content:
-        application/json:
-          schema:
-            $ref: "../../components/schemas/common/errors/StorageErrors.yaml#/RequestQueueNotFoundError"
+      $ref: ../../components/responses/NotFound.yaml
     "405":
       $ref: ../../components/responses/MethodNotAllowed.yaml
     "429":


### PR DESCRIPTION
- Add missing, but possible errors to the `ErrorResponse.yaml`
- Simplify 404s to refer to a generic error and give generic missing resource text

**Motivation:** 
- Simplify code generation by reducing the number of error objects.
- Simplify upcoming documentation of redispatch endpoints (This will allow complete reuse of the response section. Using granular 404s would not allow it due to, for example, `last run` endpoints always having `actor/run not found` errors even when referring to the default dataset, while getting the dataset directly through id will never return such 404 variant )

Follow up for: https://github.com/apify/apify-docs/pull/2398

Partially implements: https://github.com/apify/apify-docs/issues/2286