### PR TITLE
chore(openapi): Remove `count` from `ListOfRequests`

### DIFF
--- a/apify-api/openapi/components/schemas/request-queues/ListOfRequests.yaml
+++ b/apify-api/openapi/components/schemas/request-queues/ListOfRequests.yaml
@@ -10,10 +10,6 @@ properties:
     items:
       $ref: ./Request.yaml
     description: The array of requests.
-  count:
-    type: integer
-    description: The total number of requests matching the query.
-    examples: [2]
   limit:
     type: integer
     description: The maximum number of requests returned in this response.

--- a/apify-api/openapi/components/schemas/request-queues/ListOfRequestsResponse.yaml
+++ b/apify-api/openapi/components/schemas/request-queues/ListOfRequestsResponse.yaml
@@ -37,6 +37,5 @@ example:
           label: DETAIL
           image: "https://picserver1.eu"
         handledAt: "2019-06-16T10:23:31.607Z"
-    count: 2
     limit: 2
     exclusiveStartId: Ihnsp8YrvJ8102Kj


### PR DESCRIPTION
Remove `count` from `ListOfRequests`

The API implementation is not sending this field:
- [source](https://github.com/apify/apify-core/blob/5ee9e90bce523a4a1e3b5dddc0b6969c7c3c0b76/src/api/src/routes/request_queues/requests.ts)
- [tests](https://github.com/apify/apify-core/blob/master/tests/integration/tests/request_queues/request_queues.request_list.js)

### Issues
Partially implements: https://github.com/apify/apify-docs/issues/2286