### PR TITLE
chore: Replace calling reusable actions from `apify/workflows/...` to `apify/actions/...` [internal]

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -23,7 +23,7 @@ jobs:
                 with:
                     node-version: 24
 
-            -   uses: apify/workflows/pnpm-install@main
+            -   uses: apify/actions/pnpm-install@v1.0.0
 
             -   name: Build docs
                 run: |

--- a/.github/workflows/lychee.yml
+++ b/.github/workflows/lychee.yml
@@ -16,7 +16,7 @@ jobs:
                 with:
                     node-version: 24
 
-            -   uses: apify/workflows/pnpm-install@main
+            -   uses: apify/actions/pnpm-install@v1.0.0
 
             -   name: Build docs
                 run: |

--- a/.github/workflows/openapi-ci.yaml
+++ b/.github/workflows/openapi-ci.yaml
@@ -27,7 +27,7 @@ jobs:
               with:
                   node-version: 24
 
-            - uses: apify/workflows/pnpm-install@main
+            - uses: apify/actions/pnpm-install@v1.0.0
 
             - name: Lint with Redocly
               run: pnpm openapi:lint:redocly --format=github-actions
@@ -48,7 +48,7 @@ jobs:
               with:
                   node-version: 24
 
-            - uses: apify/workflows/pnpm-install@main
+            - uses: apify/actions/pnpm-install@v1.0.0
 
             - name: Build bundles
               run: pnpm openapi:build
@@ -75,7 +75,7 @@ jobs:
               with:
                   node-version: 24
 
-            - uses: apify/workflows/pnpm-install@main
+            - uses: apify/actions/pnpm-install@v1.0.0
 
             - name: Download bundles
               uses: actions/download-artifact@v8

--- a/.github/workflows/publish-to-npm.yaml
+++ b/.github/workflows/publish-to-npm.yaml
@@ -53,7 +53,7 @@ jobs:
                     node-version: 24
                     registry-url: 'https://registry.npmjs.org'
 
-            -   uses: apify/workflows/pnpm-install@main
+            -   uses: apify/actions/pnpm-install@v1.0.0
 
             -   name: Setup git user and npm
                 run: |

--- a/.github/workflows/test-academy.yml
+++ b/.github/workflows/test-academy.yml
@@ -21,7 +21,7 @@ jobs:
             -   name: Setup Python
                 uses: astral-sh/setup-uv@v7
 
-            -   uses: apify/workflows/pnpm-install@main
+            -   uses: apify/actions/pnpm-install@v1.0.0
 
             -   name: Test
                 run: pnpm test:academy

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -18,7 +18,7 @@ jobs:
                 with:
                     node-version: 24
 
-            -   uses: apify/workflows/pnpm-install@main
+            -   uses: apify/actions/pnpm-install@v1.0.0
 
             -   run: pnpm build
                 env:
@@ -245,7 +245,7 @@ jobs:
                 with:
                     node-version: 24
 
-            -   uses: apify/workflows/pnpm-install@main
+            -   uses: apify/actions/pnpm-install@v1.0.0
 
             -   name: List and Lint Changed Markdown Files
                 env:
@@ -269,7 +269,7 @@ jobs:
                 with:
                     node-version: 24
 
-            -   uses: apify/workflows/pnpm-install@main
+            -   uses: apify/actions/pnpm-install@v1.0.0
 
             -   run: pnpm lint:code
 


### PR DESCRIPTION
It was confusing that we have our custom GitHub actions in a repository called `workflows`. I've moved them to a new repository called `actions`, and this PR replaces the references to the actions to point to the new repository.

There are no functional changes, the actions just moved.