### PR TITLE
Update default actor build endpoint error handling and types

### DIFF
--- a/apify-api/openapi/components/schemas/common/ErrorType.yaml
+++ b/apify-api/openapi/components/schemas/common/ErrorType.yaml
@@ -126,6 +126,7 @@ enum:
   - expired-conference-token
   - failed-to-charge-user
   - final-invoice-negative
+  - full-permission-actor-not-approved
   - github-branch-empty
   - github-issue-already-exists
   - github-public-key-not-found
@@ -297,6 +298,7 @@ enum:
   - requested-dataset-view-does-not-exist
   - resume-token-expired
   - run-failed
+  - run-input-body-not-valid-json
   - run-timeout-exceeded
   - russia-is-evil
   - same-user

--- a/apify-api/openapi/paths/actors/acts@{actorId}@builds@default.yaml
+++ b/apify-api/openapi/paths/actors/acts@{actorId}@builds@default.yaml
@@ -27,11 +27,13 @@ get:
       $ref: ../../components/responses/BadRequest.yaml
     "403":
       # It should be 404, but is 403 for backwards compatibility. https://github.com/apify/apify-core/pull/17414
-      description: Not found - the requested resource was not found.
+      # Returned both when the default build does not exist (error type `unknown-build-tag`)
+      # and when the caller lacks read permission for the Actor (error type `insufficient-permissions`).
+      description: Forbidden - insufficient permissions, or the requested resource was not found.
       content:
         application/json:
           schema:
-            $ref: "../../components/schemas/common/errors/BuildErrors.yaml#/UnknownBuildTagError"
+            $ref: ../../components/schemas/common/ErrorResponse.yaml
     "404":
       $ref: ../../components/responses/NotFound.yaml
     "405":


### PR DESCRIPTION
## Summary
This PR updates the OpenAPI specification for the default actor build endpoint to better document error responses and adds new error type definitions to the error type schema.

## Key Changes
- **Error response documentation**: Updated the 403 response for the default actor build endpoint (`GET /actors/{actorId}/builds/default`) to clarify that it can be returned in two scenarios:
  - When the default build does not exist (error type `unknown-build-tag`)
  - When the caller lacks read permission for the Actor (error type `insufficient-permissions`)
  
- **Error response schema**: Changed the 403 response schema from a specific `BuildErrors.yaml#/UnknownBuildTagError` reference to the generic `ErrorResponse.yaml` to accommodate multiple error types

- **New error types**: Added two new error type enums to `ErrorType.yaml`:
  - `full-permission-actor-not-approved`
  - `run-input-body-not-valid-json`

## Notable Details
The 403 status code is retained for backwards compatibility despite semantically being a 404 scenario (as noted in the referenced PR #17414). The generic error response schema allows the API to return different error types while maintaining the same HTTP status code.

https://claude.ai/code/session_01WBCTVV9U7ctKjB63h9jubi