### PR TITLE
feat(openapi): Add WebhookRepresentation schema for ad-hoc webhooks

### DIFF
--- a/apify-api/openapi/components/parameters/runAndBuildParameters.yaml
+++ b/apify-api/openapi/components/parameters/runAndBuildParameters.yaml
@@ -179,13 +179,19 @@ webhooks:
   in: query
   description: |
     Specifies optional webhooks associated with the Actor run, which can be used to receive a notification
-    e.g. when the Actor finished or failed. The value is a Base64-encoded
-    JSON array of objects defining the webhooks. For more information, see
+    e.g. when the Actor finished or failed. The value is a Base64-encoded JSON array whose items follow
+    the WebhookRepresentation schema. For more information, see
     [Webhooks documentation](https://docs.apify.com/platform/integrations/webhooks).
   style: form
   explode: true
   schema:
     type: string
+    contentEncoding: base64
+    contentMediaType: application/json
+    contentSchema:
+      type: array
+      items:
+        $ref: ../schemas/webhooks/WebhookRepresentation.yaml
     example: dGhpcyBpcyBqdXN0IGV4YW1wbGUK...
 
 waitForFinishRun:

--- a/apify-api/openapi/components/schemas/webhooks/WebhookRepresentation.yaml
+++ b/apify-api/openapi/components/schemas/webhooks/WebhookRepresentation.yaml
@@ -1,0 +1,28 @@
+title: WebhookRepresentation
+description: |
+  Minimal representation of an ad-hoc webhook attached to a single Actor run or build via the
+  `webhooks` query parameter. The query parameter value is a Base64-encoded JSON array whose
+  items match this schema. Persistent webhook fields (e.g. `condition`) are not used here.
+required:
+  - eventTypes
+  - requestUrl
+type: object
+properties:
+  eventTypes:
+    type: array
+    items:
+      $ref: ./WebhookEventType.yaml
+    examples:
+      - [ACTOR.RUN.SUCCEEDED]
+  requestUrl:
+    type: string
+    description: The URL to which the webhook sends its payload.
+    examples: ["http://example.com/"]
+  payloadTemplate:
+    type: [string, "null"]
+    description: Optional template for the JSON payload sent by the webhook.
+    examples: ['{\n "userId": {{userId}}...']
+  headersTemplate:
+    type: [string, "null"]
+    description: Optional template for the HTTP headers sent by the webhook.
+    examples: ['{\n "Authorization": "Bearer ..."}']


### PR DESCRIPTION
## Summary

- Adds a new `WebhookRepresentation` schema describing the minimal ad-hoc webhook shape (`eventTypes`, `requestUrl`, optional `payloadTemplate` / `headersTemplate`).
- References it via `contentSchema` on the `webhooks` query parameter (used on Actor/task run and build endpoints), so the parameter now documents the actual decoded structure of the Base64-encoded JSON array instead of a vague free-form description.

## Why

The `webhooks` query parameter is hand-maintained in [`apify-client-python`](https://github.com/apify/apify-client-python) because the spec didn't expose its decoded shape. Lifting it into the spec lets the client generate the model from codegen (apify/apify-client-python#758) and keeps the API reference accurate for any other consumer.

## Related

- Pairs with the apify-client-python PR that drops the hand-written `WebhookRepresentation` model in favor of the generated one.