### PR TITLE
docs: reduce llms.txt size from ~196K to ~84K characters

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -32,6 +32,9 @@ jobs:
                     INTERCOM_APP_ID: ${{ secrets.INTERCOM_APP_ID }}
                     SEGMENT_TOKEN: ${{ secrets.SEGMENT_TOKEN }}
 
+            -   name: Check llms.txt size
+                run: npm run test:llms-size
+
             -   name: Install Nginx
                 run: |
                     sudo apt-get update

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -275,7 +275,7 @@ module.exports = {
             '@signalwire/docusaurus-plugin-llms-txt',
             /** @type {import('@signalwire/docusaurus-plugin-llms-txt').PluginOptions} */
             ({
-                siteDescription: 'The entire content of Apify documentation is available in a single Markdown file at https://docs.apify.com/llms-full.txt',
+                siteDescription: 'Apify is the largest marketplace of tools for AI. 25,000 ready-made Actors to automate your business. Get real-time web data, track competitors, generate leads, analyze sentiment, and orchestrate your apps. Actors are created by a global community of builders earning over $1M every month. Apify takes care of infrastructure, billing, and distribution.\n\nThe entire content of Apify documentation is available in a single Markdown file at https://docs.apify.com/llms-full.txt\n\nFor pricing details, see https://apify.com/pricing',
                 content: {
                     includeVersionedDocs: false,
                     enableLlmsFullTxt: true,

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -326,6 +326,66 @@ module.exports = {
                     },
                     excludeRoutes: [
                         '/',
+                        // API: exclude all deprecated act-* endpoints
+                        '/api/v2/act-*',
+                        // API: exclude individual CRUD endpoint pages (keep Introduction pages)
+                        '/api/v2/actor-build-abort-post',
+                        '/api/v2/actor-build-delete',
+                        '/api/v2/actor-build-get',
+                        '/api/v2/actor-build-log-get',
+                        '/api/v2/actor-build-openapi-json-get',
+                        '/api/v2/actor-builds-get',
+                        '/api/v2/actor-run-*',
+                        '/api/v2/actor-runs-get',
+                        '/api/v2/actor-task-*',
+                        '/api/v2/actor-tasks-get',
+                        '/api/v2/actor-tasks-post',
+                        '/api/v2/acts-get',
+                        '/api/v2/acts-post',
+                        '/api/v2/dataset-*',
+                        '/api/v2/datasets-*',
+                        '/api/v2/key-value-store-*',
+                        '/api/v2/key-value-stores-*',
+                        '/api/v2/log-get',
+                        '/api/v2/post-*',
+                        '/api/v2/request-queue-*',
+                        '/api/v2/request-queues-*',
+                        '/api/v2/schedule-*',
+                        '/api/v2/schedules-get',
+                        '/api/v2/schedules-post',
+                        '/api/v2/store-get',
+                        '/api/v2/tools-*',
+                        '/api/v2/user-get',
+                        '/api/v2/users-me-*',
+                        '/api/v2/webhook-*',
+                        '/api/v2/webhooks-get',
+                        '/api/v2/webhooks-post',
+                        // Academy: exclude legacy JS course
+                        '/academy/scraping-basics-javascript/legacy',
+                        '/academy/scraping-basics-javascript/legacy/**',
+                        // Academy: exclude individual Node.js tutorials (keep index)
+                        '/academy/node-js/*',
+                        // Academy: exclude individual Python tutorials (keep index)
+                        '/academy/python/*',
+                        // Academy: exclude exercise solutions
+                        '/academy/expert-scraping-with-apify/solutions',
+                        '/academy/expert-scraping-with-apify/solutions/**',
+                        // Academy: exclude legacy scraper tutorials (keep index)
+                        '/academy/apify-scrapers/*',
+                        // Academy: exclude marketing playbook deep pages
+                        '/academy/actor-marketing-playbook/**',
+                        // Academy: exclude misc
+                        '/academy/tutorials',
+                        '/academy/php/**',
+                        // Legal: exclude outdated docs
+                        '/legal/old/**',
+                        '/legal/fair-share-program-terms-and-conditions',
+                        '/legal/challenge-terms-and-conditions',
+                        '/legal/candidate-referral-program-terms',
+                        // Misc singleton pages
+                        '/open-source',
+                        '/sdk',
+                        '/search',
                     ],
                     routeRules: [
                         {

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -276,6 +276,12 @@ module.exports = {
             /** @type {import('@signalwire/docusaurus-plugin-llms-txt').PluginOptions} */
             ({
                 siteDescription: 'The entire content of Apify documentation is available in a single Markdown file at https://docs.apify.com/llms-full.txt',
+                includeOrder: [
+                    '/platform/**',
+                    '/api/**',
+                    '/academy/**',
+                    '/legal/**',
+                ],
                 content: {
                     includeVersionedDocs: false,
                     enableLlmsFullTxt: true,

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -276,12 +276,6 @@ module.exports = {
             /** @type {import('@signalwire/docusaurus-plugin-llms-txt').PluginOptions} */
             ({
                 siteDescription: 'The entire content of Apify documentation is available in a single Markdown file at https://docs.apify.com/llms-full.txt',
-                includeOrder: [
-                    '/platform/**',
-                    '/api/**',
-                    '/academy/**',
-                    '/legal/**',
-                ],
                 content: {
                     includeVersionedDocs: false,
                     enableLlmsFullTxt: true,

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
         "lint:code": "eslint .",
         "lint:code:fix": "eslint . --fix",
         "test:academy": "bats --print-output-on-failure -r .",
+        "test:llms-size": "node ./scripts/checkLlmsSize.mjs",
         "postinstall": "patch-package",
         "postbuild": "node ./scripts/joinLlmsFiles.mjs && node ./scripts/indentLlmsFile.mjs"
     },

--- a/scripts/checkLlmsSize.mjs
+++ b/scripts/checkLlmsSize.mjs
@@ -1,0 +1,43 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+const BUILD_DIR = path.resolve('build');
+const WARN_LIMIT = 90_000;
+const ERROR_LIMIT = 100_000;
+
+async function checkFile(filePath) {
+    try {
+        await fs.access(filePath);
+    } catch {
+        console.error(`ERROR: ${filePath} does not exist`);
+        process.exitCode = 1;
+        return null;
+    }
+    // Use string .length for character count (not byte count)
+    const content = await fs.readFile(filePath, 'utf8');
+    return content.length;
+}
+
+const llmsPath = path.join(BUILD_DIR, 'llms.txt');
+const llmsFullPath = path.join(BUILD_DIR, 'llms-full.txt');
+
+const [llmsChars, llmsFullChars] = await Promise.all([
+    checkFile(llmsPath),
+    checkFile(llmsFullPath),
+]);
+
+if (llmsChars === null || llmsFullChars === null) {
+    process.exit(1);
+}
+
+console.log(`llms.txt:      ${llmsChars.toLocaleString()} characters`);
+console.log(`llms-full.txt: ${llmsFullChars.toLocaleString()} characters`);
+
+if (llmsChars > ERROR_LIMIT) {
+    console.error(`\nERROR: llms.txt exceeds ${ERROR_LIMIT.toLocaleString()} character limit`);
+    process.exitCode = 1;
+} else if (llmsChars > WARN_LIMIT) {
+    console.warn(`\nWARNING: llms.txt exceeds ${WARN_LIMIT.toLocaleString()} characters — consider reducing`);
+} else {
+    console.log(`\nOK (under ${WARN_LIMIT.toLocaleString()} character target)`);
+}

--- a/scripts/joinLlmsFiles.mjs
+++ b/scripts/joinLlmsFiles.mjs
@@ -31,13 +31,62 @@ async function fetchFile(route) {
     }
 }
 
+// Desired section order for llms.txt — sections not listed here appear at the end in original order
+const SECTION_ORDER = [
+    'Platform documentation',
+    'Apify API',
+    'Apify API client for JavaScript',
+    'Apify API client for Python',
+    'Apify SDK for JavaScript',
+    'Apify SDK for Python',
+    'Apify CLI',
+    'Apify academy',
+    'Legal documents',
+];
+
+/**
+ * Reorder ## sections in llms.txt according to SECTION_ORDER.
+ * Keeps the header (everything before the first ## section) in place.
+ */
+function reorderSections(content) {
+    const sectionRegex = /^## .+$/gm;
+    const firstMatch = sectionRegex.exec(content);
+    if (!firstMatch) return content;
+
+    const header = content.slice(0, firstMatch.index);
+    const body = content.slice(firstMatch.index);
+
+    // Split into sections by ## headings
+    const sections = [];
+    const parts = body.split(/^(?=## )/gm);
+    for (const part of parts) {
+        const nameMatch = part.match(/^## (.+)$/m);
+        sections.push({ name: nameMatch ? nameMatch[1].trim() : '', content: part });
+    }
+
+    sections.sort((a, b) => {
+        const indexA = SECTION_ORDER.indexOf(a.name);
+        const indexB = SECTION_ORDER.indexOf(b.name);
+        // Sections not in the list keep their relative order at the end
+        const orderA = indexA === -1 ? SECTION_ORDER.length + sections.indexOf(a) : indexA;
+        const orderB = indexB === -1 ? SECTION_ORDER.length + sections.indexOf(b) : indexB;
+        return orderA - orderB;
+    });
+
+    return header + sections.map((s) => s.content).join('');
+}
+
 async function joinFiles() {
     await fs.mkdir(BUILD_DIR, { recursive: true });
+    const llmsPath = path.join(BUILD_DIR, 'llms.txt');
 
-    // llms.txt: append curated static content (not full reference docs from external repos)
+    // llms.txt: append curated static content, then reorder all sections
     const curatedContent = await fs.readFile(CURATED_FILE, 'utf8');
-    await fs.appendFile(path.join(BUILD_DIR, 'llms.txt'), curatedContent, 'utf8');
-    console.log('Wrote curated external references to build/llms.txt');
+    await fs.appendFile(llmsPath, curatedContent, 'utf8');
+
+    const combined = await fs.readFile(llmsPath, 'utf8');
+    await fs.writeFile(llmsPath, reorderSections(combined), 'utf8');
+    console.log('Wrote and reordered build/llms.txt');
 
     // llms-full.txt: fetch and append full content from external repos (unchanged behavior)
     const contents = await Promise.all(

--- a/scripts/joinLlmsFiles.mjs
+++ b/scripts/joinLlmsFiles.mjs
@@ -73,7 +73,7 @@ function reorderSections(content) {
         return orderA - orderB;
     });
 
-    return header + sections.map((s) => s.content).join('');
+    return header + sections.map((s) => s.content.replace(/\n*$/, '\n')).join('\n');
 }
 
 async function joinFiles() {

--- a/scripts/joinLlmsFiles.mjs
+++ b/scripts/joinLlmsFiles.mjs
@@ -2,31 +2,23 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 
 const BUILD_DIR = path.resolve('build');
+const CURATED_FILE = path.resolve('scripts/llms-external-curated.txt');
 
-const FILES_ROUTES = {
-    'llms.txt': [
-        'https://docs.apify.com/api/client/js/llms.txt',
-        'https://docs.apify.com/api/client/python/llms.txt',
-        'https://docs.apify.com/sdk/js/llms.txt',
-        'https://docs.apify.com/sdk/python/llms.txt',
-        'https://docs.apify.com/cli/llms.txt',
-    ],
-    'llms-full.txt': [
-        'https://docs.apify.com/api/client/js/llms-full.txt',
-        'https://docs.apify.com/api/client/python/llms-full.txt',
-        'https://docs.apify.com/sdk/js/llms-full.txt',
-        'https://docs.apify.com/sdk/python/llms-full.txt',
-        'https://docs.apify.com/cli/llms-full.txt',
-        'https://raw.githubusercontent.com/apify/actor-whitepaper/refs/heads/master/README.md',
-        'https://raw.githubusercontent.com/apify/actor-whitepaper/refs/heads/master/pages/ACTOR_FILE.md',
-        'https://raw.githubusercontent.com/apify/actor-whitepaper/refs/heads/master/pages/DATASET_SCHEMA.md',
-        'https://raw.githubusercontent.com/apify/actor-whitepaper/refs/heads/master/pages/IDEAS.md',
-        'https://raw.githubusercontent.com/apify/actor-whitepaper/refs/heads/master/pages/INPUT_SCHEMA.md',
-        'https://raw.githubusercontent.com/apify/actor-whitepaper/refs/heads/master/pages/KEY_VALUE_STORE_SCHEMA.md',
-        'https://raw.githubusercontent.com/apify/actor-whitepaper/refs/heads/master/pages/OUTPUT_SCHEMA.md',
-        'https://raw.githubusercontent.com/apify/actor-whitepaper/refs/heads/master/pages/REQUEST_QUEUE_SCHEMA.md',
-    ],
-};
+const EXTERNAL_FETCH_URLS = [
+    'https://docs.apify.com/api/client/js/llms-full.txt',
+    'https://docs.apify.com/api/client/python/llms-full.txt',
+    'https://docs.apify.com/sdk/js/llms-full.txt',
+    'https://docs.apify.com/sdk/python/llms-full.txt',
+    'https://docs.apify.com/cli/llms-full.txt',
+    'https://raw.githubusercontent.com/apify/actor-whitepaper/refs/heads/master/README.md',
+    'https://raw.githubusercontent.com/apify/actor-whitepaper/refs/heads/master/pages/ACTOR_FILE.md',
+    'https://raw.githubusercontent.com/apify/actor-whitepaper/refs/heads/master/pages/DATASET_SCHEMA.md',
+    'https://raw.githubusercontent.com/apify/actor-whitepaper/refs/heads/master/pages/IDEAS.md',
+    'https://raw.githubusercontent.com/apify/actor-whitepaper/refs/heads/master/pages/INPUT_SCHEMA.md',
+    'https://raw.githubusercontent.com/apify/actor-whitepaper/refs/heads/master/pages/KEY_VALUE_STORE_SCHEMA.md',
+    'https://raw.githubusercontent.com/apify/actor-whitepaper/refs/heads/master/pages/OUTPUT_SCHEMA.md',
+    'https://raw.githubusercontent.com/apify/actor-whitepaper/refs/heads/master/pages/REQUEST_QUEUE_SCHEMA.md',
+];
 
 async function fetchFile(route) {
     try {
@@ -41,14 +33,19 @@ async function fetchFile(route) {
 
 async function joinFiles() {
     await fs.mkdir(BUILD_DIR, { recursive: true });
-    for (const [llmsFile, files] of Object.entries(FILES_ROUTES)) {
-        const contents = await Promise.all(
-            files.map((route) => fetchFile(route)),
-        );
-        const joined = contents.filter(Boolean).join('\n\n');
-        await fs.appendFile(path.join(BUILD_DIR, llmsFile), joined, 'utf8');
-        console.log(`Wrote ${llmsFile} to build/`);
-    }
+
+    // llms.txt: append curated static content (not full reference docs from external repos)
+    const curatedContent = await fs.readFile(CURATED_FILE, 'utf8');
+    await fs.appendFile(path.join(BUILD_DIR, 'llms.txt'), curatedContent, 'utf8');
+    console.log('Wrote curated external references to build/llms.txt');
+
+    // llms-full.txt: fetch and append full content from external repos (unchanged behavior)
+    const contents = await Promise.all(
+        EXTERNAL_FETCH_URLS.map((route) => fetchFile(route)),
+    );
+    const joined = contents.filter(Boolean).join('\n\n');
+    await fs.appendFile(path.join(BUILD_DIR, 'llms-full.txt'), joined, 'utf8');
+    console.log('Wrote llms-full.txt to build/');
 }
 
 async function sanitizeFile(filePath) {
@@ -63,4 +60,6 @@ joinFiles().catch((err) => {
     process.exit(1);
 });
 
-Object.keys(FILES_ROUTES).forEach((llmsFile) => sanitizeFile(path.join(BUILD_DIR, llmsFile)));
+for (const llmsFile of ['llms.txt', 'llms-full.txt']) {
+    sanitizeFile(path.join(BUILD_DIR, llmsFile));
+}

--- a/scripts/llms-external-curated.txt
+++ b/scripts/llms-external-curated.txt
@@ -1,0 +1,120 @@
+# API client for JavaScript | Apify Documentation
+# Source: https://docs.apify.com/api/client/js/llms.txt
+# This is a curated subset of the full llms.txt. Update when new concept/guide pages are added.
+
+
+## api
+
+      - [Overview](https://docs.apify.com/api/client/js/docs.md): The official JavaScript library to access the Apify API, with automatic retries, TypeScript support, and cross-platform compatibility.
+        - [Changelog](https://docs.apify.com/api/client/js/docs/changelog.md)
+        - [Use in bundled environments](https://docs.apify.com/api/client/js/docs/concepts/bundled-environments.md): Use the Apify API client for JavaScript in browsers, Cloudflare Workers, and other edge runtimes.
+        - [Convenience functions](https://docs.apify.com/api/client/js/docs/concepts/convenience-functions.md): Use call(), waitForFinish(), and other convenience functions in the Apify API client for JavaScript.
+        - [Error handling and retries](https://docs.apify.com/api/client/js/docs/concepts/error-handling.md): Handle API errors and configure automatic retries with exponential backoff in the Apify API client for JavaScript.
+        - [Pagination](https://docs.apify.com/api/client/js/docs/concepts/pagination.md): Paginate through large result sets and use async iteration with the Apify API client for JavaScript.
+        - [Usage patterns](https://docs.apify.com/api/client/js/docs/concepts/usage-patterns.md): Learn the resource client and collection client patterns used by the Apify API client for JavaScript.
+        - [Code examples](https://docs.apify.com/api/client/js/docs/guides/examples.md): Practical code examples for common tasks with the Apify API client for JavaScript, including webhooks and datasets.
+        - [Quick start](https://docs.apify.com/api/client/js/docs/introduction/quick-start.md): Get started with the Apify API client for JavaScript by running an Actor and retrieving results from its dataset.
+      - [apify-client reference](https://docs.apify.com/api/client/js/reference.md)
+
+
+# API client for Python | Apify Documentation
+# Source: https://docs.apify.com/api/client/python/llms.txt
+
+
+## api
+
+      - [Overview](https://docs.apify.com/api/client/python/docs.md): The official Python library to access the Apify API, with automatic retries, async support, and comprehensive API coverage.
+        - [Changelog](https://docs.apify.com/api/client/python/docs/changelog.md)
+        - [Asyncio support](https://docs.apify.com/api/client/python/docs/concepts/asyncio-support.md): Use the asynchronous ApifyClientAsync to interact with the Apify API using Python's async/await syntax.
+        - [Convenience methods](https://docs.apify.com/api/client/python/docs/concepts/convenience-methods.md): Convenience methods to handle actions that the API alone cannot perform efficiently.
+        - [Error handling](https://docs.apify.com/api/client/python/docs/concepts/error-handling.md): The client automatically extracts data, converts date strings to datetime objects, and raises ApifyApiError on errors.
+        - [Logging](https://docs.apify.com/api/client/python/docs/concepts/logging.md): Configure the apify_client logger to print debug information about API requests.
+        - [Nested clients](https://docs.apify.com/api/client/python/docs/concepts/nested-clients.md): Use nested clients to simplify working with related collections like Actor runs.
+        - [Pagination](https://docs.apify.com/api/client/python/docs/concepts/pagination.md): Work with paginated data using the ListPage object returned by list methods.
+        - [Retries](https://docs.apify.com/api/client/python/docs/concepts/retries.md): Automatic retries for requests that fail due to network issues or rate limiting.
+        - [Single and collection clients](https://docs.apify.com/api/client/python/docs/concepts/single-and-collection-clients.md): Understand the two main types of clients for managing API resources.
+        - [Streaming resources](https://docs.apify.com/api/client/python/docs/concepts/streaming-resources.md): Stream dataset items, key-value store records, and logs incrementally without downloading entirely into memory.
+        - [Integration with data libraries](https://docs.apify.com/api/client/python/docs/guides/integration-with-data-libraries.md): Load dataset items directly into a Pandas DataFrame for efficient manipulation and analysis.
+        - [Manage tasks for reusable input](https://docs.apify.com/api/client/python/docs/guides/manage-tasks-for-reusable-input.md): Create multiple tasks with different input configurations for the same Actor.
+        - [Passing input to Actor](https://docs.apify.com/api/client/python/docs/guides/passing-input-to-actor.md): Run an Actor and retrieve results by passing input data directly to the call method.
+        - [Retrieve Actor data](https://docs.apify.com/api/client/python/docs/guides/retrieve-actor-data.md): Retrieve, paginate, merge, and export Actor output data from datasets.
+        - [Quick start](https://docs.apify.com/api/client/python/docs/introduction/quick-start.md): Get started with the Apify API client for Python by running an Actor and retrieving results from its dataset.
+        - [Upgrading to v2](https://docs.apify.com/api/client/python/docs/upgrading/upgrading-to-v2.md): Breaking changes between Apify Python API Client v1.x and v2.0.
+      - [apify-client reference](https://docs.apify.com/api/client/python/reference.md)
+
+
+# SDK for JavaScript | Apify Documentation
+# Source: https://docs.apify.com/sdk/js/llms.txt
+
+
+## sdk
+
+      - [Apify SDK for JavaScript](https://docs.apify.com/sdk/js/docs/overview.md): The official library for creating Apify Actors in JavaScript, providing tools for web crawling, scraping, and automation at scale.
+        - [Changelog](https://docs.apify.com/sdk/js/docs/changelog.md)
+        - [Actor lifecycle](https://docs.apify.com/sdk/js/docs/concepts/actor-lifecycle.md): Understanding Actor lifecycle, initialization, and the Apify platform.
+        - [Running in Docker](https://docs.apify.com/sdk/js/docs/concepts/docker-images.md): Example Docker images to run your crawlers.
+        - [Environment Variables](https://docs.apify.com/sdk/js/docs/concepts/environment-variables.md): Environment variables used by Apify SDK.
+        - [Pay-per-event Monetization](https://docs.apify.com/sdk/js/docs/concepts/pay-per-event.md): Monetize your Actors using the pay-per-event pricing model.
+        - [Proxy Management](https://docs.apify.com/sdk/js/docs/concepts/proxy-management.md): IP address rotation and proxy configuration.
+        - [Request Storage](https://docs.apify.com/sdk/js/docs/concepts/request-storage.md): Request storage types for managing crawl queues.
+        - [Result Storage](https://docs.apify.com/sdk/js/docs/concepts/result-storage.md): Result storage types for saving crawl output.
+        - [Session Management](https://docs.apify.com/sdk/js/docs/concepts/session-management.md): SessionPool for managing browser sessions and cookies.
+        - [Quick start](https://docs.apify.com/sdk/js/docs/introduction/quick-start.md): Get started with the Apify SDK for JavaScript by creating your first Actor.
+        - [Accept user input](https://docs.apify.com/sdk/js/docs/guides/accept-user-input.md): Accept and log user input in your Actor.
+        - [Add data to dataset](https://docs.apify.com/sdk/js/docs/guides/add-data-to-dataset.md): Save data to the default dataset.
+        - [Basic crawler](https://docs.apify.com/sdk/js/docs/guides/basic-crawler.md): Bare-bones example using BasicCrawler.
+        - [Call actor](https://docs.apify.com/sdk/js/docs/guides/call-actor.md): Start an Apify Actor programmatically.
+        - [Cheerio crawler](https://docs.apify.com/sdk/js/docs/guides/cheerio-crawler.md): Crawl URLs using plain HTTP requests and parse HTML with Cheerio.
+        - [Crawl all links on a website](https://docs.apify.com/sdk/js/docs/guides/crawl-all-links.md): Use enqueueLinks() to crawl entire websites.
+        - [Crawl a sitemap](https://docs.apify.com/sdk/js/docs/guides/crawl-sitemap.md): Download and crawl URLs from a sitemap.
+        - [Playwright crawler](https://docs.apify.com/sdk/js/docs/guides/playwright-crawler.md): Use PlaywrightCrawler for browser-based crawling.
+        - [Puppeteer crawler](https://docs.apify.com/sdk/js/docs/guides/puppeteer-crawler.md): Use PuppeteerCrawler for browser-based crawling.
+        - [Setting up a TypeScript project](https://docs.apify.com/sdk/js/docs/guides/type-script-actor.md): TypeScript support in Apify SDK.
+        - [Upgrading to v3](https://docs.apify.com/sdk/js/docs/upgrading/upgrading-to-v3.md): Breaking changes between Crawlee (v3) and Apify SDK (v2).
+    - [apify reference](https://docs.apify.com/sdk/js/reference.md)
+
+
+# SDK for Python | Apify Documentation
+# Source: https://docs.apify.com/sdk/python/llms.txt
+
+
+## sdk
+
+      - [Overview](https://docs.apify.com/sdk/python/docs/overview.md): The official library for creating Apify Actors in Python, providing tools for web scraping, automation, and data storage integration.
+        - [Changelog](https://docs.apify.com/sdk/python/docs/changelog.md)
+        - [Accessing Apify API](https://docs.apify.com/sdk/python/docs/concepts/access-apify-api.md): Access Apify API features not covered by the SDK.
+        - [Actor configuration](https://docs.apify.com/sdk/python/docs/concepts/actor-configuration.md): Configure the Actor class using the Configuration class and environment variables.
+        - [Actor events & state persistence](https://docs.apify.com/sdk/python/docs/concepts/actor-events.md): Handle Actor events sent by the Apify platform during runtime.
+        - [Actor input](https://docs.apify.com/sdk/python/docs/concepts/actor-input.md): Read Actor input from the default key-value store.
+        - [Actor lifecycle](https://docs.apify.com/sdk/python/docs/concepts/actor-lifecycle.md): How an Apify Actor starts, runs, and shuts down.
+        - [Interacting with other Actors](https://docs.apify.com/sdk/python/docs/concepts/interacting-with-other-actors.md): Methods to interact with other Actors and tasks on the platform.
+        - [Logging](https://docs.apify.com/sdk/python/docs/concepts/logging.md): Logging through Python's standard logging module.
+        - [Pay-per-event monetization](https://docs.apify.com/sdk/python/docs/concepts/pay-per-event.md): Monetize your Actors using the pay-per-event pricing model.
+        - [Proxy management](https://docs.apify.com/sdk/python/docs/concepts/proxy-management.md): Work around IP blocking using proxy servers.
+        - [Working with storages](https://docs.apify.com/sdk/python/docs/concepts/storages.md): Work with default or named storages for datasets, key-value stores, and request queues.
+        - [Creating webhooks](https://docs.apify.com/sdk/python/docs/concepts/webhooks.md): Configure webhooks to trigger actions on Actor events.
+        - [Quick start](https://docs.apify.com/sdk/python/docs/introduction/quick-start.md): Get started with the Apify SDK for Python by creating your first Actor.
+        - [Using BeautifulSoup with HTTPX](https://docs.apify.com/sdk/python/docs/guides/beautifulsoup-httpx.md): Use BeautifulSoup with HTTPX in your Actors.
+        - [Using Crawlee](https://docs.apify.com/sdk/python/docs/guides/crawlee.md): Use the Crawlee library in your Actors.
+        - [Using Parsel with Impit](https://docs.apify.com/sdk/python/docs/guides/parsel-impit.md): Combine Parsel and Impit libraries for scraping.
+        - [Using Playwright](https://docs.apify.com/sdk/python/docs/guides/playwright.md): Use Playwright for web scraping in your Actors.
+        - [Running webserver](https://docs.apify.com/sdk/python/docs/guides/running-webserver.md): Run a web server inside your Actor.
+        - [Using Scrapy](https://docs.apify.com/sdk/python/docs/guides/scrapy.md): Use the Scrapy framework in your Actors.
+        - [Using Selenium](https://docs.apify.com/sdk/python/docs/guides/selenium.md): Use Selenium for web scraping in your Actors.
+        - [Upgrading to v3](https://docs.apify.com/sdk/python/docs/upgrading/upgrading-to-v3.md): Breaking changes between Apify Python SDK v2.x and v3.0.
+    - [apify-sdk-python reference](https://docs.apify.com/sdk/python/reference.md)
+
+
+# CLI | Apify Documentation
+# Source: https://docs.apify.com/cli/llms.txt
+
+
+## cli
+
+  - [Apify CLI overview](https://docs.apify.com/cli/docs.md): An introduction to Apify CLI, a command-line interface for creating, developing, building, and running Apify Actors and managing the Apify cloud platform.
+    - [Changelog](https://docs.apify.com/cli/docs/changelog.md)
+    - [Installation](https://docs.apify.com/cli/docs/installation.md): Learn how to install Apify CLI using installation scripts, Homebrew, or NPM.
+    - [Integrating Scrapy projects](https://docs.apify.com/cli/docs/integrating-scrapy.md): Learn how to run Scrapy projects as Apify Actors and deploy them on the Apify platform.
+    - [Quick start](https://docs.apify.com/cli/docs/quick-start.md): Learn how to create, run, and manage Actors using Apify CLI.
+    - [Command reference](https://docs.apify.com/cli/docs/reference.md): The Apify CLI provides tools for managing your Apify projects and resources from the command line.
+    - [Telemetry](https://docs.apify.com/cli/docs/telemetry.md): Apify collects telemetry data about the general usage of the CLI.

--- a/scripts/llms-external-curated.txt
+++ b/scripts/llms-external-curated.txt
@@ -2,95 +2,95 @@
 ## Apify API client for JavaScript
 
 - [Overview](https://docs.apify.com/api/client/js/docs.md): The official JavaScript library to access the Apify API, with automatic retries, TypeScript support, and cross-platform compatibility.
-  - [Changelog](https://docs.apify.com/api/client/js/docs/changelog.md)
-  - [Use in bundled environments](https://docs.apify.com/api/client/js/docs/concepts/bundled-environments.md): Use the Apify API client for JavaScript in browsers, Cloudflare Workers, and other edge runtimes.
+  - [Quick start](https://docs.apify.com/api/client/js/docs/introduction/quick-start.md): Get started with the Apify API client for JavaScript by running an Actor and retrieving results from its dataset.
+  - [Usage patterns](https://docs.apify.com/api/client/js/docs/concepts/usage-patterns.md): Learn the resource client and collection client patterns used by the Apify API client for JavaScript.
   - [Convenience functions](https://docs.apify.com/api/client/js/docs/concepts/convenience-functions.md): Use call(), waitForFinish(), and other convenience functions in the Apify API client for JavaScript.
   - [Error handling and retries](https://docs.apify.com/api/client/js/docs/concepts/error-handling.md): Handle API errors and configure automatic retries with exponential backoff in the Apify API client for JavaScript.
   - [Pagination](https://docs.apify.com/api/client/js/docs/concepts/pagination.md): Paginate through large result sets and use async iteration with the Apify API client for JavaScript.
-  - [Usage patterns](https://docs.apify.com/api/client/js/docs/concepts/usage-patterns.md): Learn the resource client and collection client patterns used by the Apify API client for JavaScript.
+  - [Use in bundled environments](https://docs.apify.com/api/client/js/docs/concepts/bundled-environments.md): Use the Apify API client for JavaScript in browsers, Cloudflare Workers, and other edge runtimes.
   - [Code examples](https://docs.apify.com/api/client/js/docs/guides/examples.md): Practical code examples for common tasks with the Apify API client for JavaScript, including webhooks and datasets.
-  - [Quick start](https://docs.apify.com/api/client/js/docs/introduction/quick-start.md): Get started with the Apify API client for JavaScript by running an Actor and retrieving results from its dataset.
+  - [Changelog](https://docs.apify.com/api/client/js/docs/changelog.md)
 - [apify-client reference](https://docs.apify.com/api/client/js/reference.md)
 
 ## Apify API client for Python
 
 - [Overview](https://docs.apify.com/api/client/python/docs.md): The official Python library to access the Apify API, with automatic retries, async support, and comprehensive API coverage.
-  - [Changelog](https://docs.apify.com/api/client/python/docs/changelog.md)
-  - [Asyncio support](https://docs.apify.com/api/client/python/docs/concepts/asyncio-support.md): Use the asynchronous ApifyClientAsync to interact with the Apify API using Python's async/await syntax.
+  - [Quick start](https://docs.apify.com/api/client/python/docs/introduction/quick-start.md): Get started with the Apify API client for Python by running an Actor and retrieving results from its dataset.
+  - [Single and collection clients](https://docs.apify.com/api/client/python/docs/concepts/single-and-collection-clients.md): Understand the two main types of clients for managing API resources.
   - [Convenience methods](https://docs.apify.com/api/client/python/docs/concepts/convenience-methods.md): Convenience methods to handle actions that the API alone cannot perform efficiently.
   - [Error handling](https://docs.apify.com/api/client/python/docs/concepts/error-handling.md): The client automatically extracts data, converts date strings to datetime objects, and raises ApifyApiError on errors.
-  - [Logging](https://docs.apify.com/api/client/python/docs/concepts/logging.md): Configure the apify_client logger to print debug information about API requests.
-  - [Nested clients](https://docs.apify.com/api/client/python/docs/concepts/nested-clients.md): Use nested clients to simplify working with related collections like Actor runs.
   - [Pagination](https://docs.apify.com/api/client/python/docs/concepts/pagination.md): Work with paginated data using the ListPage object returned by list methods.
+  - [Asyncio support](https://docs.apify.com/api/client/python/docs/concepts/asyncio-support.md): Use the asynchronous ApifyClientAsync to interact with the Apify API using Python's async/await syntax.
   - [Retries](https://docs.apify.com/api/client/python/docs/concepts/retries.md): Automatic retries for requests that fail due to network issues or rate limiting.
-  - [Single and collection clients](https://docs.apify.com/api/client/python/docs/concepts/single-and-collection-clients.md): Understand the two main types of clients for managing API resources.
+  - [Nested clients](https://docs.apify.com/api/client/python/docs/concepts/nested-clients.md): Use nested clients to simplify working with related collections like Actor runs.
   - [Streaming resources](https://docs.apify.com/api/client/python/docs/concepts/streaming-resources.md): Stream dataset items, key-value store records, and logs incrementally without downloading entirely into memory.
-  - [Integration with data libraries](https://docs.apify.com/api/client/python/docs/guides/integration-with-data-libraries.md): Load dataset items directly into a Pandas DataFrame for efficient manipulation and analysis.
-  - [Manage tasks for reusable input](https://docs.apify.com/api/client/python/docs/guides/manage-tasks-for-reusable-input.md): Create multiple tasks with different input configurations for the same Actor.
+  - [Logging](https://docs.apify.com/api/client/python/docs/concepts/logging.md): Configure the apify_client logger to print debug information about API requests.
   - [Passing input to Actor](https://docs.apify.com/api/client/python/docs/guides/passing-input-to-actor.md): Run an Actor and retrieve results by passing input data directly to the call method.
   - [Retrieve Actor data](https://docs.apify.com/api/client/python/docs/guides/retrieve-actor-data.md): Retrieve, paginate, merge, and export Actor output data from datasets.
-  - [Quick start](https://docs.apify.com/api/client/python/docs/introduction/quick-start.md): Get started with the Apify API client for Python by running an Actor and retrieving results from its dataset.
+  - [Manage tasks for reusable input](https://docs.apify.com/api/client/python/docs/guides/manage-tasks-for-reusable-input.md): Create multiple tasks with different input configurations for the same Actor.
+  - [Integration with data libraries](https://docs.apify.com/api/client/python/docs/guides/integration-with-data-libraries.md): Load dataset items directly into a Pandas DataFrame for efficient manipulation and analysis.
   - [Upgrading to v2](https://docs.apify.com/api/client/python/docs/upgrading/upgrading-to-v2.md): Breaking changes between Apify Python API Client v1.x and v2.0.
+  - [Changelog](https://docs.apify.com/api/client/python/docs/changelog.md)
 - [apify-client reference](https://docs.apify.com/api/client/python/reference.md)
 
 ## Apify SDK for JavaScript
 
 - [Apify SDK for JavaScript](https://docs.apify.com/sdk/js/docs/overview.md): The official library for creating Apify Actors in JavaScript, providing tools for web crawling, scraping, and automation at scale.
-  - [Changelog](https://docs.apify.com/sdk/js/docs/changelog.md)
+  - [Quick start](https://docs.apify.com/sdk/js/docs/introduction/quick-start.md): Get started with the Apify SDK for JavaScript by creating your first Actor.
   - [Actor lifecycle](https://docs.apify.com/sdk/js/docs/concepts/actor-lifecycle.md): Understanding Actor lifecycle, initialization, and the Apify platform.
-  - [Running in Docker](https://docs.apify.com/sdk/js/docs/concepts/docker-images.md): Example Docker images to run your crawlers.
   - [Environment Variables](https://docs.apify.com/sdk/js/docs/concepts/environment-variables.md): Environment variables used by Apify SDK.
-  - [Pay-per-event Monetization](https://docs.apify.com/sdk/js/docs/concepts/pay-per-event.md): Monetize your Actors using the pay-per-event pricing model.
   - [Proxy Management](https://docs.apify.com/sdk/js/docs/concepts/proxy-management.md): IP address rotation and proxy configuration.
   - [Request Storage](https://docs.apify.com/sdk/js/docs/concepts/request-storage.md): Request storage types for managing crawl queues.
   - [Result Storage](https://docs.apify.com/sdk/js/docs/concepts/result-storage.md): Result storage types for saving crawl output.
   - [Session Management](https://docs.apify.com/sdk/js/docs/concepts/session-management.md): SessionPool for managing browser sessions and cookies.
-  - [Quick start](https://docs.apify.com/sdk/js/docs/introduction/quick-start.md): Get started with the Apify SDK for JavaScript by creating your first Actor.
-  - [Accept user input](https://docs.apify.com/sdk/js/docs/guides/accept-user-input.md): Accept and log user input in your Actor.
-  - [Add data to dataset](https://docs.apify.com/sdk/js/docs/guides/add-data-to-dataset.md): Save data to the default dataset.
+  - [Running in Docker](https://docs.apify.com/sdk/js/docs/concepts/docker-images.md): Example Docker images to run your crawlers.
+  - [Pay-per-event Monetization](https://docs.apify.com/sdk/js/docs/concepts/pay-per-event.md): Monetize your Actors using the pay-per-event pricing model.
   - [Basic crawler](https://docs.apify.com/sdk/js/docs/guides/basic-crawler.md): Bare-bones example using BasicCrawler.
-  - [Call actor](https://docs.apify.com/sdk/js/docs/guides/call-actor.md): Start an Apify Actor programmatically.
   - [Cheerio crawler](https://docs.apify.com/sdk/js/docs/guides/cheerio-crawler.md): Crawl URLs using plain HTTP requests and parse HTML with Cheerio.
-  - [Crawl all links on a website](https://docs.apify.com/sdk/js/docs/guides/crawl-all-links.md): Use enqueueLinks() to crawl entire websites.
-  - [Crawl a sitemap](https://docs.apify.com/sdk/js/docs/guides/crawl-sitemap.md): Download and crawl URLs from a sitemap.
   - [Playwright crawler](https://docs.apify.com/sdk/js/docs/guides/playwright-crawler.md): Use PlaywrightCrawler for browser-based crawling.
   - [Puppeteer crawler](https://docs.apify.com/sdk/js/docs/guides/puppeteer-crawler.md): Use PuppeteerCrawler for browser-based crawling.
+  - [Crawl all links on a website](https://docs.apify.com/sdk/js/docs/guides/crawl-all-links.md): Use enqueueLinks() to crawl entire websites.
+  - [Crawl a sitemap](https://docs.apify.com/sdk/js/docs/guides/crawl-sitemap.md): Download and crawl URLs from a sitemap.
+  - [Accept user input](https://docs.apify.com/sdk/js/docs/guides/accept-user-input.md): Accept and log user input in your Actor.
+  - [Add data to dataset](https://docs.apify.com/sdk/js/docs/guides/add-data-to-dataset.md): Save data to the default dataset.
+  - [Call actor](https://docs.apify.com/sdk/js/docs/guides/call-actor.md): Start an Apify Actor programmatically.
   - [Setting up a TypeScript project](https://docs.apify.com/sdk/js/docs/guides/type-script-actor.md): TypeScript support in Apify SDK.
   - [Upgrading to v3](https://docs.apify.com/sdk/js/docs/upgrading/upgrading-to-v3.md): Breaking changes between Crawlee (v3) and Apify SDK (v2).
+  - [Changelog](https://docs.apify.com/sdk/js/docs/changelog.md)
 - [apify reference](https://docs.apify.com/sdk/js/reference.md)
 
 ## Apify SDK for Python
 
 - [Overview](https://docs.apify.com/sdk/python/docs/overview.md): The official library for creating Apify Actors in Python, providing tools for web scraping, automation, and data storage integration.
-  - [Changelog](https://docs.apify.com/sdk/python/docs/changelog.md)
-  - [Accessing Apify API](https://docs.apify.com/sdk/python/docs/concepts/access-apify-api.md): Access Apify API features not covered by the SDK.
+  - [Quick start](https://docs.apify.com/sdk/python/docs/introduction/quick-start.md): Get started with the Apify SDK for Python by creating your first Actor.
+  - [Actor lifecycle](https://docs.apify.com/sdk/python/docs/concepts/actor-lifecycle.md): How an Apify Actor starts, runs, and shuts down.
+  - [Actor input](https://docs.apify.com/sdk/python/docs/concepts/actor-input.md): Read Actor input from the default key-value store.
   - [Actor configuration](https://docs.apify.com/sdk/python/docs/concepts/actor-configuration.md): Configure the Actor class using the Configuration class and environment variables.
   - [Actor events & state persistence](https://docs.apify.com/sdk/python/docs/concepts/actor-events.md): Handle Actor events sent by the Apify platform during runtime.
-  - [Actor input](https://docs.apify.com/sdk/python/docs/concepts/actor-input.md): Read Actor input from the default key-value store.
-  - [Actor lifecycle](https://docs.apify.com/sdk/python/docs/concepts/actor-lifecycle.md): How an Apify Actor starts, runs, and shuts down.
+  - [Working with storages](https://docs.apify.com/sdk/python/docs/concepts/storages.md): Work with default or named storages for datasets, key-value stores, and request queues.
+  - [Proxy management](https://docs.apify.com/sdk/python/docs/concepts/proxy-management.md): Work around IP blocking using proxy servers.
   - [Interacting with other Actors](https://docs.apify.com/sdk/python/docs/concepts/interacting-with-other-actors.md): Methods to interact with other Actors and tasks on the platform.
+  - [Accessing Apify API](https://docs.apify.com/sdk/python/docs/concepts/access-apify-api.md): Access Apify API features not covered by the SDK.
+  - [Creating webhooks](https://docs.apify.com/sdk/python/docs/concepts/webhooks.md): Configure webhooks to trigger actions on Actor events.
   - [Logging](https://docs.apify.com/sdk/python/docs/concepts/logging.md): Logging through Python's standard logging module.
   - [Pay-per-event monetization](https://docs.apify.com/sdk/python/docs/concepts/pay-per-event.md): Monetize your Actors using the pay-per-event pricing model.
-  - [Proxy management](https://docs.apify.com/sdk/python/docs/concepts/proxy-management.md): Work around IP blocking using proxy servers.
-  - [Working with storages](https://docs.apify.com/sdk/python/docs/concepts/storages.md): Work with default or named storages for datasets, key-value stores, and request queues.
-  - [Creating webhooks](https://docs.apify.com/sdk/python/docs/concepts/webhooks.md): Configure webhooks to trigger actions on Actor events.
-  - [Quick start](https://docs.apify.com/sdk/python/docs/introduction/quick-start.md): Get started with the Apify SDK for Python by creating your first Actor.
-  - [Using BeautifulSoup with HTTPX](https://docs.apify.com/sdk/python/docs/guides/beautifulsoup-httpx.md): Use BeautifulSoup with HTTPX in your Actors.
   - [Using Crawlee](https://docs.apify.com/sdk/python/docs/guides/crawlee.md): Use the Crawlee library in your Actors.
-  - [Using Parsel with Impit](https://docs.apify.com/sdk/python/docs/guides/parsel-impit.md): Combine Parsel and Impit libraries for scraping.
+  - [Using BeautifulSoup with HTTPX](https://docs.apify.com/sdk/python/docs/guides/beautifulsoup-httpx.md): Use BeautifulSoup with HTTPX in your Actors.
   - [Using Playwright](https://docs.apify.com/sdk/python/docs/guides/playwright.md): Use Playwright for web scraping in your Actors.
-  - [Running webserver](https://docs.apify.com/sdk/python/docs/guides/running-webserver.md): Run a web server inside your Actor.
   - [Using Scrapy](https://docs.apify.com/sdk/python/docs/guides/scrapy.md): Use the Scrapy framework in your Actors.
   - [Using Selenium](https://docs.apify.com/sdk/python/docs/guides/selenium.md): Use Selenium for web scraping in your Actors.
+  - [Using Parsel with Impit](https://docs.apify.com/sdk/python/docs/guides/parsel-impit.md): Combine Parsel and Impit libraries for scraping.
+  - [Running webserver](https://docs.apify.com/sdk/python/docs/guides/running-webserver.md): Run a web server inside your Actor.
   - [Upgrading to v3](https://docs.apify.com/sdk/python/docs/upgrading/upgrading-to-v3.md): Breaking changes between Apify Python SDK v2.x and v3.0.
+  - [Changelog](https://docs.apify.com/sdk/python/docs/changelog.md)
 - [apify-sdk-python reference](https://docs.apify.com/sdk/python/reference.md)
 
 ## Apify CLI
 
 - [Apify CLI overview](https://docs.apify.com/cli/docs.md): An introduction to Apify CLI, a command-line interface for creating, developing, building, and running Apify Actors and managing the Apify cloud platform.
-  - [Changelog](https://docs.apify.com/cli/docs/changelog.md)
-  - [Installation](https://docs.apify.com/cli/docs/installation.md): Learn how to install Apify CLI using installation scripts, Homebrew, or NPM.
-  - [Integrating Scrapy projects](https://docs.apify.com/cli/docs/integrating-scrapy.md): Learn how to run Scrapy projects as Apify Actors and deploy them on the Apify platform.
   - [Quick start](https://docs.apify.com/cli/docs/quick-start.md): Learn how to create, run, and manage Actors using Apify CLI.
+  - [Installation](https://docs.apify.com/cli/docs/installation.md): Learn how to install Apify CLI using installation scripts, Homebrew, or NPM.
   - [Command reference](https://docs.apify.com/cli/docs/reference.md): The Apify CLI provides tools for managing your Apify projects and resources from the command line.
+  - [Integrating Scrapy projects](https://docs.apify.com/cli/docs/integrating-scrapy.md): Learn how to run Scrapy projects as Apify Actors and deploy them on the Apify platform.
   - [Telemetry](https://docs.apify.com/cli/docs/telemetry.md): Apify collects telemetry data about the general usage of the CLI.
+  - [Changelog](https://docs.apify.com/cli/docs/changelog.md)

--- a/scripts/llms-external-curated.txt
+++ b/scripts/llms-external-curated.txt
@@ -1,8 +1,6 @@
 
 ## Apify API client for JavaScript
 
-> Source: https://docs.apify.com/api/client/js/llms.txt — this is a curated subset. Update when new concept/guide pages are added.
-
 - [Overview](https://docs.apify.com/api/client/js/docs.md): The official JavaScript library to access the Apify API, with automatic retries, TypeScript support, and cross-platform compatibility.
   - [Changelog](https://docs.apify.com/api/client/js/docs/changelog.md)
   - [Use in bundled environments](https://docs.apify.com/api/client/js/docs/concepts/bundled-environments.md): Use the Apify API client for JavaScript in browsers, Cloudflare Workers, and other edge runtimes.
@@ -15,8 +13,6 @@
 - [apify-client reference](https://docs.apify.com/api/client/js/reference.md)
 
 ## Apify API client for Python
-
-> Source: https://docs.apify.com/api/client/python/llms.txt
 
 - [Overview](https://docs.apify.com/api/client/python/docs.md): The official Python library to access the Apify API, with automatic retries, async support, and comprehensive API coverage.
   - [Changelog](https://docs.apify.com/api/client/python/docs/changelog.md)
@@ -38,8 +34,6 @@
 - [apify-client reference](https://docs.apify.com/api/client/python/reference.md)
 
 ## Apify SDK for JavaScript
-
-> Source: https://docs.apify.com/sdk/js/llms.txt
 
 - [Apify SDK for JavaScript](https://docs.apify.com/sdk/js/docs/overview.md): The official library for creating Apify Actors in JavaScript, providing tools for web crawling, scraping, and automation at scale.
   - [Changelog](https://docs.apify.com/sdk/js/docs/changelog.md)
@@ -67,8 +61,6 @@
 
 ## Apify SDK for Python
 
-> Source: https://docs.apify.com/sdk/python/llms.txt
-
 - [Overview](https://docs.apify.com/sdk/python/docs/overview.md): The official library for creating Apify Actors in Python, providing tools for web scraping, automation, and data storage integration.
   - [Changelog](https://docs.apify.com/sdk/python/docs/changelog.md)
   - [Accessing Apify API](https://docs.apify.com/sdk/python/docs/concepts/access-apify-api.md): Access Apify API features not covered by the SDK.
@@ -94,8 +86,6 @@
 - [apify-sdk-python reference](https://docs.apify.com/sdk/python/reference.md)
 
 ## Apify CLI
-
-> Source: https://docs.apify.com/cli/llms.txt
 
 - [Apify CLI overview](https://docs.apify.com/cli/docs.md): An introduction to Apify CLI, a command-line interface for creating, developing, building, and running Apify Actors and managing the Apify cloud platform.
   - [Changelog](https://docs.apify.com/cli/docs/changelog.md)

--- a/scripts/llms-external-curated.txt
+++ b/scripts/llms-external-curated.txt
@@ -1,120 +1,106 @@
-# API client for JavaScript | Apify Documentation
-# Source: https://docs.apify.com/api/client/js/llms.txt
-# This is a curated subset of the full llms.txt. Update when new concept/guide pages are added.
 
+## Apify API client for JavaScript
 
-## api
+> Source: https://docs.apify.com/api/client/js/llms.txt — this is a curated subset. Update when new concept/guide pages are added.
 
-      - [Overview](https://docs.apify.com/api/client/js/docs.md): The official JavaScript library to access the Apify API, with automatic retries, TypeScript support, and cross-platform compatibility.
-        - [Changelog](https://docs.apify.com/api/client/js/docs/changelog.md)
-        - [Use in bundled environments](https://docs.apify.com/api/client/js/docs/concepts/bundled-environments.md): Use the Apify API client for JavaScript in browsers, Cloudflare Workers, and other edge runtimes.
-        - [Convenience functions](https://docs.apify.com/api/client/js/docs/concepts/convenience-functions.md): Use call(), waitForFinish(), and other convenience functions in the Apify API client for JavaScript.
-        - [Error handling and retries](https://docs.apify.com/api/client/js/docs/concepts/error-handling.md): Handle API errors and configure automatic retries with exponential backoff in the Apify API client for JavaScript.
-        - [Pagination](https://docs.apify.com/api/client/js/docs/concepts/pagination.md): Paginate through large result sets and use async iteration with the Apify API client for JavaScript.
-        - [Usage patterns](https://docs.apify.com/api/client/js/docs/concepts/usage-patterns.md): Learn the resource client and collection client patterns used by the Apify API client for JavaScript.
-        - [Code examples](https://docs.apify.com/api/client/js/docs/guides/examples.md): Practical code examples for common tasks with the Apify API client for JavaScript, including webhooks and datasets.
-        - [Quick start](https://docs.apify.com/api/client/js/docs/introduction/quick-start.md): Get started with the Apify API client for JavaScript by running an Actor and retrieving results from its dataset.
-      - [apify-client reference](https://docs.apify.com/api/client/js/reference.md)
+- [Overview](https://docs.apify.com/api/client/js/docs.md): The official JavaScript library to access the Apify API, with automatic retries, TypeScript support, and cross-platform compatibility.
+  - [Changelog](https://docs.apify.com/api/client/js/docs/changelog.md)
+  - [Use in bundled environments](https://docs.apify.com/api/client/js/docs/concepts/bundled-environments.md): Use the Apify API client for JavaScript in browsers, Cloudflare Workers, and other edge runtimes.
+  - [Convenience functions](https://docs.apify.com/api/client/js/docs/concepts/convenience-functions.md): Use call(), waitForFinish(), and other convenience functions in the Apify API client for JavaScript.
+  - [Error handling and retries](https://docs.apify.com/api/client/js/docs/concepts/error-handling.md): Handle API errors and configure automatic retries with exponential backoff in the Apify API client for JavaScript.
+  - [Pagination](https://docs.apify.com/api/client/js/docs/concepts/pagination.md): Paginate through large result sets and use async iteration with the Apify API client for JavaScript.
+  - [Usage patterns](https://docs.apify.com/api/client/js/docs/concepts/usage-patterns.md): Learn the resource client and collection client patterns used by the Apify API client for JavaScript.
+  - [Code examples](https://docs.apify.com/api/client/js/docs/guides/examples.md): Practical code examples for common tasks with the Apify API client for JavaScript, including webhooks and datasets.
+  - [Quick start](https://docs.apify.com/api/client/js/docs/introduction/quick-start.md): Get started with the Apify API client for JavaScript by running an Actor and retrieving results from its dataset.
+- [apify-client reference](https://docs.apify.com/api/client/js/reference.md)
 
+## Apify API client for Python
 
-# API client for Python | Apify Documentation
-# Source: https://docs.apify.com/api/client/python/llms.txt
+> Source: https://docs.apify.com/api/client/python/llms.txt
 
+- [Overview](https://docs.apify.com/api/client/python/docs.md): The official Python library to access the Apify API, with automatic retries, async support, and comprehensive API coverage.
+  - [Changelog](https://docs.apify.com/api/client/python/docs/changelog.md)
+  - [Asyncio support](https://docs.apify.com/api/client/python/docs/concepts/asyncio-support.md): Use the asynchronous ApifyClientAsync to interact with the Apify API using Python's async/await syntax.
+  - [Convenience methods](https://docs.apify.com/api/client/python/docs/concepts/convenience-methods.md): Convenience methods to handle actions that the API alone cannot perform efficiently.
+  - [Error handling](https://docs.apify.com/api/client/python/docs/concepts/error-handling.md): The client automatically extracts data, converts date strings to datetime objects, and raises ApifyApiError on errors.
+  - [Logging](https://docs.apify.com/api/client/python/docs/concepts/logging.md): Configure the apify_client logger to print debug information about API requests.
+  - [Nested clients](https://docs.apify.com/api/client/python/docs/concepts/nested-clients.md): Use nested clients to simplify working with related collections like Actor runs.
+  - [Pagination](https://docs.apify.com/api/client/python/docs/concepts/pagination.md): Work with paginated data using the ListPage object returned by list methods.
+  - [Retries](https://docs.apify.com/api/client/python/docs/concepts/retries.md): Automatic retries for requests that fail due to network issues or rate limiting.
+  - [Single and collection clients](https://docs.apify.com/api/client/python/docs/concepts/single-and-collection-clients.md): Understand the two main types of clients for managing API resources.
+  - [Streaming resources](https://docs.apify.com/api/client/python/docs/concepts/streaming-resources.md): Stream dataset items, key-value store records, and logs incrementally without downloading entirely into memory.
+  - [Integration with data libraries](https://docs.apify.com/api/client/python/docs/guides/integration-with-data-libraries.md): Load dataset items directly into a Pandas DataFrame for efficient manipulation and analysis.
+  - [Manage tasks for reusable input](https://docs.apify.com/api/client/python/docs/guides/manage-tasks-for-reusable-input.md): Create multiple tasks with different input configurations for the same Actor.
+  - [Passing input to Actor](https://docs.apify.com/api/client/python/docs/guides/passing-input-to-actor.md): Run an Actor and retrieve results by passing input data directly to the call method.
+  - [Retrieve Actor data](https://docs.apify.com/api/client/python/docs/guides/retrieve-actor-data.md): Retrieve, paginate, merge, and export Actor output data from datasets.
+  - [Quick start](https://docs.apify.com/api/client/python/docs/introduction/quick-start.md): Get started with the Apify API client for Python by running an Actor and retrieving results from its dataset.
+  - [Upgrading to v2](https://docs.apify.com/api/client/python/docs/upgrading/upgrading-to-v2.md): Breaking changes between Apify Python API Client v1.x and v2.0.
+- [apify-client reference](https://docs.apify.com/api/client/python/reference.md)
 
-## api
+## Apify SDK for JavaScript
 
-      - [Overview](https://docs.apify.com/api/client/python/docs.md): The official Python library to access the Apify API, with automatic retries, async support, and comprehensive API coverage.
-        - [Changelog](https://docs.apify.com/api/client/python/docs/changelog.md)
-        - [Asyncio support](https://docs.apify.com/api/client/python/docs/concepts/asyncio-support.md): Use the asynchronous ApifyClientAsync to interact with the Apify API using Python's async/await syntax.
-        - [Convenience methods](https://docs.apify.com/api/client/python/docs/concepts/convenience-methods.md): Convenience methods to handle actions that the API alone cannot perform efficiently.
-        - [Error handling](https://docs.apify.com/api/client/python/docs/concepts/error-handling.md): The client automatically extracts data, converts date strings to datetime objects, and raises ApifyApiError on errors.
-        - [Logging](https://docs.apify.com/api/client/python/docs/concepts/logging.md): Configure the apify_client logger to print debug information about API requests.
-        - [Nested clients](https://docs.apify.com/api/client/python/docs/concepts/nested-clients.md): Use nested clients to simplify working with related collections like Actor runs.
-        - [Pagination](https://docs.apify.com/api/client/python/docs/concepts/pagination.md): Work with paginated data using the ListPage object returned by list methods.
-        - [Retries](https://docs.apify.com/api/client/python/docs/concepts/retries.md): Automatic retries for requests that fail due to network issues or rate limiting.
-        - [Single and collection clients](https://docs.apify.com/api/client/python/docs/concepts/single-and-collection-clients.md): Understand the two main types of clients for managing API resources.
-        - [Streaming resources](https://docs.apify.com/api/client/python/docs/concepts/streaming-resources.md): Stream dataset items, key-value store records, and logs incrementally without downloading entirely into memory.
-        - [Integration with data libraries](https://docs.apify.com/api/client/python/docs/guides/integration-with-data-libraries.md): Load dataset items directly into a Pandas DataFrame for efficient manipulation and analysis.
-        - [Manage tasks for reusable input](https://docs.apify.com/api/client/python/docs/guides/manage-tasks-for-reusable-input.md): Create multiple tasks with different input configurations for the same Actor.
-        - [Passing input to Actor](https://docs.apify.com/api/client/python/docs/guides/passing-input-to-actor.md): Run an Actor and retrieve results by passing input data directly to the call method.
-        - [Retrieve Actor data](https://docs.apify.com/api/client/python/docs/guides/retrieve-actor-data.md): Retrieve, paginate, merge, and export Actor output data from datasets.
-        - [Quick start](https://docs.apify.com/api/client/python/docs/introduction/quick-start.md): Get started with the Apify API client for Python by running an Actor and retrieving results from its dataset.
-        - [Upgrading to v2](https://docs.apify.com/api/client/python/docs/upgrading/upgrading-to-v2.md): Breaking changes between Apify Python API Client v1.x and v2.0.
-      - [apify-client reference](https://docs.apify.com/api/client/python/reference.md)
+> Source: https://docs.apify.com/sdk/js/llms.txt
 
+- [Apify SDK for JavaScript](https://docs.apify.com/sdk/js/docs/overview.md): The official library for creating Apify Actors in JavaScript, providing tools for web crawling, scraping, and automation at scale.
+  - [Changelog](https://docs.apify.com/sdk/js/docs/changelog.md)
+  - [Actor lifecycle](https://docs.apify.com/sdk/js/docs/concepts/actor-lifecycle.md): Understanding Actor lifecycle, initialization, and the Apify platform.
+  - [Running in Docker](https://docs.apify.com/sdk/js/docs/concepts/docker-images.md): Example Docker images to run your crawlers.
+  - [Environment Variables](https://docs.apify.com/sdk/js/docs/concepts/environment-variables.md): Environment variables used by Apify SDK.
+  - [Pay-per-event Monetization](https://docs.apify.com/sdk/js/docs/concepts/pay-per-event.md): Monetize your Actors using the pay-per-event pricing model.
+  - [Proxy Management](https://docs.apify.com/sdk/js/docs/concepts/proxy-management.md): IP address rotation and proxy configuration.
+  - [Request Storage](https://docs.apify.com/sdk/js/docs/concepts/request-storage.md): Request storage types for managing crawl queues.
+  - [Result Storage](https://docs.apify.com/sdk/js/docs/concepts/result-storage.md): Result storage types for saving crawl output.
+  - [Session Management](https://docs.apify.com/sdk/js/docs/concepts/session-management.md): SessionPool for managing browser sessions and cookies.
+  - [Quick start](https://docs.apify.com/sdk/js/docs/introduction/quick-start.md): Get started with the Apify SDK for JavaScript by creating your first Actor.
+  - [Accept user input](https://docs.apify.com/sdk/js/docs/guides/accept-user-input.md): Accept and log user input in your Actor.
+  - [Add data to dataset](https://docs.apify.com/sdk/js/docs/guides/add-data-to-dataset.md): Save data to the default dataset.
+  - [Basic crawler](https://docs.apify.com/sdk/js/docs/guides/basic-crawler.md): Bare-bones example using BasicCrawler.
+  - [Call actor](https://docs.apify.com/sdk/js/docs/guides/call-actor.md): Start an Apify Actor programmatically.
+  - [Cheerio crawler](https://docs.apify.com/sdk/js/docs/guides/cheerio-crawler.md): Crawl URLs using plain HTTP requests and parse HTML with Cheerio.
+  - [Crawl all links on a website](https://docs.apify.com/sdk/js/docs/guides/crawl-all-links.md): Use enqueueLinks() to crawl entire websites.
+  - [Crawl a sitemap](https://docs.apify.com/sdk/js/docs/guides/crawl-sitemap.md): Download and crawl URLs from a sitemap.
+  - [Playwright crawler](https://docs.apify.com/sdk/js/docs/guides/playwright-crawler.md): Use PlaywrightCrawler for browser-based crawling.
+  - [Puppeteer crawler](https://docs.apify.com/sdk/js/docs/guides/puppeteer-crawler.md): Use PuppeteerCrawler for browser-based crawling.
+  - [Setting up a TypeScript project](https://docs.apify.com/sdk/js/docs/guides/type-script-actor.md): TypeScript support in Apify SDK.
+  - [Upgrading to v3](https://docs.apify.com/sdk/js/docs/upgrading/upgrading-to-v3.md): Breaking changes between Crawlee (v3) and Apify SDK (v2).
+- [apify reference](https://docs.apify.com/sdk/js/reference.md)
 
-# SDK for JavaScript | Apify Documentation
-# Source: https://docs.apify.com/sdk/js/llms.txt
+## Apify SDK for Python
 
+> Source: https://docs.apify.com/sdk/python/llms.txt
 
-## sdk
+- [Overview](https://docs.apify.com/sdk/python/docs/overview.md): The official library for creating Apify Actors in Python, providing tools for web scraping, automation, and data storage integration.
+  - [Changelog](https://docs.apify.com/sdk/python/docs/changelog.md)
+  - [Accessing Apify API](https://docs.apify.com/sdk/python/docs/concepts/access-apify-api.md): Access Apify API features not covered by the SDK.
+  - [Actor configuration](https://docs.apify.com/sdk/python/docs/concepts/actor-configuration.md): Configure the Actor class using the Configuration class and environment variables.
+  - [Actor events & state persistence](https://docs.apify.com/sdk/python/docs/concepts/actor-events.md): Handle Actor events sent by the Apify platform during runtime.
+  - [Actor input](https://docs.apify.com/sdk/python/docs/concepts/actor-input.md): Read Actor input from the default key-value store.
+  - [Actor lifecycle](https://docs.apify.com/sdk/python/docs/concepts/actor-lifecycle.md): How an Apify Actor starts, runs, and shuts down.
+  - [Interacting with other Actors](https://docs.apify.com/sdk/python/docs/concepts/interacting-with-other-actors.md): Methods to interact with other Actors and tasks on the platform.
+  - [Logging](https://docs.apify.com/sdk/python/docs/concepts/logging.md): Logging through Python's standard logging module.
+  - [Pay-per-event monetization](https://docs.apify.com/sdk/python/docs/concepts/pay-per-event.md): Monetize your Actors using the pay-per-event pricing model.
+  - [Proxy management](https://docs.apify.com/sdk/python/docs/concepts/proxy-management.md): Work around IP blocking using proxy servers.
+  - [Working with storages](https://docs.apify.com/sdk/python/docs/concepts/storages.md): Work with default or named storages for datasets, key-value stores, and request queues.
+  - [Creating webhooks](https://docs.apify.com/sdk/python/docs/concepts/webhooks.md): Configure webhooks to trigger actions on Actor events.
+  - [Quick start](https://docs.apify.com/sdk/python/docs/introduction/quick-start.md): Get started with the Apify SDK for Python by creating your first Actor.
+  - [Using BeautifulSoup with HTTPX](https://docs.apify.com/sdk/python/docs/guides/beautifulsoup-httpx.md): Use BeautifulSoup with HTTPX in your Actors.
+  - [Using Crawlee](https://docs.apify.com/sdk/python/docs/guides/crawlee.md): Use the Crawlee library in your Actors.
+  - [Using Parsel with Impit](https://docs.apify.com/sdk/python/docs/guides/parsel-impit.md): Combine Parsel and Impit libraries for scraping.
+  - [Using Playwright](https://docs.apify.com/sdk/python/docs/guides/playwright.md): Use Playwright for web scraping in your Actors.
+  - [Running webserver](https://docs.apify.com/sdk/python/docs/guides/running-webserver.md): Run a web server inside your Actor.
+  - [Using Scrapy](https://docs.apify.com/sdk/python/docs/guides/scrapy.md): Use the Scrapy framework in your Actors.
+  - [Using Selenium](https://docs.apify.com/sdk/python/docs/guides/selenium.md): Use Selenium for web scraping in your Actors.
+  - [Upgrading to v3](https://docs.apify.com/sdk/python/docs/upgrading/upgrading-to-v3.md): Breaking changes between Apify Python SDK v2.x and v3.0.
+- [apify-sdk-python reference](https://docs.apify.com/sdk/python/reference.md)
 
-      - [Apify SDK for JavaScript](https://docs.apify.com/sdk/js/docs/overview.md): The official library for creating Apify Actors in JavaScript, providing tools for web crawling, scraping, and automation at scale.
-        - [Changelog](https://docs.apify.com/sdk/js/docs/changelog.md)
-        - [Actor lifecycle](https://docs.apify.com/sdk/js/docs/concepts/actor-lifecycle.md): Understanding Actor lifecycle, initialization, and the Apify platform.
-        - [Running in Docker](https://docs.apify.com/sdk/js/docs/concepts/docker-images.md): Example Docker images to run your crawlers.
-        - [Environment Variables](https://docs.apify.com/sdk/js/docs/concepts/environment-variables.md): Environment variables used by Apify SDK.
-        - [Pay-per-event Monetization](https://docs.apify.com/sdk/js/docs/concepts/pay-per-event.md): Monetize your Actors using the pay-per-event pricing model.
-        - [Proxy Management](https://docs.apify.com/sdk/js/docs/concepts/proxy-management.md): IP address rotation and proxy configuration.
-        - [Request Storage](https://docs.apify.com/sdk/js/docs/concepts/request-storage.md): Request storage types for managing crawl queues.
-        - [Result Storage](https://docs.apify.com/sdk/js/docs/concepts/result-storage.md): Result storage types for saving crawl output.
-        - [Session Management](https://docs.apify.com/sdk/js/docs/concepts/session-management.md): SessionPool for managing browser sessions and cookies.
-        - [Quick start](https://docs.apify.com/sdk/js/docs/introduction/quick-start.md): Get started with the Apify SDK for JavaScript by creating your first Actor.
-        - [Accept user input](https://docs.apify.com/sdk/js/docs/guides/accept-user-input.md): Accept and log user input in your Actor.
-        - [Add data to dataset](https://docs.apify.com/sdk/js/docs/guides/add-data-to-dataset.md): Save data to the default dataset.
-        - [Basic crawler](https://docs.apify.com/sdk/js/docs/guides/basic-crawler.md): Bare-bones example using BasicCrawler.
-        - [Call actor](https://docs.apify.com/sdk/js/docs/guides/call-actor.md): Start an Apify Actor programmatically.
-        - [Cheerio crawler](https://docs.apify.com/sdk/js/docs/guides/cheerio-crawler.md): Crawl URLs using plain HTTP requests and parse HTML with Cheerio.
-        - [Crawl all links on a website](https://docs.apify.com/sdk/js/docs/guides/crawl-all-links.md): Use enqueueLinks() to crawl entire websites.
-        - [Crawl a sitemap](https://docs.apify.com/sdk/js/docs/guides/crawl-sitemap.md): Download and crawl URLs from a sitemap.
-        - [Playwright crawler](https://docs.apify.com/sdk/js/docs/guides/playwright-crawler.md): Use PlaywrightCrawler for browser-based crawling.
-        - [Puppeteer crawler](https://docs.apify.com/sdk/js/docs/guides/puppeteer-crawler.md): Use PuppeteerCrawler for browser-based crawling.
-        - [Setting up a TypeScript project](https://docs.apify.com/sdk/js/docs/guides/type-script-actor.md): TypeScript support in Apify SDK.
-        - [Upgrading to v3](https://docs.apify.com/sdk/js/docs/upgrading/upgrading-to-v3.md): Breaking changes between Crawlee (v3) and Apify SDK (v2).
-    - [apify reference](https://docs.apify.com/sdk/js/reference.md)
+## Apify CLI
 
+> Source: https://docs.apify.com/cli/llms.txt
 
-# SDK for Python | Apify Documentation
-# Source: https://docs.apify.com/sdk/python/llms.txt
-
-
-## sdk
-
-      - [Overview](https://docs.apify.com/sdk/python/docs/overview.md): The official library for creating Apify Actors in Python, providing tools for web scraping, automation, and data storage integration.
-        - [Changelog](https://docs.apify.com/sdk/python/docs/changelog.md)
-        - [Accessing Apify API](https://docs.apify.com/sdk/python/docs/concepts/access-apify-api.md): Access Apify API features not covered by the SDK.
-        - [Actor configuration](https://docs.apify.com/sdk/python/docs/concepts/actor-configuration.md): Configure the Actor class using the Configuration class and environment variables.
-        - [Actor events & state persistence](https://docs.apify.com/sdk/python/docs/concepts/actor-events.md): Handle Actor events sent by the Apify platform during runtime.
-        - [Actor input](https://docs.apify.com/sdk/python/docs/concepts/actor-input.md): Read Actor input from the default key-value store.
-        - [Actor lifecycle](https://docs.apify.com/sdk/python/docs/concepts/actor-lifecycle.md): How an Apify Actor starts, runs, and shuts down.
-        - [Interacting with other Actors](https://docs.apify.com/sdk/python/docs/concepts/interacting-with-other-actors.md): Methods to interact with other Actors and tasks on the platform.
-        - [Logging](https://docs.apify.com/sdk/python/docs/concepts/logging.md): Logging through Python's standard logging module.
-        - [Pay-per-event monetization](https://docs.apify.com/sdk/python/docs/concepts/pay-per-event.md): Monetize your Actors using the pay-per-event pricing model.
-        - [Proxy management](https://docs.apify.com/sdk/python/docs/concepts/proxy-management.md): Work around IP blocking using proxy servers.
-        - [Working with storages](https://docs.apify.com/sdk/python/docs/concepts/storages.md): Work with default or named storages for datasets, key-value stores, and request queues.
-        - [Creating webhooks](https://docs.apify.com/sdk/python/docs/concepts/webhooks.md): Configure webhooks to trigger actions on Actor events.
-        - [Quick start](https://docs.apify.com/sdk/python/docs/introduction/quick-start.md): Get started with the Apify SDK for Python by creating your first Actor.
-        - [Using BeautifulSoup with HTTPX](https://docs.apify.com/sdk/python/docs/guides/beautifulsoup-httpx.md): Use BeautifulSoup with HTTPX in your Actors.
-        - [Using Crawlee](https://docs.apify.com/sdk/python/docs/guides/crawlee.md): Use the Crawlee library in your Actors.
-        - [Using Parsel with Impit](https://docs.apify.com/sdk/python/docs/guides/parsel-impit.md): Combine Parsel and Impit libraries for scraping.
-        - [Using Playwright](https://docs.apify.com/sdk/python/docs/guides/playwright.md): Use Playwright for web scraping in your Actors.
-        - [Running webserver](https://docs.apify.com/sdk/python/docs/guides/running-webserver.md): Run a web server inside your Actor.
-        - [Using Scrapy](https://docs.apify.com/sdk/python/docs/guides/scrapy.md): Use the Scrapy framework in your Actors.
-        - [Using Selenium](https://docs.apify.com/sdk/python/docs/guides/selenium.md): Use Selenium for web scraping in your Actors.
-        - [Upgrading to v3](https://docs.apify.com/sdk/python/docs/upgrading/upgrading-to-v3.md): Breaking changes between Apify Python SDK v2.x and v3.0.
-    - [apify-sdk-python reference](https://docs.apify.com/sdk/python/reference.md)
-
-
-# CLI | Apify Documentation
-# Source: https://docs.apify.com/cli/llms.txt
-
-
-## cli
-
-  - [Apify CLI overview](https://docs.apify.com/cli/docs.md): An introduction to Apify CLI, a command-line interface for creating, developing, building, and running Apify Actors and managing the Apify cloud platform.
-    - [Changelog](https://docs.apify.com/cli/docs/changelog.md)
-    - [Installation](https://docs.apify.com/cli/docs/installation.md): Learn how to install Apify CLI using installation scripts, Homebrew, or NPM.
-    - [Integrating Scrapy projects](https://docs.apify.com/cli/docs/integrating-scrapy.md): Learn how to run Scrapy projects as Apify Actors and deploy them on the Apify platform.
-    - [Quick start](https://docs.apify.com/cli/docs/quick-start.md): Learn how to create, run, and manage Actors using Apify CLI.
-    - [Command reference](https://docs.apify.com/cli/docs/reference.md): The Apify CLI provides tools for managing your Apify projects and resources from the command line.
-    - [Telemetry](https://docs.apify.com/cli/docs/telemetry.md): Apify collects telemetry data about the general usage of the CLI.
+- [Apify CLI overview](https://docs.apify.com/cli/docs.md): An introduction to Apify CLI, a command-line interface for creating, developing, building, and running Apify Actors and managing the Apify cloud platform.
+  - [Changelog](https://docs.apify.com/cli/docs/changelog.md)
+  - [Installation](https://docs.apify.com/cli/docs/installation.md): Learn how to install Apify CLI using installation scripts, Homebrew, or NPM.
+  - [Integrating Scrapy projects](https://docs.apify.com/cli/docs/integrating-scrapy.md): Learn how to run Scrapy projects as Apify Actors and deploy them on the Apify platform.
+  - [Quick start](https://docs.apify.com/cli/docs/quick-start.md): Learn how to create, run, and manage Actors using Apify CLI.
+  - [Command reference](https://docs.apify.com/cli/docs/reference.md): The Apify CLI provides tools for managing your Apify projects and resources from the command line.
+  - [Telemetry](https://docs.apify.com/cli/docs/telemetry.md): Apify collects telemetry data about the general usage of the CLI.


### PR DESCRIPTION
## Summary

- Reduce `llms.txt` from ~196K to ~84K characters (57% reduction, under 100K target)
- Replace live fetching of external repo `llms.txt` with a curated static file (`scripts/llms-external-curated.txt`) that keeps overview, concept, and guide pages but drops ~400 individual class/interface/enum reference entries
- Exclude individual API endpoint pages from the Docusaurus llms-txt plugin via `excludeRoutes`, keeping only Introduction category pages and Getting started
- Exclude legacy Academy content (old JS scraping course, node-js/python tutorial collections, exercise solutions, marketing playbook deep pages) and outdated legal documents
- `llms-full.txt` remains unchanged - it still fetches all content from external repos

## Test plan

- [ ] `npm run build` succeeds
- [ ] `wc -c build/llms.txt` is under 100K characters
- [ ] `build/llms.txt` contains API Introduction pages but no individual endpoint pages
- [ ] `build/llms.txt` contains no legacy Academy content or reference class entries
- [ ] `build/llms-full.txt` size is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)