### PR TITLE
fix(ci): rewrite nginx backend on the included config, not the wrapper

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -42,6 +42,8 @@ jobs:
             -   name: Start Nginx with project config
                 run: |
                     PWD_PATH="$(pwd)"
+                    cp nginx.conf nginx-test.conf
+                    sed -i 's|https://apify.github.io/apify-docs|http://127.0.0.1:3000|g' nginx-test.conf
                     cat > default.conf <<EOF
                     worker_processes auto;
                     error_log ${PWD_PATH}/logs/error.log;
@@ -49,10 +51,9 @@ jobs:
                     events {}
                     http {
                         access_log ${PWD_PATH}/logs/access.log;
-                        include ${PWD_PATH}/nginx.conf;
+                        include ${PWD_PATH}/nginx-test.conf;
                     }
                     EOF
-                    sed -i 's|https://apify.github.io/apify-docs|http://localhost:3000|g' default.conf
                     mkdir -p "${PWD_PATH}/logs"
                     nginx -c "${PWD_PATH}/default.conf"
                     sleep 1


### PR DESCRIPTION
## Summary

- The `sed` substitution in the `Start Nginx with project config` step ran against `default.conf`, which only contains the wrapper (`worker_processes`, `events`, `http { include nginx.conf; }`) — not the `https://apify.github.io/apify-docs` upstream URL, which lives in `nginx.conf`. So the rewrite was a no-op and the header-assertions step silently proxied to live prod instead of the PR's local Docusaurus serve at port 3000.
- This masked regressions in the PR-under-test (the test could pass purely because prod happened to serve the right content) and caused spurious failures when the PR introduced changes that prod hadn't yet picked up — see #2480, where `assert_header ".../sdk.md" "Content-Type" "text/markdown"` failed because prod hadn't been redeployed yet.

## Test plan

- [ ] CI `Test / Docs build` job passes
- [ ] `Run header assertions` step actually exercises the local build (e.g. break a `.md` route in a follow-up draft and confirm the test now fails)

🤖 Generated with [Claude Code](https://claude.com/claude-code)