### PR TITLE
chore(ci): update Python docs workflow references 

### DIFF
--- a/.github/workflows/publish-to-npm.yaml
+++ b/.github/workflows/publish-to-npm.yaml
@@ -139,4 +139,4 @@ jobs:
             -   env:
                     GITHUB_TOKEN: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}
                 run: |
-                    gh workflow run _release_docs.yaml --repo ${{ matrix.repo }}
+                    gh workflow run manual_release_docs.yaml --repo ${{ matrix.repo }}


### PR DESCRIPTION
Following the CI action rename from https://github.com/apify/apify-sdk-python/pull/858 and https://github.com/apify/apify-client-python/pull/728, the reference here needed updates (the publishing CI action [was failing](https://github.com/apify/apify-docs/actions/runs/24672504318/job/72147421521)). 