### PR TITLE
chore(deps): resolve Dependabot security alerts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
                 "react": "^19.1.0",
                 "react-dom": "^19.1.0",
                 "react-github-btn": "^1.4.0",
-                "styled-components": "6.3.12",
+                "styled-components": "^6.4.1",
                 "unist-util-visit": "^5.0.0"
             },
             "devDependencies": {
@@ -65,7 +65,7 @@
         },
         "apify-docs-theme": {
             "name": "@apify/docs-theme",
-            "version": "1.0.240",
+            "version": "1.0.243",
             "license": "ISC",
             "dependencies": {
                 "@apify/docs-search-modal": "^1.3.3",
@@ -8046,6 +8046,18 @@
                 "url": "https://paulmillr.com/funding/"
             }
         },
+        "node_modules/@nodable/entities": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
+            "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/nodable"
+                }
+            ],
+            "license": "MIT"
+        },
         "node_modules/@nodelib/fs.scandir": {
             "version": "2.1.5",
             "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -8794,9 +8806,9 @@
             "license": "BSD-3-Clause"
         },
         "node_modules/@protobufjs/codegen": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
-            "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+            "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
             "license": "BSD-3-Clause"
         },
         "node_modules/@protobufjs/eventemitter": {
@@ -8822,9 +8834,9 @@
             "license": "BSD-3-Clause"
         },
         "node_modules/@protobufjs/inquire": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
-            "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.1.tgz",
+            "integrity": "sha512-mnzgDV26ueAvk7rsbt9L7bE0SuAoqyuys/sMMrmVcN5x9VsxpcG3rqAUSgDyLp0UZlmNfIbQ4fHfCtreVBk8Ew==",
             "license": "BSD-3-Clause"
         },
         "node_modules/@protobufjs/path": {
@@ -8840,9 +8852,9 @@
             "license": "BSD-3-Clause"
         },
         "node_modules/@protobufjs/utf8": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
-            "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
+            "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
             "license": "BSD-3-Clause"
         },
         "node_modules/@radix-ui/primitive": {
@@ -9246,34 +9258,6 @@
             "license": "MIT",
             "bin": {
                 "ulid": "bin/cli.js"
-            }
-        },
-        "node_modules/@redocly/cli/node_modules/postcss": {
-            "version": "8.4.49",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.49.tgz",
-            "integrity": "sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA==",
-            "funding": [
-                {
-                    "type": "opencollective",
-                    "url": "https://opencollective.com/postcss/"
-                },
-                {
-                    "type": "tidelift",
-                    "url": "https://tidelift.com/funding/github/npm/postcss"
-                },
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/ai"
-                }
-            ],
-            "license": "MIT",
-            "dependencies": {
-                "nanoid": "^3.3.7",
-                "picocolors": "^1.1.1",
-                "source-map-js": "^1.2.1"
-            },
-            "engines": {
-                "node": "^10 || ^12 || >=14"
             }
         },
         "node_modules/@redocly/cli/node_modules/styled-components": {
@@ -9890,9 +9874,9 @@
             }
         },
         "node_modules/@stoplight/spectral-cli": {
-            "version": "6.15.0",
-            "resolved": "https://registry.npmjs.org/@stoplight/spectral-cli/-/spectral-cli-6.15.0.tgz",
-            "integrity": "sha512-FVeQIuqQQnnLfa8vy+oatTKUve7uU+3SaaAfdjpX/B+uB1NcfkKRJYhKT9wMEehDRaMPL5AKIRYMCFerdEbIpw==",
+            "version": "6.15.1",
+            "resolved": "https://registry.npmjs.org/@stoplight/spectral-cli/-/spectral-cli-6.15.1.tgz",
+            "integrity": "sha512-ev72bUglbaZvFSMWCP5o1Iso5NGgbLZOAuedvRxYrUMey9dVCR83i033tSFvDv6cpj86HsbEmiilh8vwrY/asQ==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -9910,7 +9894,7 @@
                 "chalk": "4.1.2",
                 "fast-glob": "~3.2.12",
                 "hpagent": "~1.2.0",
-                "lodash": "~4.17.21",
+                "lodash": "^4.18.1",
                 "pony-cause": "^1.1.1",
                 "stacktracey": "^2.1.8",
                 "tslib": "^2.8.1",
@@ -9942,13 +9926,6 @@
             "version": "8.0.0",
             "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
             "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/@stoplight/spectral-cli/node_modules/lodash": {
-            "version": "4.17.23",
-            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-            "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
             "dev": true,
             "license": "MIT"
         },
@@ -10015,9 +9992,9 @@
             }
         },
         "node_modules/@stoplight/spectral-core": {
-            "version": "1.21.0",
-            "resolved": "https://registry.npmjs.org/@stoplight/spectral-core/-/spectral-core-1.21.0.tgz",
-            "integrity": "sha512-oj4e/FrDLUhBRocIW+lRMKlJ/q/rDZw61HkLbTFsdMd+f/FTkli2xHNB1YC6n1mrMKjjvy7XlUuFkC7XxtgbWw==",
+            "version": "1.22.0",
+            "resolved": "https://registry.npmjs.org/@stoplight/spectral-core/-/spectral-core-1.22.0.tgz",
+            "integrity": "sha512-4hTxMDs4TFUG4/jKjaZttA65gNuV2PCKI9+51I+J4nL6ylo17DlbW+sl6byKnBuV/85HxaV33ri5fEGlp8lTSA==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -10030,17 +10007,17 @@
                 "@stoplight/types": "~13.6.0",
                 "@types/es-aggregate-error": "^1.0.2",
                 "@types/json-schema": "^7.0.11",
-                "ajv": "^8.17.1",
+                "ajv": "^8.18.0",
                 "ajv-errors": "~3.0.0",
                 "ajv-formats": "~2.1.1",
                 "es-aggregate-error": "^1.0.7",
+                "expr-eval-fork": "^3.0.1",
                 "jsonpath-plus": "^10.3.0",
-                "lodash": "~4.17.23",
+                "lodash": "^4.18.1",
                 "lodash.topath": "^4.5.2",
-                "minimatch": "3.1.2",
+                "minimatch": "^3.1.4",
                 "nimma": "0.2.3",
                 "pony-cause": "^1.1.1",
-                "simple-eval": "1.0.1",
                 "tslib": "^2.8.1"
             },
             "engines": {
@@ -10078,13 +10055,6 @@
                     "optional": true
                 }
             }
-        },
-        "node_modules/@stoplight/spectral-core/node_modules/lodash": {
-            "version": "4.17.23",
-            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-            "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/@stoplight/spectral-formats": {
             "version": "1.8.2",
@@ -10128,9 +10098,9 @@
             }
         },
         "node_modules/@stoplight/spectral-functions": {
-            "version": "1.10.1",
-            "resolved": "https://registry.npmjs.org/@stoplight/spectral-functions/-/spectral-functions-1.10.1.tgz",
-            "integrity": "sha512-obu8ZfoHxELOapfGsCJixKZXZcffjg+lSoNuttpmUFuDzVLT3VmH8QkPXfOGOL5Pz80BR35ClNAToDkdnYIURg==",
+            "version": "1.10.2",
+            "resolved": "https://registry.npmjs.org/@stoplight/spectral-functions/-/spectral-functions-1.10.2.tgz",
+            "integrity": "sha512-PIfPUgTRo8EtAnL1MIrzhHoUuojSaE8shGSMaHS3BxGyc8d079BE5+TqJa1/WLUb9YT9JQnZ0Aj4xfi8NcJOIw==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -10139,11 +10109,11 @@
                 "@stoplight/spectral-core": "^1.19.4",
                 "@stoplight/spectral-formats": "^1.8.1",
                 "@stoplight/spectral-runtime": "^1.1.2",
-                "ajv": "^8.17.1",
+                "ajv": "^8.18.0",
                 "ajv-draft-04": "~1.0.0",
                 "ajv-errors": "~3.0.0",
                 "ajv-formats": "~2.1.1",
-                "lodash": "~4.17.21",
+                "lodash": "^4.18.1",
                 "tslib": "^2.8.1"
             },
             "engines": {
@@ -10167,13 +10137,6 @@
                     "optional": true
                 }
             }
-        },
-        "node_modules/@stoplight/spectral-functions/node_modules/lodash": {
-            "version": "4.17.23",
-            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-            "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/@stoplight/spectral-parsers": {
             "version": "1.0.5",
@@ -10300,9 +10263,9 @@
             "license": "Apache-2.0"
         },
         "node_modules/@stoplight/spectral-rulesets": {
-            "version": "1.22.0",
-            "resolved": "https://registry.npmjs.org/@stoplight/spectral-rulesets/-/spectral-rulesets-1.22.0.tgz",
-            "integrity": "sha512-l2EY2jiKKLsvnPfGy+pXC0LeGsbJzcQP5G/AojHgf+cwN//VYxW1Wvv4WKFx/CLmLxc42mJYF2juwWofjWYNIQ==",
+            "version": "1.22.1",
+            "resolved": "https://registry.npmjs.org/@stoplight/spectral-rulesets/-/spectral-rulesets-1.22.1.tgz",
+            "integrity": "sha512-DaaQJioKuYkRsOuKIJfX2ek7G7f6OCU3CI3K7ABaOcTFMiHj29SJLDdb04mCjXZFXMlXHjmCl2ZpKW6heieXpw==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -10315,11 +10278,11 @@
                 "@stoplight/spectral-runtime": "^1.1.2",
                 "@stoplight/types": "^13.6.0",
                 "@types/json-schema": "^7.0.7",
-                "ajv": "^8.17.1",
+                "ajv": "^8.18.0",
                 "ajv-formats": "~2.1.1",
                 "json-schema-traverse": "^1.0.0",
                 "leven": "3.1.0",
-                "lodash": "~4.17.21",
+                "lodash": "^4.18.1",
                 "tslib": "^2.8.1"
             },
             "engines": {
@@ -10343,13 +10306,6 @@
                     "optional": true
                 }
             }
-        },
-        "node_modules/@stoplight/spectral-rulesets/node_modules/lodash": {
-            "version": "4.17.23",
-            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-            "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/@stoplight/spectral-runtime": {
             "version": "1.1.4",
@@ -16140,9 +16096,9 @@
             }
         },
         "node_modules/dompurify": {
-            "version": "3.3.3",
-            "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.3.tgz",
-            "integrity": "sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==",
+            "version": "3.4.1",
+            "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.1.tgz",
+            "integrity": "sha512-JahakDAIg1gyOm7dlgWSDjV4n7Ip2PKR55NIT6jrMfIgLFgWo81vdr1/QGqWtFNRqXP9UV71oVePtjqS2ebnPw==",
             "license": "(MPL-2.0 OR Apache-2.0)",
             "optionalDependencies": {
                 "@types/trusted-types": "^2.0.7"
@@ -17291,6 +17247,16 @@
             "integrity": "sha512-Z+ktTxTwv9ILfgKCk32OX3n/doe+OcLTRtqK9pcL+JsP3J1/VW8Uvl4ZjLlKqeW4rzK4oesDOGMEMRIZqtP4Iw==",
             "license": "BSD-3-Clause"
         },
+        "node_modules/expr-eval-fork": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/expr-eval-fork/-/expr-eval-fork-3.0.3.tgz",
+            "integrity": "sha512-BhC+hbc5lIVjygr840n5DEkW3MQq7H9o+mc1/N7Z5uIiCFVyESLL5DIE7LNq4CYUNxy+XjA+3jRrL/h0Kt2xcg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=16.9.0"
+            }
+        },
         "node_modules/express": {
             "version": "4.22.1",
             "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
@@ -17486,9 +17452,9 @@
             "license": "BSD-3-Clause"
         },
         "node_modules/fast-xml-builder": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.4.tgz",
-            "integrity": "sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.5.tgz",
+            "integrity": "sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==",
             "funding": [
                 {
                     "type": "github",
@@ -17501,9 +17467,9 @@
             }
         },
         "node_modules/fast-xml-parser": {
-            "version": "5.5.11",
-            "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.11.tgz",
-            "integrity": "sha512-QL0eb0YbSTVWF6tTf1+LEMSgtCEjBYPpnAjoLC8SscESlAjXEIRJ7cHtLG0pLeDFaZLa4VKZLArtA/60ZS7vyA==",
+            "version": "5.7.2",
+            "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.2.tgz",
+            "integrity": "sha512-P7oW7tLbYnhOLQk/Gv7cZgzgMPP/XN03K02/Jy6Y/NHzyIAIpxuZIM/YqAkfiXFPxA2CTm7NtCijK9EDu09u2w==",
             "funding": [
                 {
                     "type": "github",
@@ -17512,8 +17478,9 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "fast-xml-builder": "^1.1.4",
-                "path-expression-matcher": "^1.4.0",
+                "@nodable/entities": "^2.1.0",
+                "fast-xml-builder": "^1.1.5",
+                "path-expression-matcher": "^1.5.0",
                 "strnum": "^2.2.3"
             },
             "bin": {
@@ -17840,9 +17807,9 @@
             "license": "ISC"
         },
         "node_modules/follow-redirects": {
-            "version": "1.15.11",
-            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-            "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+            "version": "1.16.0",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+            "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
             "funding": [
                 {
                     "type": "individual",
@@ -24811,12 +24778,6 @@
             "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
             "license": "MIT"
         },
-        "node_modules/openapi-to-postmanv2/node_modules/lodash": {
-            "version": "4.17.21",
-            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-            "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-            "license": "MIT"
-        },
         "node_modules/opener": {
             "version": "1.5.2",
             "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.2.tgz",
@@ -25250,9 +25211,9 @@
             }
         },
         "node_modules/path-expression-matcher": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.4.0.tgz",
-            "integrity": "sha512-s4DQMxIdhj3jLFWd9LxHOplj4p9yQ4ffMGowFf3cpEgrrJjEhN0V5nxw4Ye1EViAGDoL4/1AeO6qHpqYPOzE4Q==",
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+            "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
             "funding": [
                 {
                     "type": "github",
@@ -25598,9 +25559,9 @@
             }
         },
         "node_modules/postcss": {
-            "version": "8.5.9",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.9.tgz",
-            "integrity": "sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==",
+            "version": "8.5.12",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
+            "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -27064,12 +27025,6 @@
             "deprecated": "Please update to a newer version.",
             "license": "MIT"
         },
-        "node_modules/postman-collection/node_modules/lodash": {
-            "version": "4.17.23",
-            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-            "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
-            "license": "MIT"
-        },
         "node_modules/postman-collection/node_modules/semver": {
             "version": "7.7.1",
             "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
@@ -27227,22 +27182,22 @@
             "license": "ISC"
         },
         "node_modules/protobufjs": {
-            "version": "7.5.4",
-            "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
-            "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
+            "version": "7.5.6",
+            "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.6.tgz",
+            "integrity": "sha512-M71sTMB146U3u0di3yup8iM+zv8yPRNQVr1KK4tyBitl3qFvEGucq/rGDRShD2rsJhtN02RJaJ7j5X5hmy8SJg==",
             "hasInstallScript": true,
             "license": "BSD-3-Clause",
             "dependencies": {
                 "@protobufjs/aspromise": "^1.1.2",
                 "@protobufjs/base64": "^1.1.2",
-                "@protobufjs/codegen": "^2.0.4",
+                "@protobufjs/codegen": "^2.0.5",
                 "@protobufjs/eventemitter": "^1.1.0",
                 "@protobufjs/fetch": "^1.1.0",
                 "@protobufjs/float": "^1.0.2",
-                "@protobufjs/inquire": "^1.1.0",
+                "@protobufjs/inquire": "^1.1.1",
                 "@protobufjs/path": "^1.1.2",
                 "@protobufjs/pool": "^1.1.0",
-                "@protobufjs/utf8": "^1.1.0",
+                "@protobufjs/utf8": "^1.1.1",
                 "@types/node": ">=13.7.0",
                 "long": "^5.0.0"
             },
@@ -29774,19 +29729,6 @@
             "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
             "license": "ISC"
         },
-        "node_modules/simple-eval": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/simple-eval/-/simple-eval-1.0.1.tgz",
-            "integrity": "sha512-LH7FpTAkeD+y5xQC4fzS+tFtaNlvt3Ib1zKzvhjv/Y+cioV4zIuw4IZr2yhRLu67CWL7FR9/6KXKnjRoZTvGGQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "jsep": "^1.3.6"
-            },
-            "engines": {
-                "node": ">=12"
-            }
-        },
         "node_modules/simple-websocket": {
             "version": "9.1.0",
             "resolved": "https://registry.npmjs.org/simple-websocket/-/simple-websocket-9.1.0.tgz",
@@ -30363,20 +30305,15 @@
             }
         },
         "node_modules/styled-components": {
-            "version": "6.3.12",
-            "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-6.3.12.tgz",
-            "integrity": "sha512-hFR6xsVkVYbsdcUlzPYFvFfoc6o2KlV0VvgRIQwSYMtdThM7SCxnjX9efh/cWce2kTq16I/Kl3xM98xiLptsXA==",
+            "version": "6.4.1",
+            "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-6.4.1.tgz",
+            "integrity": "sha512-ADu2dF53esUzzM4I0ewxhxFtsDd6v4V6dNkg3vG0iFKhnt06sJneTZnRvujAosZwW0XD58IKgGMQoqri4wHRqg==",
             "license": "MIT",
             "dependencies": {
                 "@emotion/is-prop-valid": "1.4.0",
-                "@emotion/unitless": "0.10.0",
-                "@types/stylis": "4.2.7",
                 "css-to-react-native": "3.2.0",
                 "csstype": "3.2.3",
-                "postcss": "8.4.49",
-                "shallowequal": "1.1.0",
-                "stylis": "4.3.6",
-                "tslib": "2.8.1"
+                "stylis": "4.3.6"
             },
             "engines": {
                 "node": ">= 16"
@@ -30386,41 +30323,21 @@
                 "url": "https://opencollective.com/styled-components"
             },
             "peerDependencies": {
+                "css-to-react-native": ">= 3.2.0",
                 "react": ">= 16.8.0",
-                "react-dom": ">= 16.8.0"
+                "react-dom": ">= 16.8.0",
+                "react-native": ">= 0.68.0"
             },
             "peerDependenciesMeta": {
+                "css-to-react-native": {
+                    "optional": true
+                },
                 "react-dom": {
                     "optional": true
-                }
-            }
-        },
-        "node_modules/styled-components/node_modules/postcss": {
-            "version": "8.4.49",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.49.tgz",
-            "integrity": "sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA==",
-            "funding": [
-                {
-                    "type": "opencollective",
-                    "url": "https://opencollective.com/postcss/"
                 },
-                {
-                    "type": "tidelift",
-                    "url": "https://tidelift.com/funding/github/npm/postcss"
-                },
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/ai"
+                "react-native": {
+                    "optional": true
                 }
-            ],
-            "license": "MIT",
-            "dependencies": {
-                "nanoid": "^3.3.7",
-                "picocolors": "^1.1.1",
-                "source-map-js": "^1.2.1"
-            },
-            "engines": {
-                "node": "^10 || ^12 || >=14"
             }
         },
         "node_modules/stylehacks": {
@@ -32702,9 +32619,9 @@
             "license": "ISC"
         },
         "node_modules/yaml": {
-            "version": "1.10.2",
-            "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
-            "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+            "version": "1.10.3",
+            "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
+            "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
             "license": "ISC",
             "engines": {
                 "node": ">= 6"

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-github-btn": "^1.4.0",
-        "styled-components": "6.3.12",
+        "styled-components": "^6.4.1",
         "unist-util-visit": "^5.0.0"
     },
     "browserslist": {
@@ -129,6 +129,9 @@
         },
         "@stoplight/spectral-ruleset-bundler": {
             "rollup": "2.80.0"
-        }
+        },
+        "postcss": "^8.5.10",
+        "yaml@1": "^1.10.3",
+        "lodash": "^4.18.0"
     }
 }


### PR DESCRIPTION
## Summary

Resolves 11 of 12 open Dependabot alerts. The 12th (uuid) was dismissed separately as tolerable risk.

### Lockfile-only fixes (`npm audit fix`)
| Package | Before → After | Alert |
|---|---|---|
| `dompurify` | 3.3.3 → 3.4.1 | #200, #202, #203, #204 |
| `fast-xml-parser` | 5.5.11 → 5.7.2 | #206 |
| `follow-redirects` | 1.15.11 → 1.16.0 | #199 |
| `protobufjs` | 7.5.4 → 7.5.6 | #201 (critical) |

### Direct dep bump
- `styled-components`: `6.3.12` → `^6.4.1` (minor bump; 6.4.x dropped its `postcss` dep entirely)

### Transitive overrides (added to existing `overrides` block)
- `"postcss": "^8.5.10"` — needed because `@redocly/cli` still pins `styled-components@6.3.9` which carries old postcss. Resolves #207.
- `"yaml@1": "^1.10.3"` — scoped to v1 only (leaves yaml@2 alone). Covers `cosmiconfig@7`, `openapi-to-postmanv2`, and `swagger2openapi`. Resolves #176.
- `"lodash": "^4.18.0"` — covers nested 4.17.x copies in `openapi-to-postmanv2` and `postman-collection`. Resolves #197, #198.

All overrides are patch/minor-level within the same major and pose minimal compatibility risk.

### Dismissed (separately, in Dependabot UI)
- **#205 uuid** (GHSA-w5hq-g745-h8pq) — vulnerable code path is `uuid.v3/v5/v6` with the `buf` parameter. Our consumers (sockjs, postman-collection, mermaid) only call `uuid.v4` without `buf`, so the path is not exercised. The patch (`uuid@14`) is ESM-only and would break the affected CJS consumers; no backport exists.

## Test plan
- [x] `npm install` succeeds
- [x] `npm run lint:code` passes
- [x] `npm run openapi:bundle` passes
- [x] `npm run openapi:lint` passes (exercises spectral, which uses overridden lodash)
- [x] `npm audit` shows zero root vulnerabilities
- [ ] `npm run build` (let CI run this)
- [ ] Verify Dependabot auto-closes the 11 alerts after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)