### PR TITLE
docs(openapi): Add undocumented last task run endpoints

### DIFF
--- a/apify-api/openapi/components/objects/datasets/dataset-items.yaml
+++ b/apify-api/openapi/components/objects/datasets/dataset-items.yaml
@@ -22,6 +22,10 @@ sharedTagLastRun: &sharedTagLastRun
   tags:
     - Last Actor run's default dataset
 
+sharedTagTaskLastRun: &sharedTagTaskLastRun
+  tags:
+    - Last Actor task run's default dataset
+
 parametersGetHeadById: &parametersGetHeadById
   parameters:
     - $ref: "../../parameters/datasetParameters.yaml#/datasetId"
@@ -320,6 +324,40 @@ getLastRun:
     - $ref: "../../parameters/datasetParameters.yaml#/skipFailedPages"
     - $ref: "../../parameters/storageParameters.yaml#/signature"
 
+getTaskLastRun:
+  <<: [*sharedGet, *sharedTagTaskLastRun]
+  summary: Get last task run's dataset items
+  description: |
+    Returns data stored in the default dataset of the last Actor task run in the desired format.
+
+    This endpoint is a shortcut that resolves the last task run's `defaultDatasetId` and proxies to the
+    [Get dataset items](/api/v2/dataset-items-get) endpoint.
+  operationId: actorTask_runs_last_dataset_items_get
+  parameters:
+    - $ref: "../../parameters/runAndBuildParameters.yaml#/actorTaskId"
+    - $ref: "../../parameters/runAndBuildParameters.yaml#/statusLastRun"
+    - $ref: "../../parameters/datasetParameters.yaml#/format"
+    - $ref: "../../parameters/datasetParameters.yaml#/clean"
+    - $ref: "../../parameters/paginationParameters.yaml#/offset"
+    - $ref: "../../parameters/datasetParameters.yaml#/limit"
+    - $ref: "../../parameters/datasetParameters.yaml#/fields"
+    - $ref: "../../parameters/datasetParameters.yaml#/omit"
+    - $ref: "../../parameters/datasetParameters.yaml#/unwind"
+    - $ref: "../../parameters/datasetParameters.yaml#/flatten"
+    - $ref: "../../parameters/datasetParameters.yaml#/descDataset"
+    - $ref: "../../parameters/datasetParameters.yaml#/attachment"
+    - $ref: "../../parameters/datasetParameters.yaml#/delimiter"
+    - $ref: "../../parameters/datasetParameters.yaml#/bom"
+    - $ref: "../../parameters/datasetParameters.yaml#/xmlRoot"
+    - $ref: "../../parameters/datasetParameters.yaml#/xmlRow"
+    - $ref: "../../parameters/datasetParameters.yaml#/skipHeaderRow"
+    - $ref: "../../parameters/datasetParameters.yaml#/skipHidden"
+    - $ref: "../../parameters/datasetParameters.yaml#/skipEmpty"
+    - $ref: "../../parameters/datasetParameters.yaml#/simplified"
+    - $ref: "../../parameters/datasetParameters.yaml#/view"
+    - $ref: "../../parameters/datasetParameters.yaml#/skipFailedPages"
+    - $ref: "../../parameters/storageParameters.yaml#/signature"
+
 headById:
   <<: [*parametersGetHeadById, *sharedTagById]
   responses:
@@ -428,4 +466,18 @@ postLastRun:
   operationId: act_runs_last_dataset_items_post
   parameters:
     - $ref: "../../parameters/runAndBuildParameters.yaml#/actorId"
+    - $ref: "../../parameters/runAndBuildParameters.yaml#/statusLastRun"
+
+postTaskLastRun:
+  <<: [*sharedPost, *sharedTagTaskLastRun]
+  summary: Store items in last task run's dataset
+  description: |
+    Appends an item or an array of items to the end of the last Actor task run's default dataset.
+
+    This endpoint is a shortcut that resolves the last task run's `defaultDatasetId` and proxies to the
+    [Store items](/api/v2/dataset-items-post) endpoint.
+
+  operationId: actorTask_runs_last_dataset_items_post
+  parameters:
+    - $ref: "../../parameters/runAndBuildParameters.yaml#/actorTaskId"
     - $ref: "../../parameters/runAndBuildParameters.yaml#/statusLastRun"

--- a/apify-api/openapi/components/objects/datasets/dataset-statistics.yaml
+++ b/apify-api/openapi/components/objects/datasets/dataset-statistics.yaml
@@ -61,3 +61,18 @@ getLastRun:
   parameters:
     - $ref: "../../parameters/runAndBuildParameters.yaml#/actorId"
     - $ref: "../../parameters/runAndBuildParameters.yaml#/statusLastRun"
+
+getTaskLastRun:
+  <<: *sharedGet
+  tags:
+    - Last Actor task run's default dataset
+  summary: Get last task run's dataset statistics
+  description: |
+    Returns statistics for the last Actor task run's default dataset.
+
+    This endpoint is a shortcut that resolves the last task run's `defaultDatasetId` and proxies to the
+    [Get dataset statistics](/api/v2/dataset-statistics-get) endpoint.
+  operationId: actorTask_runs_last_dataset_statistics_get
+  parameters:
+    - $ref: "../../parameters/runAndBuildParameters.yaml#/actorTaskId"
+    - $ref: "../../parameters/runAndBuildParameters.yaml#/statusLastRun"

--- a/apify-api/openapi/components/objects/datasets/dataset.yaml
+++ b/apify-api/openapi/components/objects/datasets/dataset.yaml
@@ -40,6 +40,13 @@ sharedLastRun: &sharedLastRun
     - $ref: "../../parameters/runAndBuildParameters.yaml#/actorId"
     - $ref: "../../parameters/runAndBuildParameters.yaml#/statusLastRun"
 
+sharedTaskLastRun: &sharedTaskLastRun
+  tags:
+    - Last Actor task run's default dataset
+  parameters:
+    - $ref: "../../parameters/runAndBuildParameters.yaml#/actorTaskId"
+    - $ref: "../../parameters/runAndBuildParameters.yaml#/statusLastRun"
+
 sharedGet: &sharedGet
   responses:
     <<: [*common200, *commonErrors]
@@ -93,6 +100,16 @@ getLastRun:
     This endpoint is a shortcut for getting the last run's `defaultDatasetId` and then using the
     [Get dataset](/api/v2/dataset-get) endpoint.
   operationId: act_runs_last_dataset_get
+
+getTaskLastRun:
+  <<: [*sharedGet, *sharedTaskLastRun]
+  summary: Get last task run's default dataset
+  description: |
+    Returns the default dataset associated with the last Actor task run.
+
+    This endpoint is a shortcut for getting the last task run's `defaultDatasetId` and then using the
+    [Get dataset](/api/v2/dataset-get) endpoint.
+  operationId: actorTask_runs_last_dataset_get
 
 sharedPut: &sharedPut
   requestBody:
@@ -150,6 +167,16 @@ putLastRun:
     [Update dataset](/api/v2/dataset-put) endpoint.
   operationId: act_runs_last_dataset_put
 
+putTaskLastRun:
+  <<: [*sharedPut, *sharedTaskLastRun]
+  summary: Update last task run's default dataset
+  description: |
+    Updates the default dataset associated with the last Actor task run.
+
+    This endpoint is a shortcut for getting the last task run's `defaultDatasetId` and then using the
+    [Update dataset](/api/v2/dataset-put) endpoint.
+  operationId: actorTask_runs_last_dataset_put
+
 sharedDelete: &sharedDelete
   responses:
     <<: *commonErrors
@@ -189,3 +216,13 @@ deleteLastRun:
     This endpoint is a shortcut for getting the last run's `defaultDatasetId` and then using the
     [Delete dataset](/api/v2/dataset-delete) endpoint.
   operationId: act_runs_last_dataset_delete
+
+deleteTaskLastRun:
+  <<: [*sharedDelete, *sharedTaskLastRun]
+  summary: Delete last task run's default dataset
+  description: |
+    Deletes the default dataset associated with the last Actor task run.
+
+    This endpoint is a shortcut for getting the last task run's `defaultDatasetId` and then using the
+    [Delete dataset](/api/v2/dataset-delete) endpoint.
+  operationId: actorTask_runs_last_dataset_delete

--- a/apify-api/openapi/components/objects/key-value-stores/key-value-store-keys.yaml
+++ b/apify-api/openapi/components/objects/key-value-stores/key-value-store-keys.yaml
@@ -24,6 +24,10 @@ sharedTagLastRun: &sharedTagLastRun
   tags:
     - Last Actor run's default key-value store
 
+sharedTagTaskLastRun: &sharedTagTaskLastRun
+  tags:
+    - Last Actor task run's default key-value store
+
 sharedGet: &sharedGet
   responses:
     <<: *commonErrors
@@ -92,6 +96,24 @@ getLastRun:
   operationId: act_runs_last_keyValueStore_keys_get
   parameters:
     - $ref: "../../parameters/runAndBuildParameters.yaml#/actorId"
+    - $ref: "../../parameters/runAndBuildParameters.yaml#/statusLastRun"
+    - $ref: "../../parameters/keyValueStoreParameters.yaml#/exclusiveStartKey"
+    - $ref: "../../parameters/keyValueStoreParameters.yaml#/limit"
+    - $ref: "../../parameters/keyValueStoreParameters.yaml#/collectionKeys"
+    - $ref: "../../parameters/keyValueStoreParameters.yaml#/prefixKeys"
+    - $ref: "../../parameters/storageParameters.yaml#/signature"
+
+getTaskLastRun:
+  <<: [*sharedGet, *sharedTagTaskLastRun]
+  summary: Get last task run's default store's list of keys
+  description: |
+    Returns a list of keys for the default key-value store of the last Actor task run.
+
+    This endpoint is a shortcut for getting the last task run's `defaultKeyValueStoreId` and then using the
+    [Get list of keys](/api/v2/key-value-store-keys-get) endpoint.
+  operationId: actorTask_runs_last_keyValueStore_keys_get
+  parameters:
+    - $ref: "../../parameters/runAndBuildParameters.yaml#/actorTaskId"
     - $ref: "../../parameters/runAndBuildParameters.yaml#/statusLastRun"
     - $ref: "../../parameters/keyValueStoreParameters.yaml#/exclusiveStartKey"
     - $ref: "../../parameters/keyValueStoreParameters.yaml#/limit"

--- a/apify-api/openapi/components/objects/key-value-stores/key-value-store-record.yaml
+++ b/apify-api/openapi/components/objects/key-value-stores/key-value-store-record.yaml
@@ -24,6 +24,10 @@ sharedTagLastRun: &sharedTagLastRun
   tags:
     - Last Actor run's default key-value store
 
+sharedTagTaskLastRun: &sharedTagTaskLastRun
+  tags:
+    - Last Actor task run's default key-value store
+
 sharedGet: &sharedGet
   responses:
     <<: *commonErrors
@@ -156,6 +160,22 @@ getLastRun:
     - $ref: "../../parameters/storageParameters.yaml#/signature"
     - $ref: "../../parameters/keyValueStoreParameters.yaml#/attachment"
 
+getTaskLastRun:
+  <<: [*sharedGet, *sharedTagTaskLastRun]
+  summary: Get last task run's default store's record
+  description: |
+    Gets a value stored under a specific key in the default key-value store of the last Actor task run.
+
+    This endpoint is a shortcut for getting the last task run's `defaultKeyValueStoreId` and then using the
+    [Get record](/api/v2/key-value-store-record-get) endpoint.
+  operationId: actorTask_runs_last_keyValueStore_record_get
+  parameters:
+    - $ref: "../../parameters/runAndBuildParameters.yaml#/actorTaskId"
+    - $ref: "../../parameters/runAndBuildParameters.yaml#/statusLastRun"
+    - $ref: "../../parameters/keyValueStoreParameters.yaml#/recordKey"
+    - $ref: "../../parameters/storageParameters.yaml#/signature"
+    - $ref: "../../parameters/keyValueStoreParameters.yaml#/attachment"
+
 headById:
   <<: *sharedTagById
   summary: Check if a record exists
@@ -244,11 +264,27 @@ putLastRun:
     - $ref: "../../parameters/keyValueStoreParameters.yaml#/recordKey"
     - $ref: "../../parameters/keyValueStoreParameters.yaml#/Content-Encoding"
 
+putTaskLastRun:
+  <<: [*sharedPutPost, *sharedTagTaskLastRun]
+  summary: Store record in last task run's default store
+  description: |
+    Stores a value under a specific key in the default key-value store of the last Actor task run.
+
+    This endpoint is a shortcut for getting the last task run's `defaultKeyValueStoreId` and then using the
+    [Store record](/api/v2/key-value-store-record-put) endpoint.
+  operationId: actorTask_runs_last_keyValueStore_record_put
+  parameters:
+    - $ref: "../../parameters/runAndBuildParameters.yaml#/actorTaskId"
+    - $ref: "../../parameters/runAndBuildParameters.yaml#/statusLastRun"
+    - $ref: "../../parameters/keyValueStoreParameters.yaml#/recordKey"
+    - $ref: "../../parameters/keyValueStoreParameters.yaml#/Content-Encoding"
+
 postById:
   <<: [*sharedPutPost, *sharedTagById]
   summary: Store record (POST)
   description: |
     Stores a value under a specific key to the key-value store.
+
     This endpoint is an alias for the [`PUT` record](#tag/Key-value-storesRecord/operation/keyValueStore_record_put) method and behaves identically.
   operationId: keyValueStore_record_post
   parameters:
@@ -265,7 +301,6 @@ postDefault:
   summary: Store record in default store (POST)
   description: |
     Stores a value under a specific key in the default key-value store of the Actor run.
-    This endpoint is an alias for the [`PUT` record](/api/v2/key-value-store-record-put) method and behaves identically.
 
     This endpoint is a shortcut for getting the run's `defaultKeyValueStoreId` and then using the
     [Store record](/api/v2/key-value-store-record-post) endpoint.
@@ -280,13 +315,27 @@ postLastRun:
   summary: Store record in last run's default store (POST)
   description: |
     Stores a value under a specific key in the default key-value store of the last Actor run.
-    This endpoint is an alias for the [`PUT` record](/api/v2/act-runs-last-key-value-store-record-put) method and behaves identically.
 
     This endpoint is a shortcut for getting the last run's `defaultKeyValueStoreId` and then using the
     [Store record](/api/v2/key-value-store-record-post) endpoint.
   operationId: act_runs_last_keyValueStore_record_post
   parameters:
     - $ref: "../../parameters/runAndBuildParameters.yaml#/actorId"
+    - $ref: "../../parameters/runAndBuildParameters.yaml#/statusLastRun"
+    - $ref: "../../parameters/keyValueStoreParameters.yaml#/recordKey"
+    - $ref: "../../parameters/keyValueStoreParameters.yaml#/Content-Encoding"
+
+postTaskLastRun:
+  <<: [*sharedPutPost, *sharedTagTaskLastRun]
+  summary: Store record in last task run's default store (POST)
+  description: |
+    Stores a value under a specific key in the default key-value store of the last Actor task run.
+
+    This endpoint is a shortcut for getting the last task run's `defaultKeyValueStoreId` and then using the
+    [Store record](/api/v2/key-value-store-record-post) endpoint.
+  operationId: actorTask_runs_last_keyValueStore_record_post
+  parameters:
+    - $ref: "../../parameters/runAndBuildParameters.yaml#/actorTaskId"
     - $ref: "../../parameters/runAndBuildParameters.yaml#/statusLastRun"
     - $ref: "../../parameters/keyValueStoreParameters.yaml#/recordKey"
     - $ref: "../../parameters/keyValueStoreParameters.yaml#/Content-Encoding"
@@ -334,5 +383,19 @@ deleteLastRun:
   operationId: act_runs_last_keyValueStore_record_delete
   parameters:
     - $ref: "../../parameters/runAndBuildParameters.yaml#/actorId"
+    - $ref: "../../parameters/runAndBuildParameters.yaml#/statusLastRun"
+    - $ref: "../../parameters/keyValueStoreParameters.yaml#/recordKey"
+
+deleteTaskLastRun:
+  <<: [*sharedDelete, *sharedTagTaskLastRun]
+  summary: Delete last task run's default store's record
+  description: |
+    Removes a record specified by a key from the default key-value store of the last Actor task run.
+
+    This endpoint is a shortcut for getting the last task run's `defaultKeyValueStoreId` and then using the
+    [Delete record](/api/v2/key-value-store-record-delete) endpoint.
+  operationId: actorTask_runs_last_keyValueStore_record_delete
+  parameters:
+    - $ref: "../../parameters/runAndBuildParameters.yaml#/actorTaskId"
     - $ref: "../../parameters/runAndBuildParameters.yaml#/statusLastRun"
     - $ref: "../../parameters/keyValueStoreParameters.yaml#/recordKey"

--- a/apify-api/openapi/components/objects/key-value-stores/key-value-store-records.yaml
+++ b/apify-api/openapi/components/objects/key-value-stores/key-value-store-records.yaml
@@ -24,6 +24,10 @@ sharedTagLastRun: &sharedTagLastRun
   tags:
     - Last Actor run's default key-value store
 
+sharedTagTaskLastRun: &sharedTagTaskLastRun
+  tags:
+    - Last Actor task run's default key-value store
+
 common200: &common200
   "200":
     description: A ZIP archive containing the requested records.
@@ -80,6 +84,22 @@ getLastRun:
   operationId: act_runs_last_keyValueStore_records_get
   parameters:
     - $ref: "../../parameters/runAndBuildParameters.yaml#/actorId"
+    - $ref: "../../parameters/runAndBuildParameters.yaml#/statusLastRun"
+    - $ref: "../../parameters/keyValueStoreParameters.yaml#/collectionRecords"
+    - $ref: "../../parameters/keyValueStoreParameters.yaml#/prefixRecords"
+    - $ref: "../../parameters/storageParameters.yaml#/signature"
+
+getTaskLastRun:
+  <<: [*sharedGet, *sharedTagTaskLastRun]
+  summary: Download last task run's default store's records
+  description: |
+    Downloads all records from the default key-value store of the last Actor task run as a ZIP archive.
+
+    This endpoint is a shortcut for getting the last task run's `defaultKeyValueStoreId` and then using the
+    [Download records](/api/v2/key-value-store-records-get) endpoint.
+  operationId: actorTask_runs_last_keyValueStore_records_get
+  parameters:
+    - $ref: "../../parameters/runAndBuildParameters.yaml#/actorTaskId"
     - $ref: "../../parameters/runAndBuildParameters.yaml#/statusLastRun"
     - $ref: "../../parameters/keyValueStoreParameters.yaml#/collectionRecords"
     - $ref: "../../parameters/keyValueStoreParameters.yaml#/prefixRecords"
@@ -239,5 +259,33 @@ postLastRun:
   operationId: keyValueStore_record_post
   parameters:
     - $ref: "../../parameters/runAndBuildParameters.yaml#/actorId"
+    - $ref: "../../parameters/keyValueStoreParameters.yaml#/recordKey"
+    - $ref: "../../parameters/keyValueStoreParameters.yaml#/Content-Encoding"
+
+putTaskLastRun:
+  <<: [*sharedPutPost, *sharedTagTaskLastRun]
+  summary: Store record in last task run's default store
+  description: |
+    Stores a value under a specific key to the default key-value store of the last Actor task run.
+
+    This endpoint is a shortcut for getting the last task run's `defaultKeyValueStoreId` and then using the
+    [PUT record](/api/v2/key-value-store-record-put) endpoint.
+  operationId: actorTask_runs_last_keyValueStore_records_put
+  parameters:
+    - $ref: "../../parameters/runAndBuildParameters.yaml#/actorTaskId"
+    - $ref: "../../parameters/keyValueStoreParameters.yaml#/recordKey"
+    - $ref: "../../parameters/keyValueStoreParameters.yaml#/Content-Encoding"
+
+postTaskLastRun:
+  <<: [*sharedPutPost, *sharedTagTaskLastRun]
+  summary: Store record in last task run's default store (POST)
+  description: |
+    Stores a value under a specific key to the default key-value store of the last Actor task run.
+
+    This endpoint is a shortcut for getting the last task run's `defaultKeyValueStoreId` and then using the
+    [POST record](/api/v2/key-value-store-record-post) endpoint.
+  operationId: actorTask_runs_last_keyValueStore_records_post
+  parameters:
+    - $ref: "../../parameters/runAndBuildParameters.yaml#/actorTaskId"
     - $ref: "../../parameters/keyValueStoreParameters.yaml#/recordKey"
     - $ref: "../../parameters/keyValueStoreParameters.yaml#/Content-Encoding"

--- a/apify-api/openapi/components/objects/key-value-stores/key-value-store.yaml
+++ b/apify-api/openapi/components/objects/key-value-stores/key-value-store.yaml
@@ -40,6 +40,13 @@ sharedLastRun: &sharedLastRun
     - $ref: "../../parameters/runAndBuildParameters.yaml#/actorId"
     - $ref: "../../parameters/runAndBuildParameters.yaml#/statusLastRun"
 
+sharedTaskLastRun: &sharedTaskLastRun
+  tags:
+    - Last Actor task run's default key-value store
+  parameters:
+    - $ref: "../../parameters/runAndBuildParameters.yaml#/actorTaskId"
+    - $ref: "../../parameters/runAndBuildParameters.yaml#/statusLastRun"
+
 sharedGet: &sharedGet
   responses:
     <<: [*common200, *commonErrors]
@@ -85,6 +92,16 @@ getLastRun:
     [Get store](/api/v2/key-value-store-get) endpoint.
 
   operationId: act_runs_last_keyValueStore_get
+
+getTaskLastRun:
+  <<: [*sharedGet, *sharedTaskLastRun]
+  summary: Get last task run's default store
+  description: |
+    Gets an object that contains all the details about the default key-value store of the last Actor task run.
+
+    This endpoint is a shortcut for getting the last task run's `defaultKeyValueStoreId` and then using the
+    [Get store](/api/v2/key-value-store-get) endpoint.
+  operationId: actorTask_runs_last_keyValueStore_get
 
 sharedPut: &sharedPut
   requestBody:
@@ -149,6 +166,16 @@ putLastRun:
 
   operationId: act_runs_last_keyValueStore_put
 
+putTaskLastRun:
+  <<: [*sharedPut, *sharedTaskLastRun]
+  summary: Update last task run's default store
+  description: |
+    Updates the default key-value store associated with the last Actor task run.
+
+    This endpoint is a shortcut for getting the last task run's `defaultKeyValueStoreId` and then using the
+    [Update store](/api/v2/key-value-store-put) endpoint.
+  operationId: actorTask_runs_last_keyValueStore_put
+
 sharedDelete: &sharedDelete
   responses:
     <<: *commonErrors
@@ -190,3 +217,13 @@ deleteLastRun:
     [Delete store](/api/v2/key-value-store-delete) endpoint.
 
   operationId: act_runs_last_keyValueStore_delete
+
+deleteTaskLastRun:
+  <<: [*sharedDelete, *sharedTaskLastRun]
+  summary: Delete last task run's default store
+  description: |
+    Deletes the default key-value store of the last Actor task run.
+
+    This endpoint is a shortcut for getting the last task run's `defaultKeyValueStoreId` and then using the
+    [Delete store](/api/v2/key-value-store-delete) endpoint.
+  operationId: actorTask_runs_last_keyValueStore_delete

--- a/apify-api/openapi/components/objects/request-queues/request-queue-head-lock.yaml
+++ b/apify-api/openapi/components/objects/request-queues/request-queue-head-lock.yaml
@@ -12,18 +12,6 @@ commonErrors: &commonErrors
   "429":
     $ref: ../../responses/TooManyRequests.yaml
 
-sharedTagById: &sharedTagById
-  tags:
-    - Storage/Request queues/Requests locks
-
-sharedTagDefault: &sharedTagDefault
-  tags:
-    - Default request queue
-
-sharedTagLastRun: &sharedTagLastRun
-  tags:
-    - Last Actor run's default request queue
-
 sharedPost: &sharedPost
   responses:
     "201":
@@ -37,7 +25,9 @@ sharedPost: &sharedPost
   deprecated: false
 
 postById:
-  <<: [*sharedPost, *sharedTagById]
+  <<: *sharedPost
+  tags:
+    - Storage/Request queues/Requests locks
   summary: Get head and lock
   description: |
     Returns the given number of first requests from the queue and locks them for
@@ -67,7 +57,9 @@ postById:
   x-py-doc-url: https://docs.apify.com/api/client/python/reference/class/RequestQueueClientAsync#list_and_lock_head
 
 postDefault:
-  <<: [*sharedPost, *sharedTagDefault]
+  <<: *sharedPost
+  tags:
+    - Default request queue
   summary: Get and lock default request queue head
   description: |
     Returns the given number of first requests from the default request queue of the Actor run
@@ -83,7 +75,9 @@ postDefault:
     - $ref: "../../parameters/requestQueueParameters.yaml#/clientKey"
 
 postLastRun:
-  <<: [*sharedPost, *sharedTagLastRun]
+  <<: *sharedPost
+  tags:
+    - Last Actor run's default request queue
   summary: Get and lock last run's default request queue head
   description: |
     Returns the given number of first requests from the default request queue of the last Actor run
@@ -94,6 +88,25 @@ postLastRun:
   operationId: act_runs_last_requestQueue_head_lock_post
   parameters:
     - $ref: "../../parameters/runAndBuildParameters.yaml#/actorId"
+    - $ref: "../../parameters/runAndBuildParameters.yaml#/statusLastRun"
+    - $ref: "../../parameters/requestQueueParameters.yaml#/lockSecs"
+    - $ref: "../../parameters/requestQueueParameters.yaml#/headLockLimit"
+    - $ref: "../../parameters/requestQueueParameters.yaml#/clientKey"
+
+postTaskLastRun:
+  <<: *sharedPost
+  tags:
+    - Last Actor task run's default request queue
+  summary: Get and lock last task run's default request queue head
+  description: |
+    Returns the given number of first requests from the default request queue of the last Actor task run
+    and locks them for the given time.
+
+    This endpoint is a shortcut for getting the last task run's `defaultRequestQueueId` and then using the
+    [Get head and lock](/api/v2/request-queue-head-lock-post) endpoint.
+  operationId: actorTask_runs_last_requestQueue_head_lock_post
+  parameters:
+    - $ref: "../../parameters/runAndBuildParameters.yaml#/actorTaskId"
     - $ref: "../../parameters/runAndBuildParameters.yaml#/statusLastRun"
     - $ref: "../../parameters/requestQueueParameters.yaml#/lockSecs"
     - $ref: "../../parameters/requestQueueParameters.yaml#/headLockLimit"

--- a/apify-api/openapi/components/objects/request-queues/request-queue-head.yaml
+++ b/apify-api/openapi/components/objects/request-queues/request-queue-head.yaml
@@ -24,6 +24,10 @@ sharedTagLastRun: &sharedTagLastRun
   tags:
     - Last Actor run's default request queue
 
+sharedTagTaskLastRun: &sharedTagTaskLastRun
+  tags:
+    - Last Actor task run's default request queue
+
 sharedGet: &sharedGet
   responses:
     "200":
@@ -89,6 +93,21 @@ getLastRun:
   operationId: act_runs_last_requestQueue_head_get
   parameters:
     - $ref: "../../parameters/runAndBuildParameters.yaml#/actorId"
+    - $ref: "../../parameters/runAndBuildParameters.yaml#/statusLastRun"
+    - $ref: "../../parameters/requestQueueParameters.yaml#/headLimit"
+    - $ref: "../../parameters/requestQueueParameters.yaml#/clientKey"
+
+getTaskLastRun:
+  <<: [*sharedGet, *sharedTagTaskLastRun]
+  summary: Get last task run's default request queue head
+  description: |
+    Returns the given number of first requests from the default request queue of the last Actor task run.
+
+    This endpoint is a shortcut for getting the last task run's `defaultRequestQueueId` and then using the
+    [Get head](/api/v2/request-queue-head-get) endpoint.
+  operationId: actorTask_runs_last_requestQueue_head_get
+  parameters:
+    - $ref: "../../parameters/runAndBuildParameters.yaml#/actorTaskId"
     - $ref: "../../parameters/runAndBuildParameters.yaml#/statusLastRun"
     - $ref: "../../parameters/requestQueueParameters.yaml#/headLimit"
     - $ref: "../../parameters/requestQueueParameters.yaml#/clientKey"

--- a/apify-api/openapi/components/objects/request-queues/request-queue-request-lock.yaml
+++ b/apify-api/openapi/components/objects/request-queues/request-queue-request-lock.yaml
@@ -24,6 +24,10 @@ sharedTagLastRun: &sharedTagLastRun
   tags:
     - Last Actor run's default request queue
 
+sharedTagTaskLastRun: &sharedTagTaskLastRun
+  tags:
+    - Last Actor task run's default request queue
+
 sharedPut: &sharedPut
   responses:
     "200":
@@ -97,6 +101,23 @@ putLastRun:
     - $ref: "../../parameters/requestQueueParameters.yaml#/clientKey"
     - $ref: "../../parameters/requestQueueParameters.yaml#/lockForefront"
 
+putTaskLastRun:
+  <<: [*sharedPut, *sharedTagTaskLastRun]
+  summary: Prolong lock on request in last task run's default request queue
+  description: |
+    Prolongs a request lock in the default request queue of the last Actor task run.
+
+    This endpoint is a shortcut for getting the last task run's `defaultRequestQueueId` and then using the
+    [Prolong request lock](/api/v2/request-queue-request-lock-put) endpoint.
+  operationId: actorTask_runs_last_requestQueue_request_lock_put
+  parameters:
+    - $ref: "../../parameters/runAndBuildParameters.yaml#/actorTaskId"
+    - $ref: "../../parameters/runAndBuildParameters.yaml#/statusLastRun"
+    - $ref: "../../parameters/requestQueueParameters.yaml#/requestId"
+    - $ref: "../../parameters/requestQueueParameters.yaml#/lockSecs"
+    - $ref: "../../parameters/requestQueueParameters.yaml#/clientKey"
+    - $ref: "../../parameters/requestQueueParameters.yaml#/lockForefront"
+
 sharedDelete: &sharedDelete
   responses:
     <<: *commonErrors
@@ -157,6 +178,22 @@ deleteLastRun:
   operationId: act_runs_last_requestQueue_request_lock_delete
   parameters:
     - $ref: "../../parameters/runAndBuildParameters.yaml#/actorId"
+    - $ref: "../../parameters/runAndBuildParameters.yaml#/statusLastRun"
+    - $ref: "../../parameters/requestQueueParameters.yaml#/requestId"
+    - $ref: "../../parameters/requestQueueParameters.yaml#/clientKey"
+    - $ref: "../../parameters/requestQueueParameters.yaml#/deleteForefront"
+
+deleteTaskLastRun:
+  <<: [*sharedDelete, *sharedTagTaskLastRun]
+  summary: Delete lock on request in last task run's default request queue
+  description: |
+    Deletes a request lock in the default request queue of the last Actor task run.
+
+    This endpoint is a shortcut for getting the last task run's `defaultRequestQueueId` and then using the
+    [Delete request lock](/api/v2/request-queue-request-lock-delete) endpoint.
+  operationId: actorTask_runs_last_requestQueue_request_lock_delete
+  parameters:
+    - $ref: "../../parameters/runAndBuildParameters.yaml#/actorTaskId"
     - $ref: "../../parameters/runAndBuildParameters.yaml#/statusLastRun"
     - $ref: "../../parameters/requestQueueParameters.yaml#/requestId"
     - $ref: "../../parameters/requestQueueParameters.yaml#/clientKey"

--- a/apify-api/openapi/components/objects/request-queues/request-queue-request.yaml
+++ b/apify-api/openapi/components/objects/request-queues/request-queue-request.yaml
@@ -24,6 +24,10 @@ sharedTagLastRun: &sharedTagLastRun
   tags:
     - Last Actor run's default request queue
 
+sharedTagTaskLastRun: &sharedTagTaskLastRun
+  tags:
+    - Last Actor task run's default request queue
+
 sharedGet: &sharedGet
   responses:
     "200":
@@ -79,6 +83,20 @@ getLastRun:
   operationId: act_runs_last_requestQueue_request_get
   parameters:
     - $ref: "../../parameters/runAndBuildParameters.yaml#/actorId"
+    - $ref: "../../parameters/runAndBuildParameters.yaml#/statusLastRun"
+    - $ref: "../../parameters/requestQueueParameters.yaml#/requestId"
+
+getTaskLastRun:
+  <<: [*sharedGet, *sharedTagTaskLastRun]
+  summary: Get request from last task run's default request queue
+  description: |
+    Returns a request from the default request queue of the last Actor task run.
+
+    This endpoint is a shortcut for getting the last task run's `defaultRequestQueueId` and then using the
+    [Get request](/api/v2/request-queue-request-get) endpoint.
+  operationId: actorTask_runs_last_requestQueue_request_get
+  parameters:
+    - $ref: "../../parameters/runAndBuildParameters.yaml#/actorTaskId"
     - $ref: "../../parameters/runAndBuildParameters.yaml#/statusLastRun"
     - $ref: "../../parameters/requestQueueParameters.yaml#/requestId"
 
@@ -160,6 +178,22 @@ putLastRun:
     - $ref: "../../parameters/requestQueueParameters.yaml#/forefront"
     - $ref: "../../parameters/requestQueueParameters.yaml#/clientKey"
 
+putTaskLastRun:
+  <<: [*sharedPut, *sharedTagTaskLastRun]
+  summary: Update request in last task run's default request queue
+  description: |
+    Updates a request in the default request queue of the last Actor task run.
+
+    This endpoint is a shortcut for getting the last task run's `defaultRequestQueueId` and then using the
+    [Update request](/api/v2/request-queue-request-put) endpoint.
+  operationId: actorTask_runs_last_requestQueue_request_put
+  parameters:
+    - $ref: "../../parameters/runAndBuildParameters.yaml#/actorTaskId"
+    - $ref: "../../parameters/runAndBuildParameters.yaml#/statusLastRun"
+    - $ref: "../../parameters/requestQueueParameters.yaml#/requestId"
+    - $ref: "../../parameters/requestQueueParameters.yaml#/forefront"
+    - $ref: "../../parameters/requestQueueParameters.yaml#/clientKey"
+
 sharedDelete: &sharedDelete
   responses:
     <<: *commonErrors
@@ -209,6 +243,21 @@ deleteLastRun:
   operationId: act_runs_last_requestQueue_request_delete
   parameters:
     - $ref: "../../parameters/runAndBuildParameters.yaml#/actorId"
+    - $ref: "../../parameters/runAndBuildParameters.yaml#/statusLastRun"
+    - $ref: "../../parameters/requestQueueParameters.yaml#/requestId"
+    - $ref: "../../parameters/requestQueueParameters.yaml#/clientKey"
+
+deleteTaskLastRun:
+  <<: [*sharedDelete, *sharedTagTaskLastRun]
+  summary: Delete request from last task run's default request queue
+  description: |
+    Deletes a request from the default request queue of the last Actor task run.
+
+    This endpoint is a shortcut for getting the last task run's `defaultRequestQueueId` and then using the
+    [Delete request](/api/v2/request-queue-request-delete) endpoint.
+  operationId: actorTask_runs_last_requestQueue_request_delete
+  parameters:
+    - $ref: "../../parameters/runAndBuildParameters.yaml#/actorTaskId"
     - $ref: "../../parameters/runAndBuildParameters.yaml#/statusLastRun"
     - $ref: "../../parameters/requestQueueParameters.yaml#/requestId"
     - $ref: "../../parameters/requestQueueParameters.yaml#/clientKey"

--- a/apify-api/openapi/components/objects/request-queues/request-queue-requests-batch.yaml
+++ b/apify-api/openapi/components/objects/request-queues/request-queue-requests-batch.yaml
@@ -24,6 +24,10 @@ sharedTagLastRun: &sharedTagLastRun
   tags:
     - Last Actor run's default request queue
 
+sharedTagTaskLastRun: &sharedTagTaskLastRun
+  tags:
+    - Last Actor task run's default request queue
+
 sharedPost: &sharedPost
   requestBody:
     description: ""
@@ -109,6 +113,21 @@ postLastRun:
     - $ref: "../../parameters/requestQueueParameters.yaml#/clientKey"
     - $ref: "../../parameters/requestQueueParameters.yaml#/forefront"
 
+postTaskLastRun:
+  <<: [*sharedPost, *sharedTagTaskLastRun]
+  summary: Batch add requests to last task run's default request queue
+  description: |
+    Adds requests to the default request queue of the last Actor task run in batch.
+
+    This endpoint is a shortcut for getting the last task run's `defaultRequestQueueId` and then using the
+    [Add requests](/api/v2/request-queue-requests-batch-post) endpoint.
+  operationId: actorTask_runs_last_requestQueue_requests_batch_post
+  parameters:
+    - $ref: "../../parameters/runAndBuildParameters.yaml#/actorTaskId"
+    - $ref: "../../parameters/runAndBuildParameters.yaml#/statusLastRun"
+    - $ref: "../../parameters/requestQueueParameters.yaml#/clientKey"
+    - $ref: "../../parameters/requestQueueParameters.yaml#/forefront"
+
 sharedDelete: &sharedDelete
   requestBody:
     description: ""
@@ -190,6 +209,21 @@ deleteLastRun:
   operationId: act_runs_last_requestQueue_requests_batch_delete
   parameters:
     - $ref: "../../parameters/runAndBuildParameters.yaml#/actorId"
+    - $ref: "../../parameters/runAndBuildParameters.yaml#/statusLastRun"
+    - $ref: "../../parameters/requestQueueParameters.yaml#/contentTypeJson"
+    - $ref: "../../parameters/requestQueueParameters.yaml#/clientKey"
+
+deleteTaskLastRun:
+  <<: [*sharedDelete, *sharedTagTaskLastRun]
+  summary: Batch delete requests from last task run's default request queue
+  description: |
+    Batch-deletes requests from the default request queue of the last Actor task run.
+
+    This endpoint is a shortcut for getting the last task run's `defaultRequestQueueId` and then using the
+    [Delete requests](/api/v2/request-queue-requests-batch-delete) endpoint.
+  operationId: actorTask_runs_last_requestQueue_requests_batch_delete
+  parameters:
+    - $ref: "../../parameters/runAndBuildParameters.yaml#/actorTaskId"
     - $ref: "../../parameters/runAndBuildParameters.yaml#/statusLastRun"
     - $ref: "../../parameters/requestQueueParameters.yaml#/contentTypeJson"
     - $ref: "../../parameters/requestQueueParameters.yaml#/clientKey"

--- a/apify-api/openapi/components/objects/request-queues/request-queue-requests-unlock.yaml
+++ b/apify-api/openapi/components/objects/request-queues/request-queue-requests-unlock.yaml
@@ -24,6 +24,10 @@ sharedTagLastRun: &sharedTagLastRun
   tags:
     - Last Actor run's default request queue
 
+sharedTagTaskLastRun: &sharedTagTaskLastRun
+  tags:
+    - Last Actor task run's default request queue
+
 sharedPost: &sharedPost
   responses:
     "200":
@@ -78,5 +82,19 @@ postLastRun:
   operationId: act_runs_last_requestQueue_requests_unlock_post
   parameters:
     - $ref: "../../parameters/runAndBuildParameters.yaml#/actorId"
+    - $ref: "../../parameters/runAndBuildParameters.yaml#/statusLastRun"
+    - $ref: "../../parameters/requestQueueParameters.yaml#/clientKey"
+
+postTaskLastRun:
+  <<: [*sharedPost, *sharedTagTaskLastRun]
+  summary: Unlock requests in last task run's default request queue
+  description: |
+    Unlocks requests in the default request queue of the last Actor task run that are currently locked by the client.
+
+    This endpoint is a shortcut for getting the last task run's `defaultRequestQueueId` and then using the
+    [Unlock requests](/api/v2/request-queue-requests-unlock-post) endpoint.
+  operationId: actorTask_runs_last_requestQueue_requests_unlock_post
+  parameters:
+    - $ref: "../../parameters/runAndBuildParameters.yaml#/actorTaskId"
     - $ref: "../../parameters/runAndBuildParameters.yaml#/statusLastRun"
     - $ref: "../../parameters/requestQueueParameters.yaml#/clientKey"

--- a/apify-api/openapi/components/objects/request-queues/request-queue-requests.yaml
+++ b/apify-api/openapi/components/objects/request-queues/request-queue-requests.yaml
@@ -24,6 +24,10 @@ sharedTagLastRun: &sharedTagLastRun
   tags:
     - Last Actor run's default request queue
 
+sharedTagTaskLastRun: &sharedTagTaskLastRun
+  tags:
+    - Last Actor task run's default request queue
+
 sharedGet: &sharedGet
   responses:
     "200":
@@ -89,6 +93,24 @@ getLastRun:
   operationId: act_runs_last_requestQueue_requests_get
   parameters:
     - $ref: "../../parameters/runAndBuildParameters.yaml#/actorId"
+    - $ref: "../../parameters/runAndBuildParameters.yaml#/statusLastRun"
+    - $ref: "../../parameters/requestQueueParameters.yaml#/clientKey"
+    - $ref: "../../parameters/requestQueueParameters.yaml#/exclusiveStartId"
+    - $ref: "../../parameters/requestQueueParameters.yaml#/listLimit"
+    - $ref: "../../parameters/requestQueueParameters.yaml#/cursor"
+    - $ref: "../../parameters/requestQueueParameters.yaml#/filter"
+
+getTaskLastRun:
+  <<: [*sharedGet, *sharedTagTaskLastRun]
+  summary: List last task run's default request queue's requests
+  description: |
+    Returns a list of requests from the default request queue of the last Actor task run.
+
+    This endpoint is a shortcut for getting the last task run's `defaultRequestQueueId` and then using the
+    [List requests](/api/v2/request-queue-requests-get) endpoint.
+  operationId: actorTask_runs_last_requestQueue_requests_get
+  parameters:
+    - $ref: "../../parameters/runAndBuildParameters.yaml#/actorTaskId"
     - $ref: "../../parameters/runAndBuildParameters.yaml#/statusLastRun"
     - $ref: "../../parameters/requestQueueParameters.yaml#/clientKey"
     - $ref: "../../parameters/requestQueueParameters.yaml#/exclusiveStartId"
@@ -169,6 +191,21 @@ postLastRun:
   operationId: act_runs_last_requestQueue_requests_post
   parameters:
     - $ref: "../../parameters/runAndBuildParameters.yaml#/actorId"
+    - $ref: "../../parameters/runAndBuildParameters.yaml#/statusLastRun"
+    - $ref: "../../parameters/requestQueueParameters.yaml#/clientKey"
+    - $ref: "../../parameters/requestQueueParameters.yaml#/forefront"
+
+postTaskLastRun:
+  <<: [*sharedPost, *sharedTagTaskLastRun]
+  summary: Add request to last task run's default request queue
+  description: |
+    Adds a request to the default request queue of the last Actor task run.
+
+    This endpoint is a shortcut for getting the last task run's `defaultRequestQueueId` and then using the
+    [Add request](/api/v2/request-queue-requests-post) endpoint.
+  operationId: actorTask_runs_last_requestQueue_requests_post
+  parameters:
+    - $ref: "../../parameters/runAndBuildParameters.yaml#/actorTaskId"
     - $ref: "../../parameters/runAndBuildParameters.yaml#/statusLastRun"
     - $ref: "../../parameters/requestQueueParameters.yaml#/clientKey"
     - $ref: "../../parameters/requestQueueParameters.yaml#/forefront"

--- a/apify-api/openapi/components/objects/request-queues/request-queue.yaml
+++ b/apify-api/openapi/components/objects/request-queues/request-queue.yaml
@@ -40,6 +40,13 @@ sharedLastRun: &sharedLastRun
     - $ref: "../../parameters/runAndBuildParameters.yaml#/actorId"
     - $ref: "../../parameters/runAndBuildParameters.yaml#/statusLastRun"
 
+sharedTaskLastRun: &sharedTaskLastRun
+  tags:
+    - Last Actor task run's default request queue
+  parameters:
+    - $ref: "../../parameters/runAndBuildParameters.yaml#/actorTaskId"
+    - $ref: "../../parameters/runAndBuildParameters.yaml#/statusLastRun"
+
 sharedGet: &sharedGet
   responses:
     <<: [*common200, *commonErrors]
@@ -80,6 +87,16 @@ getLastRun:
     This endpoint is a shortcut for getting the last run's `defaultRequestQueueId` and then using the
     [Get request queue](/api/v2/request-queue-get) endpoint.
   operationId: act_runs_last_requestQueue_get
+
+getTaskLastRun:
+  <<: [*sharedGet, *sharedTaskLastRun]
+  summary: Get last task run's default request queue
+  description: |
+    Returns the default request queue associated with the last Actor task run.
+
+    This endpoint is a shortcut for getting the last task run's `defaultRequestQueueId` and then using the
+    [Get request queue](/api/v2/request-queue-get) endpoint.
+  operationId: actorTask_runs_last_requestQueue_get
 
 sharedPut: &sharedPut
   requestBody:
@@ -143,6 +160,16 @@ putLastRun:
     [Update request queue](/api/v2/request-queue-put) endpoint.
   operationId: act_runs_last_requestQueue_put
 
+putTaskLastRun:
+  <<: [*sharedPut, *sharedTaskLastRun]
+  summary: Update last task run's default request queue
+  description: |
+    Updates the default request queue associated with the last Actor task run.
+
+    This endpoint is a shortcut for getting the last task run's `defaultRequestQueueId` and then using the
+    [Update request queue](/api/v2/request-queue-put) endpoint.
+  operationId: actorTask_runs_last_requestQueue_put
+
 sharedDelete: &sharedDelete
   responses:
     <<: *commonErrors
@@ -182,3 +209,13 @@ deleteLastRun:
     This endpoint is a shortcut for getting the last run's `defaultRequestQueueId` and then using the
     [Delete request queue](/api/v2/request-queue-delete) endpoint.
   operationId: act_runs_last_requestQueue_delete
+
+deleteTaskLastRun:
+  <<: [*sharedDelete, *sharedTaskLastRun]
+  summary: Delete last task run's default request queue
+  description: |
+    Deletes the default request queue associated with the last Actor task run.
+
+    This endpoint is a shortcut for getting the last task run's `defaultRequestQueueId` and then using the
+    [Delete request queue](/api/v2/request-queue-delete) endpoint.
+  operationId: actorTask_runs_last_requestQueue_delete

--- a/apify-api/openapi/components/tags.yaml
+++ b/apify-api/openapi/components/tags.yaml
@@ -475,3 +475,21 @@
     The API endpoint described in this section is convenience endpoint that provides access to last Actor task run's log.
 
     Same as of functionality described in: [Logs](/api/v2/logs)
+- name: Last Actor task run's default dataset
+  x-displayName: Last Actor task run's default dataset - Introduction
+  description: |
+    The API endpoints described in this section are convenience endpoints that provide access to Actor task's last run's default dataset without the need to resolve the dataset ID first.
+
+    Subset of functionality described in: [Datasets](/api/v2/storage-datasets)
+- name: Last Actor task run's default key-value store
+  x-displayName: Last Actor task run's default key-value store - Introduction
+  description: |
+    The API endpoints described in this section are convenience endpoints that provide access to Actor task's last run's default key-value store without the need to resolve the key-value store ID first.
+
+    Subset of functionality described in: [Key-value stores](/api/v2/storage-key-value-stores)
+- name: Last Actor task run's default request queue
+  x-displayName: Last Actor task run's default request queue - Introduction
+  description: |
+    The API endpoints described in this section are convenience endpoints that provide access to Actor task's last run's default request queue without the need to resolve the request queue ID first.
+
+    Subset of functionality described in: [Request queues](/api/v2/storage-request-queues)

--- a/apify-api/openapi/components/x-tag-groups.yaml
+++ b/apify-api/openapi/components/x-tag-groups.yaml
@@ -50,4 +50,7 @@
     - Last Actor run's default key-value store
     - Last Actor run's default request queue
     - Last Actor run's log
+    - Last Actor task run's default dataset
+    - Last Actor task run's default key-value store
+    - Last Actor task run's default request queue
     - Last Actor task run's log

--- a/apify-api/openapi/openapi.yaml
+++ b/apify-api/openapi/openapi.yaml
@@ -570,6 +570,36 @@ paths:
     $ref: "paths/actor-tasks/actor-tasks@{actorTaskId}@runs@last.yaml"
   "/v2/actor-tasks/{actorTaskId}/runs/last/log":
     $ref: "paths/actor-tasks/actor-tasks@{actorTaskId}@runs@last@log.yaml"
+  "/v2/actor-tasks/{actorTaskId}/runs/last/dataset":
+    $ref: "paths/actor-tasks/actor-tasks@{actorTaskId}@runs@last@dataset.yaml"
+  "/v2/actor-tasks/{actorTaskId}/runs/last/dataset/items":
+    $ref: "paths/actor-tasks/actor-tasks@{actorTaskId}@runs@last@dataset@items.yaml"
+  "/v2/actor-tasks/{actorTaskId}/runs/last/dataset/statistics":
+    $ref: "paths/actor-tasks/actor-tasks@{actorTaskId}@runs@last@dataset@statistics.yaml"
+  "/v2/actor-tasks/{actorTaskId}/runs/last/key-value-store":
+    $ref: "paths/actor-tasks/actor-tasks@{actorTaskId}@runs@last@key-value-store.yaml"
+  "/v2/actor-tasks/{actorTaskId}/runs/last/key-value-store/keys":
+    $ref: "paths/actor-tasks/actor-tasks@{actorTaskId}@runs@last@key-value-store@keys.yaml"
+  "/v2/actor-tasks/{actorTaskId}/runs/last/key-value-store/records":
+    $ref: "paths/actor-tasks/actor-tasks@{actorTaskId}@runs@last@key-value-store@records.yaml"
+  "/v2/actor-tasks/{actorTaskId}/runs/last/key-value-store/records/{recordKey}":
+    $ref: "paths/actor-tasks/actor-tasks@{actorTaskId}@runs@last@key-value-store@records@{recordKey}.yaml"
+  "/v2/actor-tasks/{actorTaskId}/runs/last/request-queue":
+    $ref: "paths/actor-tasks/actor-tasks@{actorTaskId}@runs@last@request-queue.yaml"
+  "/v2/actor-tasks/{actorTaskId}/runs/last/request-queue/head":
+    $ref: "paths/actor-tasks/actor-tasks@{actorTaskId}@runs@last@request-queue@head.yaml"
+  "/v2/actor-tasks/{actorTaskId}/runs/last/request-queue/head/lock":
+    $ref: "paths/actor-tasks/actor-tasks@{actorTaskId}@runs@last@request-queue@head@lock.yaml"
+  "/v2/actor-tasks/{actorTaskId}/runs/last/request-queue/requests":
+    $ref: "paths/actor-tasks/actor-tasks@{actorTaskId}@runs@last@request-queue@requests.yaml"
+  "/v2/actor-tasks/{actorTaskId}/runs/last/request-queue/requests/batch":
+    $ref: "paths/actor-tasks/actor-tasks@{actorTaskId}@runs@last@request-queue@requests@batch.yaml"
+  "/v2/actor-tasks/{actorTaskId}/runs/last/request-queue/requests/unlock":
+    $ref: "paths/actor-tasks/actor-tasks@{actorTaskId}@runs@last@request-queue@requests@unlock.yaml"
+  "/v2/actor-tasks/{actorTaskId}/runs/last/request-queue/requests/{requestId}":
+    $ref: "paths/actor-tasks/actor-tasks@{actorTaskId}@runs@last@request-queue@requests@{requestId}.yaml"
+  "/v2/actor-tasks/{actorTaskId}/runs/last/request-queue/requests/{requestId}/lock":
+    $ref: "paths/actor-tasks/actor-tasks@{actorTaskId}@runs@last@request-queue@requests@{requestId}@lock.yaml"
   /v2/actor-runs:
     $ref: paths/actor-runs/actor-runs.yaml
   "/v2/actor-runs/{runId}":

--- a/apify-api/openapi/paths/actor-runs/actor-runs@{runId}.yaml
+++ b/apify-api/openapi/paths/actor-runs/actor-runs@{runId}.yaml
@@ -6,63 +6,13 @@ get:
     This is not a single endpoint, but an entire group of endpoints that lets
     you retrieve the run or any of its default storages.
 
-    The endpoints accept the same HTTP methods and query parameters as
-    the respective storage endpoints.
+    ##### Convenience endpoints for Actor run default storages
 
-    The base path that represents the Actor run object is:
+    * [Dataset](/api/v2/default-dataset)
 
-    `/v2/actor-runs/{runId}{?token}`
+    * [Key-value store](/api/v2/default-key-value-store)
 
-    In order to access the default storages of the Actor run, i.e. log,
-    key-value store, dataset and request queue, use the following endpoints:
-
-    * `/v2/actor-runs/{runId}/log{?token}`
-    * `/v2/actor-runs/{runId}/key-value-store{?token}`
-    * `/v2/actor-runs/{runId}/dataset{?token}`
-    * `/v2/actor-runs/{runId}/request-queue{?token}`
-
-    These API endpoints have the same usage as the equivalent storage endpoints.
-
-    For example, `/v2/actor-runs/{runId}/key-value-store` has the same HTTP method and
-    parameters as the [Key-value store object](#/reference/key-value-stores/store-object) endpoint.
-
-    Additionally, each of the above API endpoints supports all sub-endpoints
-    of the original one:
-
-    #### Log
-
-    * `/v2/actor-runs/{runId}/log` [Log](#/reference/logs)
-
-    #### Key-value store
-
-    * `/v2/actor-runs/{runId}/key-value-store/keys{?token}` [Key
-    collection](#/reference/key-value-stores/key-collection)
-    * `/v2/actor-runs/{runId}/key-value-store/records/{recordKey}{?token}`
-    [Record](#/reference/key-value-stores/record)
-
-    #### Dataset
-
-    * `/v2/actor-runs/{runId}/dataset/items{?token}` [Item
-    collection](#/reference/datasets/item-collection)
-
-    #### Request queue
-
-    * `/v2/actor-runs/{runId}/request-queue/requests{?token}` [Request
-    collection](#/reference/request-queues/request-collection)
-    * `/v2/actor-runs/{runId}/request-queue/requests/{requestId}{?token}`
-    [Request collection](#/reference/request-queues/request)
-    * `/v2/actor-runs/{runId}/request-queue/head{?token}` [Queue
-    head](#/reference/request-queues/queue-head)
-
-    For example, to download data from a dataset of the Actor run in XML format,
-    send HTTP GET request to the following URL:
-
-    ```
-    https://api.apify.com/v2/actor-runs/{runId}/dataset/items?format=xml
-    ```
-
-    In order to save new items to the dataset, send HTTP POST request with JSON
-    payload to the same URL.
+    * [Request queue](/api/v2/default-request-queue)
 
     Gets an object that contains all the details about a
     specific run of an Actor.

--- a/apify-api/openapi/paths/actor-tasks/actor-tasks@{actorTaskId}@runs@last.yaml
+++ b/apify-api/openapi/paths/actor-tasks/actor-tasks@{actorTaskId}@runs@last.yaml
@@ -7,8 +7,6 @@ get:
     retrieve and manage the last run of given actor task or any of its default storages.
     All the endpoints require an authentication token.
 
-    The endpoints accept the same HTTP methods and query parameters as
-    the respective storage endpoints.
     The base path represents the last actor task run object is:
 
     `/v2/actor-tasks/{actorTaskId}/runs/last{?token,status}`
@@ -17,38 +15,16 @@ get:
     (e.g. `status=SUCCEEDED`). The output of this endpoint and other query parameters
     are the same as in the [Run object](/api/v2/actor-run-get) endpoint.
 
-    In order to access the default storages of the last actor task run, i.e. log, key-value store, dataset and request queue,
-    use the following endpoints:
+    ##### Convenience endpoints for last Actor task run
 
-    * `/v2/actor-tasks/{actorTaskId}/runs/last/log{?token,status}`
-    * `/v2/actor-tasks/{actorTaskId}/runs/last/key-value-store{?token,status}`
-    * `/v2/actor-tasks/{actorTaskId}/runs/last/dataset{?token,status}`
-    * `/v2/actor-tasks/{actorTaskId}/runs/last/request-queue{?token,status}`
+    * [Dataset](/api/v2/last-actor-task-runs-default-dataset)
 
-    These API endpoints have the same usage as the equivalent storage endpoints.
-    For example,
-    `/v2/actor-tasks/{actorTaskId}/runs/last/key-value-store` has the same HTTP method and parameters as the
-    [Key-value store object](/api/v2/storage-key-value-stores) endpoint.
+    * [Key-value store](/api/v2/last-actor-task-runs-default-key-value-store)
 
-    Additionally, each of the above API endpoints supports all sub-endpoints
-    of the original one:
+    * [Request queue](/api/v2/last-actor-task-runs-default-request-queue)
 
-    ##### Storage endpoints
+    * [Log](/api/v2/last-actor-task-runs-log)
 
-    * [Dataset - introduction](/api/v2/storage-datasets)
-
-    * [Key-value store - introduction](/api/v2/storage-key-value-stores)
-
-    * [Request queue - introduction](/api/v2/storage-request-queues)
-
-    For example, to download data from a dataset of the last succeeded actor task run in XML format,
-    send HTTP GET request to the following URL:
-
-    ```
-    https://api.apify.com/v2/actor-tasks/{actorTaskId}/runs/last/dataset/items?token={yourApiToken}&format=xml&status=SUCCEEDED
-    ```
-
-    In order to save new items to the dataset, send HTTP POST request with JSON payload to the same URL.
   operationId: actorTask_runs_last_get
   parameters:
     - $ref: "../../components/parameters/runAndBuildParameters.yaml#/actorTaskId"

--- a/apify-api/openapi/paths/actor-tasks/actor-tasks@{actorTaskId}@runs@last@dataset.yaml
+++ b/apify-api/openapi/paths/actor-tasks/actor-tasks@{actorTaskId}@runs@last@dataset.yaml
@@ -1,0 +1,6 @@
+get:
+  $ref: "../../components/objects/datasets/dataset.yaml#/getTaskLastRun"
+put:
+  $ref: "../../components/objects/datasets/dataset.yaml#/putTaskLastRun"
+delete:
+  $ref: "../../components/objects/datasets/dataset.yaml#/deleteTaskLastRun"

--- a/apify-api/openapi/paths/actor-tasks/actor-tasks@{actorTaskId}@runs@last@dataset@items.yaml
+++ b/apify-api/openapi/paths/actor-tasks/actor-tasks@{actorTaskId}@runs@last@dataset@items.yaml
@@ -1,0 +1,4 @@
+get:
+  $ref: "../../components/objects/datasets/dataset-items.yaml#/getTaskLastRun"
+post:
+  $ref: "../../components/objects/datasets/dataset-items.yaml#/postTaskLastRun"

--- a/apify-api/openapi/paths/actor-tasks/actor-tasks@{actorTaskId}@runs@last@dataset@statistics.yaml
+++ b/apify-api/openapi/paths/actor-tasks/actor-tasks@{actorTaskId}@runs@last@dataset@statistics.yaml
@@ -1,0 +1,2 @@
+get:
+  $ref: "../../components/objects/datasets/dataset-statistics.yaml#/getTaskLastRun"

--- a/apify-api/openapi/paths/actor-tasks/actor-tasks@{actorTaskId}@runs@last@key-value-store.yaml
+++ b/apify-api/openapi/paths/actor-tasks/actor-tasks@{actorTaskId}@runs@last@key-value-store.yaml
@@ -1,0 +1,6 @@
+get:
+  $ref: "../../components/objects/key-value-stores/key-value-store.yaml#/getTaskLastRun"
+put:
+  $ref: "../../components/objects/key-value-stores/key-value-store.yaml#/putTaskLastRun"
+delete:
+  $ref: "../../components/objects/key-value-stores/key-value-store.yaml#/deleteTaskLastRun"

--- a/apify-api/openapi/paths/actor-tasks/actor-tasks@{actorTaskId}@runs@last@key-value-store@keys.yaml
+++ b/apify-api/openapi/paths/actor-tasks/actor-tasks@{actorTaskId}@runs@last@key-value-store@keys.yaml
@@ -1,0 +1,2 @@
+get:
+  $ref: "../../components/objects/key-value-stores/key-value-store-keys.yaml#/getTaskLastRun"

--- a/apify-api/openapi/paths/actor-tasks/actor-tasks@{actorTaskId}@runs@last@key-value-store@records.yaml
+++ b/apify-api/openapi/paths/actor-tasks/actor-tasks@{actorTaskId}@runs@last@key-value-store@records.yaml
@@ -1,0 +1,2 @@
+get:
+  $ref: "../../components/objects/key-value-stores/key-value-store-records.yaml#/getTaskLastRun"

--- a/apify-api/openapi/paths/actor-tasks/actor-tasks@{actorTaskId}@runs@last@key-value-store@records@{recordKey}.yaml
+++ b/apify-api/openapi/paths/actor-tasks/actor-tasks@{actorTaskId}@runs@last@key-value-store@records@{recordKey}.yaml
@@ -1,0 +1,8 @@
+get:
+  $ref: "../../components/objects/key-value-stores/key-value-store-record.yaml#/getTaskLastRun"
+put:
+  $ref: "../../components/objects/key-value-stores/key-value-store-record.yaml#/putTaskLastRun"
+post:
+  $ref: "../../components/objects/key-value-stores/key-value-store-record.yaml#/postTaskLastRun"
+delete:
+  $ref: "../../components/objects/key-value-stores/key-value-store-record.yaml#/deleteTaskLastRun"

--- a/apify-api/openapi/paths/actor-tasks/actor-tasks@{actorTaskId}@runs@last@request-queue.yaml
+++ b/apify-api/openapi/paths/actor-tasks/actor-tasks@{actorTaskId}@runs@last@request-queue.yaml
@@ -1,0 +1,6 @@
+get:
+  $ref: "../../components/objects/request-queues/request-queue.yaml#/getTaskLastRun"
+put:
+  $ref: "../../components/objects/request-queues/request-queue.yaml#/putTaskLastRun"
+delete:
+  $ref: "../../components/objects/request-queues/request-queue.yaml#/deleteTaskLastRun"

--- a/apify-api/openapi/paths/actor-tasks/actor-tasks@{actorTaskId}@runs@last@request-queue@head.yaml
+++ b/apify-api/openapi/paths/actor-tasks/actor-tasks@{actorTaskId}@runs@last@request-queue@head.yaml
@@ -1,0 +1,2 @@
+get:
+  $ref: "../../components/objects/request-queues/request-queue-head.yaml#/getTaskLastRun"

--- a/apify-api/openapi/paths/actor-tasks/actor-tasks@{actorTaskId}@runs@last@request-queue@head@lock.yaml
+++ b/apify-api/openapi/paths/actor-tasks/actor-tasks@{actorTaskId}@runs@last@request-queue@head@lock.yaml
@@ -1,0 +1,2 @@
+post:
+  $ref: "../../components/objects/request-queues/request-queue-head-lock.yaml#/postTaskLastRun"

--- a/apify-api/openapi/paths/actor-tasks/actor-tasks@{actorTaskId}@runs@last@request-queue@requests.yaml
+++ b/apify-api/openapi/paths/actor-tasks/actor-tasks@{actorTaskId}@runs@last@request-queue@requests.yaml
@@ -1,0 +1,4 @@
+get:
+  $ref: "../../components/objects/request-queues/request-queue-requests.yaml#/getTaskLastRun"
+post:
+  $ref: "../../components/objects/request-queues/request-queue-requests.yaml#/postTaskLastRun"

--- a/apify-api/openapi/paths/actor-tasks/actor-tasks@{actorTaskId}@runs@last@request-queue@requests@batch.yaml
+++ b/apify-api/openapi/paths/actor-tasks/actor-tasks@{actorTaskId}@runs@last@request-queue@requests@batch.yaml
@@ -1,0 +1,4 @@
+post:
+  $ref: "../../components/objects/request-queues/request-queue-requests-batch.yaml#/postTaskLastRun"
+delete:
+  $ref: "../../components/objects/request-queues/request-queue-requests-batch.yaml#/deleteTaskLastRun"

--- a/apify-api/openapi/paths/actor-tasks/actor-tasks@{actorTaskId}@runs@last@request-queue@requests@unlock.yaml
+++ b/apify-api/openapi/paths/actor-tasks/actor-tasks@{actorTaskId}@runs@last@request-queue@requests@unlock.yaml
@@ -1,0 +1,2 @@
+post:
+  $ref: "../../components/objects/request-queues/request-queue-requests-unlock.yaml#/postTaskLastRun"

--- a/apify-api/openapi/paths/actor-tasks/actor-tasks@{actorTaskId}@runs@last@request-queue@requests@{requestId}.yaml
+++ b/apify-api/openapi/paths/actor-tasks/actor-tasks@{actorTaskId}@runs@last@request-queue@requests@{requestId}.yaml
@@ -1,0 +1,6 @@
+get:
+  $ref: "../../components/objects/request-queues/request-queue-request.yaml#/getTaskLastRun"
+put:
+  $ref: "../../components/objects/request-queues/request-queue-request.yaml#/putTaskLastRun"
+delete:
+  $ref: "../../components/objects/request-queues/request-queue-request.yaml#/deleteTaskLastRun"

--- a/apify-api/openapi/paths/actor-tasks/actor-tasks@{actorTaskId}@runs@last@request-queue@requests@{requestId}@lock.yaml
+++ b/apify-api/openapi/paths/actor-tasks/actor-tasks@{actorTaskId}@runs@last@request-queue@requests@{requestId}@lock.yaml
@@ -1,0 +1,4 @@
+put:
+  $ref: "../../components/objects/request-queues/request-queue-request-lock.yaml#/putTaskLastRun"
+delete:
+  $ref: "../../components/objects/request-queues/request-queue-request-lock.yaml#/deleteTaskLastRun"

--- a/apify-api/openapi/paths/actors/acts@{actorId}@runs@last.yaml
+++ b/apify-api/openapi/paths/actors/acts@{actorId}@runs@last.yaml
@@ -7,8 +7,6 @@ get:
     retrieve and manage the last run of given Actor or any of its default storages.
     All the endpoints require an authentication token.
 
-    The endpoints accept the same HTTP methods and query parameters as
-    the respective storage endpoints.
     The base path represents the last Actor run object is:
 
     `/v2/acts/{actorId}/runs/last{?token,status}`
@@ -17,45 +15,16 @@ get:
     (e.g. `status=SUCCEEDED`). The output of this endpoint and other query parameters
     are the same as in the [Run object](#/reference/actors/run-object) endpoint.
 
-    In order to access the default storages of the last Actor run, i.e. log, key-value store, dataset and request queue,
-    use the following endpoints:
+    ##### Convenience endpoints for last Actor run
 
-    * `/v2/acts/{actorId}/runs/last/log{?token,status}`
-    * `/v2/acts/{actorId}/runs/last/key-value-store{?token,status}`
-    * `/v2/acts/{actorId}/runs/last/dataset{?token,status}`
-    * `/v2/acts/{actorId}/runs/last/request-queue{?token,status}`
+    * [Dataset](/api/v2/last-actor-runs-default-dataset)
 
-    These API endpoints have the same usage as the equivalent storage endpoints.
-    For example,
-    `/v2/acts/{actorId}/runs/last/key-value-store` has the same HTTP method and parameters as the
-    [Key-value store object](#/reference/key-value-stores/store-object) endpoint.
+    * [Key-value store](/api/v2/last-actor-runs-default-key-value-store)
 
-    Additionally, each of the above API endpoints supports all sub-endpoints
-    of the original one:
+    * [Request queue](/api/v2/last-actor-runs-default-request-queue)
 
-    #### Key-value store
+    * [Log](/api/v2/last-actor-runs-log)
 
-    * `/v2/acts/{actorId}/runs/last/key-value-store/keys{?token,status}` [Key collection](#/reference/key-value-stores/key-collection)
-    * `/v2/acts/{actorId}/runs/last/key-value-store/records/{recordKey}{?token,status}` [Record](#/reference/key-value-stores/record)
-
-    #### Dataset
-
-    * `/v2/acts/{actorId}/runs/last/dataset/items{?token,status}` [Item collection](#/reference/datasets/item-collection)
-
-    #### Request queue
-
-    * `/v2/acts/{actorId}/runs/last/request-queue/requests{?token,status}` [Request collection](#/reference/request-queues/request-collection)
-    * `/v2/acts/{actorId}/runs/last/request-queue/requests/{requestId}{?token,status}` [Request collection](#/reference/request-queues/request)
-    * `/v2/acts/{actorId}/runs/last/request-queue/head{?token,status}` [Queue head](#/reference/request-queues/queue-head)
-
-    For example, to download data from a dataset of the last succeeded Actor run in XML format,
-    send HTTP GET request to the following URL:
-
-    ```
-    https://api.apify.com/v2/acts/{actorId}/runs/last/dataset/items?token={yourApiToken}&format=xml&status=SUCCEEDED
-    ```
-
-    In order to save new items to the dataset, send HTTP POST request with JSON payload to the same URL.
   operationId: act_runs_last_get
   parameters:
     - $ref: "../../components/parameters/runAndBuildParameters.yaml#/actorId"


### PR DESCRIPTION
### Description
- Add undocumented, but public API endpoints related to the last task run
  - last Actor run dataset
  - last Actor run rq
  - last Actor run kvs
- Abstract reusable parts of nearly duplicate endpoints and use references.
- Replace prose description of previously not properly documented redispatch endpoints by links to their documentation.
(prose description is no longer needed, all redispatch endpoints have their own pages)

### Issues
Partially implements: https://github.com/apify/apify-docs/issues/2286
