### PR TITLE
docs(openapi): Autofix OpenAPI spec validation errors

### DIFF
--- a/apify-api/openapi/components/objects/logs/log.yaml
+++ b/apify-api/openapi/components/objects/logs/log.yaml
@@ -100,6 +100,8 @@ getLastRun:
   operationId: act_runs_last_log_get
   parameters:
     - $ref: "../../parameters/runAndBuildParameters.yaml#/actorId"
+    - $ref: "../../parameters/runAndBuildParameters.yaml#/statusLastRun"
+    - $ref: "../../parameters/runAndBuildParameters.yaml#/originLastRun"
     - $ref: "../../parameters/logParameters.yaml#/stream"
     - $ref: "../../parameters/logParameters.yaml#/download"
     - $ref: "../../parameters/logParameters.yaml#/raw"
@@ -116,6 +118,8 @@ getTaskLastRun:
   operationId: actorTask_last_log_get
   parameters:
     - $ref: "../../parameters/runAndBuildParameters.yaml#/actorTaskId"
+    - $ref: "../../parameters/runAndBuildParameters.yaml#/statusLastRun"
+    - $ref: "../../parameters/runAndBuildParameters.yaml#/originLastRun"
     - $ref: "../../parameters/logParameters.yaml#/stream"
     - $ref: "../../parameters/logParameters.yaml#/download"
     - $ref: "../../parameters/logParameters.yaml#/raw"

--- a/apify-api/openapi/components/parameters/runAndBuildParameters.yaml
+++ b/apify-api/openapi/components/parameters/runAndBuildParameters.yaml
@@ -98,6 +98,15 @@ statusLastRun:
     type: string
     example: SUCCEEDED
 
+originLastRun:
+  name: origin
+  in: query
+  description: Filter for the run origin.
+  style: form
+  explode: true
+  schema:
+    $ref: ../schemas/actor-runs/RunOrigin.yaml
+
 timeout: &timeout
   name: timeout
   in: query

--- a/apify-api/openapi/openapi.yaml
+++ b/apify-api/openapi/openapi.yaml
@@ -742,6 +742,8 @@ paths:
     $ref: paths/tools/tools@encode-and-sign.yaml
   /v2/tools/decode-and-verify:
     $ref: paths/tools/tools@decode-and-verify.yaml
+  /v2/openapi.json:
+    $ref: paths/openapi.json.yaml
 components:
   securitySchemes:
     httpBearer:

--- a/apify-api/openapi/paths/openapi.json.yaml
+++ b/apify-api/openapi/paths/openapi.json.yaml
@@ -1,0 +1,24 @@
+get:
+  tags:
+    - Tools
+  summary: Get OpenAPI definition
+  description: |
+    Returns the OpenAPI specification document for the Apify API.
+
+    The returned document describes every endpoint of the Apify public API.
+    No authentication is required.
+  operationId: openapi_json_get
+  security: []
+  responses:
+    "200":
+      description: The OpenAPI specification document for the Apify API.
+      headers: {}
+      content:
+        application/json:
+          schema:
+            type: object
+            description: A standard OpenAPI 3.x JSON document.
+    "405":
+      $ref: ../components/responses/MethodNotAllowed.yaml
+    "429":
+      $ref: ../components/responses/TooManyRequests.yaml


### PR DESCRIPTION
## Summary
Autogenerated OpenAPI fixes suggestions based on validation errors generated from running API integration tests with OpenAPI validator turned on.

**Error log:** https://apify-pr-test-env-logs.s3.us-east-1.amazonaws.com/apify/apify-core/27741/api-26503638a9894312504cba273505e092d4d29ead.log

**apify-core version:** https://github.com/apify/apify-core/commit/7d2eac75947fb2075dee591dec0d90a3883e0dbe

**Stop reason:** No further fixes are possible without re-examining the upstream apify-core API. The remaining response-validation errors (48 unique) are all instances of the documented nullable `date-time` validator false positive (covering `finishedAt`, `lastRunAt`, `nextRunAt`, `startedAt`, `lastDispatch`, `taggedBuilds.*`). The remaining request-validation errors are either intentional malformed-input tests (sending invalid dates, wrong enum values, missing required fields, unsupported media types, etc.) or middleware-induced false positives caused by the global `?method=` HTTP method override that runs outside the validator's scope.

## Detailed changes description
### Error fixes

#### Document `status` and `origin` query parameters on the last-Actor-run log endpoint
- **Files:** `apify-api/openapi/components/objects/logs/log.yaml:101-105` and `apify-api/openapi/components/parameters/runAndBuildParameters.yaml:101-109`
- **Error:** `WARN Request OpenAPI validation error {"url":"/v2/acts/{actorId}/runs/last/log?status=SUCCEEDED","method":"GET","errors":[{"message":"Unknown query parameter 'status'","path":"/query/status"}]}`
- **Root cause:** The shared `lastRunRouter` handler for `/v2/acts/{actorId}/runs/last*` reads the `status` and `origin` query parameters from `req.query` and uses them to select the most recent run before delegating to the specific sub-endpoint. These parameters were declared on the parent `act_runs_last_get` operation (via the pre-existing `statusLastRun` parameter), but they were missing from the convenience log endpoint `act_runs_last_log_get`. Added references to `statusLastRun` and a new `originLastRun` parameter (which reuses the existing `RunOrigin` schema so the documented values match the API validation).
- **Reference:** https://github.com/apify/apify-core/tree/7d2eac75947fb2075dee591dec0d90a3883e0dbe/src/api/src/routes/actors/last_run.ts#L21

#### Document `status` and `origin` query parameters on the last-Actor-task-run log endpoint
- **Files:** `apify-api/openapi/components/objects/logs/log.yaml:118-122` and `apify-api/openapi/components/parameters/runAndBuildParameters.yaml:101-109`
- **Error:** `WARN Request OpenAPI validation error {"url":"/v2/actor-tasks/{actorTaskId}/runs/last/log?status=SUCCEEDED","method":"GET","errors":[{"message":"Unknown query parameter 'status'","path":"/query/status"}]}`
- **Root cause:** Same root cause as above — the Actor-tasks variant of the last/log endpoint also passes through the same `lastRunRouter` controller in apify-core (mounted at `/actor-tasks/:actorTaskId/runs/last*`), which accepts the `status` and `origin` query parameters. The spec entry `actorTask_last_log_get` was missing both parameters.
- **Reference:** https://github.com/apify/apify-core/tree/7d2eac75947fb2075dee591dec0d90a3883e0dbe/src/api/src/routes/actor_tasks/last_run.ts

#### Add the `/v2/openapi.json` endpoint to the spec
- **Files:** `apify-api/openapi/paths/openapi.json.yaml` (new) and `apify-api/openapi/openapi.yaml:745-746`
- **Error:** `WARN Request OpenAPI validation error {"url":"/v2/openapi.json","method":"GET","errors":[{"message":"not found","path":"/openapi.json"}]}`
- **Root cause:** The `/v2/openapi.json` endpoint is wired up in apify-core (`API_V2_SERVER_ROUTES.MISC.OPENAPI`) and served by the `OpenApiRetriever` controller, but the OpenAPI specification did not include a path entry for it. Added a new path describing the unauthenticated GET that returns the OpenAPI JSON document, with the conventional 405 and 429 error responses.
- **Reference:** https://github.com/apify/apify-core/tree/7d2eac75947fb2075dee591dec0d90a3883e0dbe/src/api/src/routes/misc/openapi.ts#L33

### Refactoring
None.

## Issues
Partially implements: https://github.com/apify/apify-docs/issues/2286

## Unfixed errors

### False positives

#### Nullable `date-time` fields trigger the validator on `taggedBuilds.*.finishedAt`, schedule `lastRunAt`/`nextRunAt`, webhook-dispatch `calls[].startedAt`/`finishedAt`, and webhook `lastDispatch`
- **Error:** `WARN Response OpenAPI validation error {"url":"/v2/acts/{actorId}","method":"GET","statusCode":200,"errors":[{"message":"must be string,null","errorCode":"type.openapi.validation","path":"/response/data/taggedBuilds/latest/finishedAt"}, ...]}` (and equivalent errors on `PUT /v2/acts/{actorId}`, `GET/POST /v2/schedules`, `GET /v2/schedules/{scheduleId}`, `GET /v2/webhook-dispatches/{dispatchId}`, `PUT /v2/webhooks/{webhookId}`)
- **Root cause:** All 48 unique response-validation errors collapse to a single root cause: fields declared as `type: [string, "null"]` with `format: date-time` are valid OpenAPI 3.1 multi-type definitions, but the `express-openapi-validator`/Ajv combination does not honor multi-type for formatted strings and emits `must be string,null` on every `null` value. The cascading `must be null` and `must match a schema in anyOf` errors at the parent paths (`taggedBuilds`, `taggedBuilds.latest`, `lastDispatch`) are downstream effects of the same root cause. Per `CLAUDE.md`, this is a documented validator false positive and must not be "fixed" by changing the schema.
- **Reference:** https://github.com/apify/apify-core/tree/7d2eac75947fb2075dee591dec0d90a3883e0dbe/src/api/src/lib/api_server.ts#L131

#### `?method=` query parameter on every endpoint is a global HTTP-method override
- **Error:** `WARN Request OpenAPI validation error {"url":"/v2/browser-info?method=PoSt","method":"POST","errors":[{"message":"Unknown query parameter 'method'","path":"/query/method"}]}` (and similar lines for `/v2/browser-info?method=XXX` and `/v2/actor-tasks/{actorTaskId}/runs?method=post`)
- **Root cause:** apify-core applies `overrideMethodMiddleware` as part of the route-specific middleware chain, which lets clients change the HTTP method via the `?method=` query string. The OpenAPI validator runs at the global app level and sees the `method` query parameter on every URL, but the OpenAPI spec does not (and arguably should not) duplicate it on every operation. The PR template `CLAUDE.md` explicitly lists middleware-induced request transformations as a known source of false positives.
- **Reference:** https://github.com/apify/apify-core/tree/7d2eac75947fb2075dee591dec0d90a3883e0dbe/src/api/src/middleware/override_method_by_param.ts#L8

### Out of scope errors

#### Intentional malformed-input request validations
- **Error:** Numerous `WARN Request OpenAPI validation error` lines for `body/generalAccess` enum/type (`PUT /v2/actor-runs/{runId}`, `PUT /v2/datasets/{datasetId}`, `PUT /v2/key-value-stores/{storeId}`, `PUT /v2/request-queues/{queueId}`), `body/handledAt` `must match format date-time` (`POST /v2/request-queues/{queueId}/requests`, `POST /v2/request-queues/{queueId}/requests/batch`, `PUT /v2/request-queues/{queueId}/requests/{requestId}`), `headers/content-encoding` enum (`PUT /v2/key-value-stores/{storeId}/records/{recordKey}`), `query/startedAfter`/`query/startedBefore` `must match format date-time` (`GET /v2/acts/{actorId}/runs`), `query/filter` enum (`GET /v2/request-queues/{queueId}/requests`), `OPTIONS method not allowed` on `/v2/users/{userId}`, `unsupported media type application/x-www-form-urlencoded` on `POST /v2/acts`, `unsupported media type text/plain` on `POST /v2/tools/encode-and-sign`, `body must be array` and `must have required property 'id'`/`'uniqueKey'` on `DELETE /v2/request-queues/{queueId}/requests/batch`, `body/eventTypes/0` enum on `POST /v2/webhooks`, `body/options/timeoutSecs` `must be integer,null` on `PUT /v2/actor-tasks/{actorTaskId}`, `must have required property 'actId'` on `POST /v2/actor-tasks`, `body` and `body/0`/`body/1` `must be object` / `oneOf` mismatches on `POST /v2/datasets/{datasetId}/items`, `body/input` `must be object`/`must be null` on `POST` and `PUT /v2/actor-tasks/{actorTaskId}`, `must have required property 'id'` on `PUT /v2/actor-runs/{runId}/request-queue/requests/{requestId}`.
- **Root cause:** All of these requests are produced by integration tests that deliberately send malformed inputs to exercise the API's request-rejection paths (each is followed by an `SFAIL`/`type:invalid-input` log line showing the API correctly rejects them). Per `CLAUDE.md`, request-validation errors caused by intentional bad-input tests are not spec issues and must not be "fixed".

---
_Generated by [Claude Code](https://claude.ai/code/session_015ys1mchQZzridkdj3g9aTk)_