### PR TITLE
docs(openapi): Relax `PendingRequestCount` until API bug is fixed

### DIFF
--- a/apify-api/openapi/components/schemas/request-queues/SharedProperties.yaml
+++ b/apify-api/openapi/components/schemas/request-queues/SharedProperties.yaml
@@ -79,7 +79,7 @@ HandledRequestCount:
 PendingRequestCount:
   type: integer
   description: The number of requests that are pending and have not been handled yet.
-  minimum: 0
+  # minimum: 0 Bug in API allows negative numbers https://github.com/apify/apify-core/issues/27403
   examples: [670]
 
 QueueModifiedAt:


### PR DESCRIPTION
Currently API can return `PendingRequestCount` negative
 
Due to bug: https://github.com/apify/apify-core/issues/27403
This can cause problems in downstream Python-generated models as the constraints are enforced by the Pydantic models.

### Issues
Partially implements: https://github.com/apify/apify-docs/issues/2286