### PR TITLE
fix(openapi): allow 128MB memory limits and add CI to RunOrigin enum

### DIFF
--- a/apify-api/openapi/components/schemas/actor-runs/RunOrigin.yaml
+++ b/apify-api/openapi/components/schemas/actor-runs/RunOrigin.yaml
@@ -9,4 +9,5 @@ enum:
   - WEBHOOK
   - ACTOR
   - CLI
+  - CI
   - STANDBY

--- a/apify-api/openapi/components/schemas/actors/ActorDefinition.yaml
+++ b/apify-api/openapi/components/schemas/actors/ActorDefinition.yaml
@@ -51,11 +51,11 @@ properties:
     description: Specifies the default amount of memory in megabytes to be used when the Actor is started. Can be an integer or a [dynamic memory expression](/platform/actors/development/actor-definition/dynamic-actor-memory).
   minMemoryMbytes:
     type: integer
-    minimum: 256
+    minimum: 128
     description: Specifies the minimum amount of memory in megabytes required by the Actor.
   maxMemoryMbytes:
     type: integer
-    minimum: 256
+    minimum: 128
     description: Specifies the maximum amount of memory in megabytes required by the Actor.
   usesStandbyMode:
     type: boolean


### PR DESCRIPTION
Two schema mismatches with the live API:

1. **`ActorDefinition.minMemoryMbytes` / `maxMemoryMbytes`** required `>= 256`, but actors actually run with 128 MB (the real platform minimum, consistent with `RunOptions.memoryMbytes: minimum 128`). Affected at least 20 store actors (`apify/instagram-profile-scraper`, all of `apimaestro/*`, `harvestapi/*`, …).
2. **`RunOrigin`** enum was missing `CI`. `apify/cheerio-scraper` and other Apify-owned actors have builds with `meta.origin: "CI"` from the internal CI pipeline.