### PR TITLE
feat: return 410 status code on missing JS assets

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -21,6 +21,18 @@ server {
     set $backend "https://apify.github.io/apify-docs";
     resolver 1.1.1.1 8.8.8.8 valid=30s ipv6=off;
 
+    # Stale Docusaurus chunks: when a deploy invalidates hashed JS bundles, signal
+    # search engine crawlers to drop cached references by returning 410 (Gone) instead of 404.
+    proxy_intercept_errors on;
+    error_page 404 = @maybe_gone_js_asset;
+
+    location @maybe_gone_js_asset {
+        if ($request_uri ~ "/assets/js/[^?]+\.js(\?|$)") {
+            return 410;
+        }
+        return 404;
+    }
+
     location = / {
         if ($serve_markdown) {
             rewrite ^ /llms.txt last;
@@ -767,6 +779,18 @@ server {
     listen 0.0.0.0:8080;
     resolver 172.20.0.10;
     server_name ~^(?<subdomain>[^.]+)\.preview\.docs\.apify\.com$;
+
+    # Stale Docusaurus chunks: when a deploy invalidates hashed JS bundles, signal
+    # search engine crawlers to drop cached references by returning 410 (Gone) instead of 404.
+    proxy_intercept_errors on;
+    error_page 404 = @maybe_gone_js_asset;
+
+    location @maybe_gone_js_asset {
+        if ($request_uri ~ "/assets/js/[^?]+\.js(\?|$)") {
+            return 410;
+        }
+        return 404;
+    }
 
     # add trailing slashes to the root of GH pages docs
     rewrite ^/api/client/js$ /api/client/js/ redirect;

--- a/nginx.conf
+++ b/nginx.conf
@@ -21,16 +21,16 @@ server {
     set $backend "https://apify.github.io/apify-docs";
     resolver 1.1.1.1 8.8.8.8 valid=30s ipv6=off;
 
-    # Stale Docusaurus chunks: when a deploy invalidates hashed JS bundles, signal
-    # search engine crawlers to drop cached references by returning 410 (Gone) instead of 404.
-    proxy_intercept_errors on;
-    error_page 404 = @maybe_gone_js_asset;
+    # Stale Docusaurus chunks: return 410 instead of 404 for missing /assets/{js,css}/*
+    # so caches/crawlers drop references to hashed bundles removed by a new deploy.
+    # Scoped to dedicated locations per backend so the nice Docusaurus 404 page is
+    # preserved for everything else.
+    location @gone { return 410; }
 
-    location @maybe_gone_js_asset {
-        if ($request_uri ~ "/assets/js/[^?]+\.js(\?|$)") {
-            return 410;
-        }
-        return 404;
+    location ~ ^/assets/(js/.+\.js|css/.+\.css)$ {
+        proxy_intercept_errors on;
+        error_page 404 = @gone;
+        proxy_pass $backend$request_uri;
     }
 
     location = / {
@@ -75,6 +75,12 @@ server {
 
     ### Repository path: "/sdk/js"
 
+    location ~ ^/sdk/js/(assets/js/.+\.js|assets/css/.+\.css)$ {
+        proxy_intercept_errors on;
+        error_page 404 = @gone;
+        proxy_pass https://apify.github.io/apify-sdk-js/$1;
+    }
+
     location = /sdk/js {
         if ($serve_markdown) {
             rewrite ^ /sdk-js-llms.txt last;
@@ -115,6 +121,12 @@ server {
     }
 
     ### Repository path: "/sdk/python"
+
+    location ~ ^/sdk/python/(assets/js/.+\.js|assets/css/.+\.css)$ {
+        proxy_intercept_errors on;
+        error_page 404 = @gone;
+        proxy_pass https://apify.github.io/apify-sdk-python/$1;
+    }
 
     location = /sdk/python {
         if ($serve_markdown) {
@@ -157,6 +169,12 @@ server {
 
     ### Repository path: "/api/client/js"
 
+    location ~ ^/api/client/js/(assets/js/.+\.js|assets/css/.+\.css)$ {
+        proxy_intercept_errors on;
+        error_page 404 = @gone;
+        proxy_pass https://apify.github.io/apify-client-js/$1;
+    }
+
     location = /api/client/js {
         if ($serve_markdown) {
             rewrite ^ /client-js-llms.txt last;
@@ -198,6 +216,12 @@ server {
 
     ### Repository path: "/api/client/python"
 
+    location ~ ^/api/client/python/(assets/js/.+\.js|assets/css/.+\.css)$ {
+        proxy_intercept_errors on;
+        error_page 404 = @gone;
+        proxy_pass https://apify.github.io/apify-client-python/$1;
+    }
+
     location = /api/client/python {
         if ($serve_markdown) {
             rewrite ^ /client-python-llms.txt last;
@@ -238,6 +262,12 @@ server {
     }
 
     ### Repository path: "/cli"
+
+    location ~ ^/cli/(assets/js/.+\.js|assets/css/.+\.css)$ {
+        proxy_intercept_errors on;
+        error_page 404 = @gone;
+        proxy_pass https://apify.github.io/apify-cli/$1;
+    }
 
     location = /cli {
         if ($serve_markdown) {

--- a/nginx.conf
+++ b/nginx.conf
@@ -780,18 +780,6 @@ server {
     resolver 172.20.0.10;
     server_name ~^(?<subdomain>[^.]+)\.preview\.docs\.apify\.com$;
 
-    # Stale Docusaurus chunks: when a deploy invalidates hashed JS bundles, signal
-    # search engine crawlers to drop cached references by returning 410 (Gone) instead of 404.
-    proxy_intercept_errors on;
-    error_page 404 = @maybe_gone_js_asset;
-
-    location @maybe_gone_js_asset {
-        if ($request_uri ~ "/assets/js/[^?]+\.js(\?|$)") {
-            return 410;
-        }
-        return 404;
-    }
-
     # add trailing slashes to the root of GH pages docs
     rewrite ^/api/client/js$ /api/client/js/ redirect;
     rewrite ^/api/client/python$ /api/client/python/ redirect;


### PR DESCRIPTION
As per the findings of the SEO team:

> The 404 JS files (e.g. docs.apify.com/assets/js/3b91d6c4.c7552f0b.js) are auto-generated during deployment. Every time the site is updated and published, these JS files are generated with new random names and the old ones are deleted. Googlebot had cached the old filenames and kept trying to fetch them after they were already gone, causing the 404s.
> Why we should solve this: Googlebot is wasting its crawl budget on docs.apify.com requesting JS files that no longer exist, causing an 8% 404 instead of crawling actual content pages.

Returning `410 Gone` instead of `404 Not Found` on regenerated JS assets should send a stronger signal that the asset path is no longer valid to the consumer. 
