### PR TITLE
docs: clarify x402 is chain-agnostic, not Base-only

### DIFF
--- a/sources/platform/integrations/ai/x402.md
+++ b/sources/platform/integrations/ai/x402.md
@@ -16,7 +16,7 @@ Agentic payments are experimental and may change as payment protocols evolve. On
 
 ## What is x402
 
-The [x402 protocol](https://www.x402.org/) is an open standard for on-chain payments over HTTP. It uses [USDC](https://www.circle.com/usdc), a stablecoin pegged to the US dollar, on the [Base](https://www.base.org/) blockchain.
+The [x402 protocol](https://www.x402.org/) is an open standard for on-chain payments over HTTP. It is blockchain-agnostic and supports any EVM-compatible chain and Solana, with stablecoins as the primary payment method. The Apify integration uses [USDC](https://www.circle.com/usdc), a stablecoin pegged to the US dollar, on the [Base](https://www.base.org/) blockchain.
 
 When a server requires payment, it responds with HTTP `402` and tells the client what payment formats it accepts. The client signs a USDC transfer off-chain (locally, without touching the blockchain) and resends the request with the signature attached. The server settles (finalizes) the payment on-chain (on the blockchain) and processes the request.
 


### PR DESCRIPTION
## Summary

- The "What is x402" section described the x402 protocol itself as using USDC on Base, but x402 is blockchain-agnostic and supports any EVM-compatible chain plus Solana, with stablecoins as the primary payment method.
- The Apify integration still uses USDC on Base — only the general protocol description was wrong.

Reported by Kevin Lewis in Slack: https://apify.slack.com/archives/CQ96RHG2U/p1778049658299699

## Test plan

- [ ] \`pnpm lint\` passes
- [ ] \`pnpm build\` succeeds (no broken links)
- [ ] Page renders correctly at \`/integrations/x402\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)