### PR TITLE
docs(openapi): Remove uri format where not enforced by API

### DIFF
--- a/apify-api/openapi/components/schemas/request-queues/RequestBase.yaml
+++ b/apify-api/openapi/components/schemas/request-queues/RequestBase.yaml
@@ -11,7 +11,6 @@ properties:
     $ref: ./SharedProperties.yaml#/RetryCount
   loadedUrl:
     type: [string, "null"]
-    format: uri
     description: The final URL that was loaded, after redirects (if any).
     examples: [https://apify.com/jobs]
   payload:

--- a/apify-api/openapi/components/schemas/request-queues/RequestUserData.yaml
+++ b/apify-api/openapi/components/schemas/request-queues/RequestUserData.yaml
@@ -2,12 +2,6 @@ title: RequestUserData
 description: Custom user data attached to the request. Can contain arbitrary fields.
 type: object
 additionalProperties: true
-properties:
-  label:
-    type: [string, "null"]
-    description: Optional label for categorizing the request.
-    examples: [DETAIL]
-  image:
-    type: [string, "null"]
-    description: Optional image URL associated with the request.
-    examples: [https://picserver1.eu]
+example:
+  label: DETAIL
+  customField: custom-value

--- a/apify-api/openapi/components/schemas/request-queues/RequestUserData.yaml
+++ b/apify-api/openapi/components/schemas/request-queues/RequestUserData.yaml
@@ -9,6 +9,5 @@ properties:
     examples: [DETAIL]
   image:
     type: [string, "null"]
-    format: uri
     description: Optional image URL associated with the request.
     examples: [https://picserver1.eu]


### PR DESCRIPTION
- Remove uri format where not enforced by API:
  - `RequestBase.loadedUrl`

- Remove unnecessary properties from UserData
 
- `Format uri` left for following:                                                    
  - Webhook.yaml, WebhookUpdate.yaml, WebhookShort.yaml → requestUrl: regex + runtime validation (WEBHOOK_REQUEST_URL_REGEXP + new URL())
  - Profile.yaml → websiteUrl: HTTP_URL_REGEX validation                                                                                     
  - Profile.yaml → pictureUrl: runtime S3 URL check     
  - All output-only fields (consoleUrl, keysPublicUrl, itemsPublicUrl, containerUrl, recordPublicUrl, standbyUrl,                            
  StoreListActor.pictureUrl/userPictureUrl/url): generated by the API itself, always valid URIs   

**Follow-up for:** https://github.com/apify/apify-docs/pull/2403#discussion_r3071462194

**Partially implements:** https://github.com/apify/apify-docs/issues/2286