### PR TITLE
chore: Use custom action to commit changes in CI instead of `git commit`

### DIFF
--- a/.github/workflows/bump-openapi-version.yaml
+++ b/.github/workflows/bump-openapi-version.yaml
@@ -20,21 +20,10 @@ jobs:
             - name: Bump OpenAPI version
               run: echo "v2-$(date -u +%Y-%m-%dT%H%M%SZ)" > apify-api/openapi/components/version.yaml
 
-            - name: Stage changes
-              id: stage
-              run: |
-                  git pull --rebase --autostash
-                  git add -A
-                  if git diff --cached --quiet; then
-                    echo "has-changes=false" >> "$GITHUB_OUTPUT"
-                  else
-                    echo "has-changes=true" >> "$GITHUB_OUTPUT"
-                  fi
-
             - name: Commit changes
               id: commit
-              if: steps.stage.outputs.has-changes == 'true'
-              uses: apify/workflows/commit@v0.44.0
+              uses: apify/actions/signed-commit@v1.0.0
               with:
-                  commit-message: "chore(openapi): Update OpenAPI version [skip ci]"
+                  message: "chore(openapi): Update OpenAPI version [skip ci]"
+                  pull: '--rebase --autostash'
                   github-token: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}

--- a/.github/workflows/bump-openapi-version.yaml
+++ b/.github/workflows/bump-openapi-version.yaml
@@ -20,11 +20,21 @@ jobs:
             - name: Bump OpenAPI version
               run: echo "v2-$(date -u +%Y-%m-%dT%H%M%SZ)" > apify-api/openapi/components/version.yaml
 
+            - name: Stage changes
+              id: stage
+              run: |
+                  git pull --rebase --autostash
+                  git add -A
+                  if git diff --cached --quiet; then
+                    echo "has-changes=false" >> "$GITHUB_OUTPUT"
+                  else
+                    echo "has-changes=true" >> "$GITHUB_OUTPUT"
+                  fi
+
             - name: Commit changes
               id: commit
-              uses: EndBug/add-and-commit@v10
+              if: steps.stage.outputs.has-changes == 'true'
+              uses: apify/workflows/commit@v0.44.0
               with:
-                  author_name: github-actions[bot]
-                  author_email: 41898282+github-actions[bot]@users.noreply.github.com
-                  message: "chore(openapi): Update OpenAPI version [skip ci]"
-                  pull: '--rebase --autostash'
+                  commit-message: "chore(openapi): Update OpenAPI version [skip ci]"
+                  github-token: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}

--- a/.github/workflows/publish-to-npm.yaml
+++ b/.github/workflows/publish-to-npm.yaml
@@ -91,15 +91,25 @@ jobs:
                     done;
                     pnpm show "$PACKAGE_NAME@$PACKAGE_VER" # fails if the package is not available, succeeds if it is
 
-            -   name: Commit the new theme version
+            -   name: Stage the new theme version
+                id: stage-theme
                 continue-on-error: true
-                uses: EndBug/add-and-commit@v10
+                run: |
+                    git pull --rebase --autostash
+                    git add 'apify-docs-theme/package.json' 'apify-docs-theme/package-lock.json'
+                    if git diff --cached --quiet; then
+                      echo "has-changes=false" >> "$GITHUB_OUTPUT"
+                    else
+                      echo "has-changes=true" >> "$GITHUB_OUTPUT"
+                    fi
+
+            -   name: Commit the new theme version
+                if: steps.stage-theme.outputs.has-changes == 'true'
+                continue-on-error: true
+                uses: apify/workflows/commit@v0.44.0
                 with:
-                    add: 'apify-docs-theme/package*.json'
-                    author_name: github-actions[bot]
-                    author_email: 41898282+github-actions[bot]@users.noreply.github.com
-                    message: 'chore: publish new version of @apify/docs-theme [skip ci]'
-                    pull: '--rebase --autostash'
+                    commit-message: 'chore: publish new version of @apify/docs-theme [skip ci]'
+                    github-token: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}
 
     rebuild-docs:
         needs: publish

--- a/.github/workflows/publish-to-npm.yaml
+++ b/.github/workflows/publish-to-npm.yaml
@@ -91,24 +91,13 @@ jobs:
                     done;
                     pnpm show "$PACKAGE_NAME@$PACKAGE_VER" # fails if the package is not available, succeeds if it is
 
-            -   name: Stage the new theme version
-                id: stage-theme
-                continue-on-error: true
-                run: |
-                    git pull --rebase --autostash
-                    git add 'apify-docs-theme/package.json' 'apify-docs-theme/package-lock.json'
-                    if git diff --cached --quiet; then
-                      echo "has-changes=false" >> "$GITHUB_OUTPUT"
-                    else
-                      echo "has-changes=true" >> "$GITHUB_OUTPUT"
-                    fi
-
             -   name: Commit the new theme version
-                if: steps.stage-theme.outputs.has-changes == 'true'
                 continue-on-error: true
-                uses: apify/workflows/commit@v0.44.0
+                uses: apify/actions/signed-commit@v1.0.0
                 with:
-                    commit-message: 'chore: publish new version of @apify/docs-theme [skip ci]'
+                    message: 'chore: publish new version of @apify/docs-theme [skip ci]'
+                    add: 'apify-docs-theme/package.json apify-docs-theme/package-lock.json'
+                    pull: '--rebase --autostash'
                     github-token: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}
 
     rebuild-docs:


### PR DESCRIPTION
We want to enforce commit signing for all commits in our repositories.
To do that, we need to make sure even commits created by CI workflows are signed.

It would be possible to sign using GPG keys, but that would require a lot of maintenance.

Instead, we can commit using the GitHub GraphQL API, which automatically signs commits.

This PR replaces direct `git commit` / `git push` usage (and third-party commit actions like `EndBug/add-and-commit`)
with the `apify/actions/signed-commit` action, which uses the GraphQL API under the hood.