### PR TITLE
fix: skip alternate markdown link on /search page

### DIFF
--- a/apify-docs-theme/src/theme/Layout/index.jsx
+++ b/apify-docs-theme/src/theme/Layout/index.jsx
@@ -26,9 +26,12 @@ export default function LayoutWrapper(props) {
         pluginData.versions?.some((version) => !version.isLast && pathname.startsWith(version.path)),
     );
 
-    const shouldRenderAlternateLink = currentPath && currentPath !== '404' && !isVersionedPage;
+    const shouldRenderAlternateLink =
+        currentPath && currentPath !== '404' && currentPath !== 'search' && !isVersionedPage;
 
-    const alternateMarkdownLink = useBaseUrl(`/${currentPath}.md`, { absolute: true });
+    const alternateMarkdownLink = useBaseUrl(`/${currentPath}.md`, {
+        absolute: true,
+    });
 
     return (
         <>


### PR DESCRIPTION
/search is in the llms-txt plugin's excludeRoutes, so no /search.md counterpart is generated. The Layout was still rendering <link rel="alternate" type="text/markdown" href="/search.md">, producing a daily lychee 404 report on docs.apify.com/search.md.

Skip the alternate link for /search, matching the existing handling for /404 and versioned pages.