### PR TITLE
docs: Clarify monthly usage API documentation

### DIFF
--- a/apify-api/openapi/paths/users/users@me@usage@monthly.yaml
+++ b/apify-api/openapi/paths/users/users@me@usage@monthly.yaml
@@ -3,12 +3,12 @@ get:
     - Users
   summary: Get monthly usage
   description: |
-    Returns a complete summary of your usage for the current usage cycle,
+    Returns a complete summary of your usage for the current monthly usage cycle,
     an overall sum, as well as a daily breakdown of usage. It is the same
-    information you will see on your account's [Billing page](https://console.apify.com/billing#/usage). The information
+    information you will see on your account's [Billing > Historical usage page](https://console.apify.com/billing/historical-usage). The information
     includes your use of storage, data transfer, and request queue usage.
 
-    Using the `date` parameter will show your usage in the usage cycle that
+    Using the `date` parameter will show your usage in the monthly usage cycle that
     includes that date.
   operationId: users_me_usage_monthly_get
   parameters:

--- a/apify-api/openapi/paths/users/users@me@usage@monthly.yaml
+++ b/apify-api/openapi/paths/users/users@me@usage@monthly.yaml
@@ -6,7 +6,7 @@ get:
     Returns a complete summary of your usage for the current monthly usage cycle,
     an overall sum, as well as a daily breakdown of usage. It is the same
     information you will see on your account's [Billing > Historical usage page](https://console.apify.com/billing/historical-usage). The information
-    includes your use of storage, data transfer, and request queue usage.
+    includes your use of Actors, compute, data transfer, and storage.
 
     Using the `date` parameter will show your usage in the monthly usage cycle that
     includes that date.


### PR DESCRIPTION
## Summary
Updated the OpenAPI documentation for the monthly usage endpoint to provide clearer and more accurate descriptions of the API functionality.

## Key Changes
- Clarified that the usage cycle is specifically a "monthly usage cycle" (not just "usage cycle")
- Updated the Billing page reference to point to the more specific "Billing > Historical usage page" with the correct URL (`/billing/historical-usage`)
- Improved consistency in terminology throughout the endpoint description

## Details
These documentation improvements help users better understand:
- The monthly nature of the usage cycle being reported
- Where to find the equivalent information in the Apify console UI
- How the `date` parameter affects which monthly cycle's data is returned

https://claude.ai/code/session_016zLNhC5XUAQcqLci4e5ABS