### PR TITLE
docs: add state targeting info to proxy usage page

### DIFF
--- a/sources/platform/proxy/residential_proxy.md
+++ b/sources/platform/proxy/residential_proxy.md
@@ -114,7 +114,7 @@ async def main():
 State-level targeting is currently only supported for the United States.
 :::
 
-To use state targeting, specify the `country` parameter in the [username](./usage.md#username-parameters) using the [ISO 3166-2:US](https://en.wikipedia.org/wiki/ISO_3166-2:US) format: `country-US_XX`, where `XX` is the two-letter state abbreviation. For example, to target California when using the proxy URL directly, set the username to `groups-RESIDENTIAL,country-US-CA`
+To use state targeting, specify the `country` parameter in the [username](./usage.md#username-parameters) using the [ISO 3166-2:US](https://en.wikipedia.org/wiki/ISO_3166-2:US) format: `country-US_XX`, where `XX` is the two-letter state abbreviation. For example, to target California when using the proxy URL directly, set the username to `groups-RESIDENTIAL,country-US_CA`.
 
 
 In the [Apify SDK](/sdk) you set the state in your proxy configuration using the `countryCode`/`country_code` parameter:

--- a/sources/platform/proxy/usage.md
+++ b/sources/platform/proxy/usage.md
@@ -107,6 +107,7 @@ The table below describes the available parameters.
         <td>Optional</td>
         <td>
             If specified, all proxied requests will use proxy servers from a selected country. Note that if there are no proxy servers from the specified country, the connection will fail. For example <code>groups-SHADER,country-US</code> uses proxies from the <code>SHADER</code> group located in the USA. By default, the proxy uses all available proxy servers from all countries.
+            <br/><br/>For <a href="./residential_proxy#how-to-set-a-state">residential proxies</a>, you can also target US states using the <a href="https://en.wikipedia.org/wiki/ISO_3166-2:US">ISO 3166-2:US</a> format: <code>country-US_XX</code>, where <code>XX</code> is the two-letter state abbreviation. For example, <code>groups-RESIDENTIAL,country-US_CA</code> targets California.
         </td>
     </tr>
     </tbody>


### PR DESCRIPTION
Add US state-level targeting (ISO 3166-2:US) to the country parameter description on the proxy usage page. 
Fix dash/underscore inconsistency in the residential proxy page example.