### PR TITLE
fix: Update MCP CLI repository URL from mcp-cli to mcpc

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -140,6 +140,7 @@ Use `pnpm start:dev` + nginx to serve all repos together locally. See `CONTRIBUT
 - Auto-deploy on merge to `master`
 - Preview builds on pull requests
 - PR titles must use [Conventional Commits](https://www.conventionalcommits.org/) format (`docs:`, `fix:`, `feat:`, etc.) - enforced by CI
+- Keep PR descriptions short - one or two sentences covering what changed and why. Skip boilerplate headings (`## Summary`, `## Changes`, `## Details`), bullet lists that restate the diff, and filler text. The diff is the record of what changed; the description explains the why.
 
 ## Common pitfalls
 

--- a/apify-docs-theme/src/config.js
+++ b/apify-docs-theme/src/config.js
@@ -120,7 +120,7 @@ const themeConfig = {
                     },
                     {
                         label: 'MCP CLI',
-                        href: 'https://github.com/apify/mcp-cli',
+                        href: 'https://github.com/apify/mcpc',
                     },
                     {
                         label: 'Actor whitepaper',

--- a/apify-docs-theme/src/config.js
+++ b/apify-docs-theme/src/config.js
@@ -234,6 +234,12 @@ const themeConfig = {
                         target: '_self',
                         rel: 'dofollow',
                     },
+                    {
+                        label: 'llms.txt',
+                        href: `${absoluteUrl}/llms.txt`,
+                        target: '_self',
+                        rel: 'dofollow',
+                    },
                 ],
             },
             {

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -280,7 +280,7 @@ module.exports = {
             /** @type {import('@signalwire/docusaurus-plugin-llms-txt').PluginOptions} */
             ({
                 siteDescription:
-                    'Apify is the largest marketplace of tools for AI. 25,000 ready-made Actors to automate your business. Get real-time web data, track competitors, generate leads, analyze sentiment, and orchestrate your apps. Actors are created by a global community of builders earning over $1M every month. Apify takes care of infrastructure, billing, and distribution.\n\nThe entire content of Apify documentation is available in a single Markdown file at https://docs.apify.com/llms-full.txt\n\nFor pricing details, see https://apify.com/pricing',
+                    'Apify is the largest marketplace of tools for AI. 25,000 ready-made Actors to automate your business. Get real-time web data, track competitors, generate leads, analyze sentiment, and orchestrate your apps. Actors are created by a global community of builders earning over $1M every month. Apify takes care of infrastructure, billing, and distribution.\n\nThe entire content of Apify documentation is available in a single Markdown file at https://docs.apify.com/llms-full.txt\n\nFor pricing details, see https://apify.com/pricing.md',
                 content: {
                     includeVersionedDocs: false,
                     enableLlmsFullTxt: true,

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -280,7 +280,7 @@ module.exports = {
             /** @type {import('@signalwire/docusaurus-plugin-llms-txt').PluginOptions} */
             ({
                 siteDescription:
-                    'Apify is the largest marketplace of tools for AI. 25,000 ready-made Actors to automate your business. Get real-time web data, track competitors, generate leads, analyze sentiment, and orchestrate your apps. Actors are created by a global community of builders earning over $1M every month. Apify takes care of infrastructure, billing, and distribution.\n\nThe entire content of Apify documentation is available in a single Markdown file at https://docs.apify.com/llms-full.txt\n\nFor pricing details, see https://apify.com/pricing.md',
+                    'Apify is the largest marketplace of tools for AI. Thousands of ready-made Actors to automate your business. Get real-time web data, track competitors, generate leads, analyze sentiment, and orchestrate your apps. Actors are created by a global community of builders earning over $1M every month. Apify takes care of infrastructure, billing, and distribution.\n\nThe entire content of Apify documentation is available in a single Markdown file at https://docs.apify.com/llms-full.txt\n\nFor pricing details, see https://apify.com/pricing.md',
                 content: {
                     includeVersionedDocs: false,
                     enableLlmsFullTxt: true,

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -345,7 +345,7 @@ module.exports = {
                         },
                         {
                             route: '/academy/**',
-                            categoryName: 'Apify academy',
+                            categoryName: 'Apify Academy',
                         },
                         {
                             route: '/legal/**',

--- a/scripts/joinLlmsFiles.mjs
+++ b/scripts/joinLlmsFiles.mjs
@@ -116,7 +116,7 @@ const SECTION_ORDER = [
     'Apify SDK for JavaScript',
     'Apify SDK for Python',
     'Apify CLI',
-    'Apify academy',
+    'Apify Academy',
     'Legal documents',
 ];
 

--- a/sources/platform/index.mdx
+++ b/sources/platform/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: Apify Platform documentation
+title: Apify platform documentation
 description: Apify is a cloud platform for web scraping, data extraction, and automation. Run pre-built Actors or develop your own tools on the Apify platform.
 slug: /
 hide_table_of_contents: true

--- a/sources/platform/integrations/ai/agno.md
+++ b/sources/platform/integrations/ai/agno.md
@@ -129,9 +129,8 @@ Agno supports any Apify Actor via the ApifyTools class. You can specify a single
 
 ## Resources
 
-- [How to build an AI Agent](https://blog.apify.com/how-to-build-an-ai-agent/)
-- [Agno Framework Documentation](https://docs.agno.com)
-- [Apify platform Documentation](https://docs.apify.com)
-- [Apify Actor Documentation](/platform/actors)
-- [Apify Store - Browse available Actors](https://apify.com/store)
-- [Agno Apify Toolkit Documentation](https://docs.agno.com/tools/toolkits/others/apify#apify)
+- [How to build an AI agent](https://blog.apify.com/how-to-build-an-ai-agent/)
+- [Agno framework documentation](https://docs.agno.com)
+- [Apify Actor documentation](/platform/actors)
+- [Apify Store - browse available Actors](https://apify.com/store)
+- [Agno Apify toolkit documentation](https://docs.agno.com/tools/toolkits/others/apify#apify)

--- a/sources/platform/integrations/ai/agno.md
+++ b/sources/platform/integrations/ai/agno.md
@@ -131,7 +131,7 @@ Agno supports any Apify Actor via the ApifyTools class. You can specify a single
 
 - [How to build an AI Agent](https://blog.apify.com/how-to-build-an-ai-agent/)
 - [Agno Framework Documentation](https://docs.agno.com)
-- [Apify Platform Documentation](https://docs.apify.com)
+- [Apify platform Documentation](https://docs.apify.com)
 - [Apify Actor Documentation](/platform/actors)
 - [Apify Store - Browse available Actors](https://apify.com/store)
 - [Agno Apify Toolkit Documentation](https://docs.agno.com/tools/toolkits/others/apify#apify)

--- a/sources/platform/integrations/ai/x402.md
+++ b/sources/platform/integrations/ai/x402.md
@@ -22,7 +22,7 @@ When a server requires payment, it responds with HTTP `402` and tells the client
 
 ## Prerequisites
 
-- [`mcpc` CLI](https://github.com/apify/mcp-cli) installed (`npm install -g @apify/mcpc`) - manages your wallet and signs payments.
+- [`mcpc` CLI](https://github.com/apify/mcpc) installed (`npm install -g @apify/mcpc`) - manages your wallet and signs payments.
 - A wallet funded with USDC on [Base](https://www.base.org/) mainnet.
 
 ### Wallet setup

--- a/sources/platform/integrations/ai/x402.md
+++ b/sources/platform/integrations/ai/x402.md
@@ -22,7 +22,7 @@ When a server requires payment, it responds with HTTP `402` and tells the client
 
 ## Prerequisites
 
-- [`mcpc` CLI](https://github.com/apify/mcpc) installed (`npm install -g @apify/mcpc`) - manages your wallet and signs payments.
+- [`mcpc` MCP CLI](https://github.com/apify/mcpc) installed (`npm install -g @apify/mcpc`) - manages your wallet and signs payments.
 - A wallet funded with USDC on [Base](https://www.base.org/) mainnet.
 
 ### Wallet setup

--- a/src/components/OpenSourceCards/OpenSourceCards.tsx
+++ b/src/components/OpenSourceCards/OpenSourceCards.tsx
@@ -123,7 +123,7 @@ const OpenSourceCards: React.FC<OpenSourceCardsProps> = ({ hideCrawlee = false }
             />
             <CardWithImageAndContent
                 image={
-                    <Link to="https://github.com/apify/mcp-cli" className={styles.imageLink}>
+                    <Link to="https://github.com/apify/mcpc" className={styles.imageLink}>
                         <div className={styles.iconWrapper}>
                             <img src={useBaseUrl('/img/landing-pages/mcpc.svg')} alt="mcpc" />
                         </div>
@@ -132,7 +132,7 @@ const OpenSourceCards: React.FC<OpenSourceCardsProps> = ({ hideCrawlee = false }
                 content={
                     <div className="cardContentWrapper">
                         <div className="cardContentWrapperText">
-                            <Link to="https://github.com/apify/mcp-cli" className={styles.headingLink}>
+                            <Link to="https://github.com/apify/mcpc" className={styles.headingLink}>
                                 <Heading type="titleM">mcpc</Heading>
                             </Link>
                             <Text color={theme.color.neutral.textMuted}>
@@ -142,11 +142,11 @@ const OpenSourceCards: React.FC<OpenSourceCardsProps> = ({ hideCrawlee = false }
                         </div>
                         <div className={styles.githubButtonWrapper}>
                             <GitHubButton
-                                href="https://github.com/apify/mcp-cli"
+                                href="https://github.com/apify/mcpc"
                                 data-color-scheme={colorMode}
                                 data-size="large"
                                 data-show-count="true"
-                                aria-label="Star apify/mcp-cli on GitHub"
+                                aria-label="Star apify/mcpc on GitHub"
                             >
                                 Star
                             </GitHubButton>


### PR DESCRIPTION
Updates references from `apify/mcp-cli` to `apify/mcpc` (repo renamed), labels `mcpc` as "MCP CLI" in the x402 prerequisites, and points the llms.txt pricing link to the `.md` variant.

https://claude.ai/code/session_014ZtLVLVdZMRJjbx2hXboe9