### PR TITLE
fix: Reference image from docs-theme for external links

### DIFF
--- a/apify-docs-theme/src/theme/custom.css
+++ b/apify-docs-theme/src/theme/custom.css
@@ -505,7 +505,7 @@ aside > div > a > b {
     height: 0.9em;
     vertical-align: -0.1em;
     background-color: currentColor;
-    mask-image: url('/img/external_link_icon.svg');
+    mask-image: url('/img/external-link.svg');
     mask-size: contain;
     mask-repeat: no-repeat;
     mask-position: center;


### PR DESCRIPTION
Fixes: https://github.com/apify/apify-docs/pull/2445#issuecomment-4294527326