### PR TITLE
fix(openapi): Add missing response fields returned by the live API

### DIFF
--- a/apify-api/openapi/components/schemas/actor-builds/Build.yaml
+++ b/apify-api/openapi/components/schemas/actor-builds/Build.yaml
@@ -63,6 +63,7 @@ properties:
     examples: ['# Magic Actor\nThis Actor is magic.']
   buildNumber:
     type: string
+    pattern: ^[0-9]+(\.[0-9]+)+(-[0-9A-Za-z][0-9A-Za-z\-\.]*)?$
     examples: [0.1.1]
   actVersion:
     title: BuildActVersion
@@ -76,6 +77,7 @@ properties:
         examples: [experimental]
       versionNumber:
         type: string
+        pattern: ^[0-9]+(\.[0-9]+)+(-[0-9A-Za-z][0-9A-Za-z\-\.]*)?$
         examples: ["0.0"]
       gitRepoUrl:
         type: string

--- a/apify-api/openapi/components/schemas/actor-builds/Build.yaml
+++ b/apify-api/openapi/components/schemas/actor-builds/Build.yaml
@@ -63,7 +63,7 @@ properties:
     examples: ['# Magic Actor\nThis Actor is magic.']
   buildNumber:
     type: string
-    pattern: ^([0-9]|[1-9][0-9])\.([0-9]|[1-9][0-9])(\.[1-9][0-9]{0,4})?$
+    pattern: ^([0-9]|[1-9][0-9])\.([0-9]|[1-9][0-9])(\.[1-9][0-9]{0,4})$
     examples: [0.1.1]
   actVersion:
     title: BuildActVersion

--- a/apify-api/openapi/components/schemas/actor-builds/Build.yaml
+++ b/apify-api/openapi/components/schemas/actor-builds/Build.yaml
@@ -63,7 +63,7 @@ properties:
     examples: ['# Magic Actor\nThis Actor is magic.']
   buildNumber:
     type: string
-    pattern: ^[0-9]+(\.[0-9]+)+(-[0-9A-Za-z][0-9A-Za-z\-\.]*)?$
+    pattern: ^(0|[1-9][0-9]?)\.(0|[1-9][0-9]?)(\.[1-9][0-9]{0,4})?$
     examples: [0.1.1]
   actVersion:
     title: BuildActVersion
@@ -77,7 +77,7 @@ properties:
         examples: [experimental]
       versionNumber:
         type: string
-        pattern: ^[0-9]+(\.[0-9]+)+(-[0-9A-Za-z][0-9A-Za-z\-\.]*)?$
+        pattern: ^(0|[1-9][0-9]?)\.(0|[1-9][0-9]?)$
         examples: ["0.0"]
       gitRepoUrl:
         type: string

--- a/apify-api/openapi/components/schemas/actor-builds/Build.yaml
+++ b/apify-api/openapi/components/schemas/actor-builds/Build.yaml
@@ -70,9 +70,7 @@ properties:
     description: Snapshot of the Actor version that this build was created from.
     properties:
       sourceType:
-        type: string
-        description: The source type of the Actor version (e.g. SOURCE_FILES, GIT_REPO, TARBALL, GITHUB_GIST).
-        examples: [SOURCE_FILES]
+        $ref: ../actors/VersionSourceType.yaml
       buildTag:
         type: string
         examples: [experimental]

--- a/apify-api/openapi/components/schemas/actor-builds/Build.yaml
+++ b/apify-api/openapi/components/schemas/actor-builds/Build.yaml
@@ -63,7 +63,7 @@ properties:
     examples: ['# Magic Actor\nThis Actor is magic.']
   buildNumber:
     type: string
-    pattern: ^(0|[1-9][0-9]?)\.(0|[1-9][0-9]?)(\.[1-9][0-9]{0,4})?$
+    pattern: ^([0-9]|[1-9][0-9])\.([0-9]|[1-9][0-9])(\.[1-9][0-9]{0,4})?$
     examples: [0.1.1]
   actVersion:
     title: BuildActVersion
@@ -77,7 +77,7 @@ properties:
         examples: [experimental]
       versionNumber:
         type: string
-        pattern: ^(0|[1-9][0-9]?)\.(0|[1-9][0-9]?)$
+        pattern: ^([0-9]|[1-9][0-9])\.([0-9]|[1-9][0-9])$
         examples: ["0.0"]
       gitRepoUrl:
         type: string

--- a/apify-api/openapi/components/schemas/actor-builds/Build.yaml
+++ b/apify-api/openapi/components/schemas/actor-builds/Build.yaml
@@ -65,12 +65,10 @@ properties:
     type: string
     examples: [0.1.1]
   actVersion:
+    title: BuildActVersion
     type: object
     description: Snapshot of the Actor version that this build was created from.
     properties:
-      gitRepoUrl:
-        type: string
-        examples: ["https://github.com/apifytech/actor-crawler.git#experimental:web-scraper"]
       sourceType:
         $ref: ../actors/VersionSourceType.yaml
       buildTag:
@@ -79,6 +77,15 @@ properties:
       versionNumber:
         type: string
         examples: ["0.0"]
+      gitRepoUrl:
+        type: string
+        description: URL of the git repository, present when sourceType is GIT_REPO.
+        examples: ["https://github.com/apifytech/actor-crawler.git#experimental:web-scraper"]
+      sourceFiles:
+        type: array
+        description: Inline source files, present when sourceType is SOURCE_FILES.
+        items:
+          $ref: ../actors/SourceCodeFile.yaml
   actorDefinition:
     anyOf:
       - $ref: ../actors/ActorDefinition.yaml

--- a/apify-api/openapi/components/schemas/actor-builds/Build.yaml
+++ b/apify-api/openapi/components/schemas/actor-builds/Build.yaml
@@ -64,6 +64,21 @@ properties:
   buildNumber:
     type: string
     examples: [0.1.1]
+  actVersion:
+    type: object
+    description: Snapshot of the Actor version that this build was created from.
+    properties:
+      gitRepoUrl:
+        type: string
+        examples: ["https://github.com/apifytech/actor-crawler.git#experimental:web-scraper"]
+      sourceType:
+        $ref: ../actors/VersionSourceType.yaml
+      buildTag:
+        type: string
+        examples: [experimental]
+      versionNumber:
+        type: string
+        examples: ["0.0"]
   actorDefinition:
     anyOf:
       - $ref: ../actors/ActorDefinition.yaml

--- a/apify-api/openapi/components/schemas/actor-builds/Build.yaml
+++ b/apify-api/openapi/components/schemas/actor-builds/Build.yaml
@@ -70,7 +70,9 @@ properties:
     description: Snapshot of the Actor version that this build was created from.
     properties:
       sourceType:
-        $ref: ../actors/VersionSourceType.yaml
+        type: string
+        description: The source type of the Actor version (e.g. SOURCE_FILES, GIT_REPO, TARBALL, GITHUB_GIST).
+        examples: [SOURCE_FILES]
       buildTag:
         type: string
         examples: [experimental]

--- a/apify-api/openapi/components/schemas/actor-builds/BuildShort.yaml
+++ b/apify-api/openapi/components/schemas/actor-builds/BuildShort.yaml
@@ -31,7 +31,7 @@ properties:
     examples: [0.02]
   buildNumber:
     type: string
-    pattern: ^(0|[1-9][0-9]?)\.(0|[1-9][0-9]?)(\.[1-9][0-9]{0,4})?$
+    pattern: ^([0-9]|[1-9][0-9])\.([0-9]|[1-9][0-9])(\.[1-9][0-9]{0,4})?$
     examples: [0.1.1]
   buildNumberInt:
     type: integer

--- a/apify-api/openapi/components/schemas/actor-builds/BuildShort.yaml
+++ b/apify-api/openapi/components/schemas/actor-builds/BuildShort.yaml
@@ -13,6 +13,9 @@ properties:
   actId:
     type: string
     examples: [janedoe~my-actor]
+  userId:
+    type: string
+    examples: [klmdEpoiojmdEMlk3]
   status:
     $ref: ../common/ActorJobStatus.yaml
   startedAt:
@@ -29,5 +32,8 @@ properties:
   buildNumber:
     type: string
     examples: [0.1.1]
+  buildNumberInt:
+    type: integer
+    examples: [10000]
   meta:
     $ref: ./BuildsMeta.yaml

--- a/apify-api/openapi/components/schemas/actor-builds/BuildShort.yaml
+++ b/apify-api/openapi/components/schemas/actor-builds/BuildShort.yaml
@@ -31,7 +31,7 @@ properties:
     examples: [0.02]
   buildNumber:
     type: string
-    pattern: ^[0-9]+(\.[0-9]+)+(-[0-9A-Za-z][0-9A-Za-z\-\.]*)?$
+    pattern: ^(0|[1-9][0-9]?)\.(0|[1-9][0-9]?)(\.[1-9][0-9]{0,4})?$
     examples: [0.1.1]
   buildNumberInt:
     type: integer

--- a/apify-api/openapi/components/schemas/actor-builds/BuildShort.yaml
+++ b/apify-api/openapi/components/schemas/actor-builds/BuildShort.yaml
@@ -31,6 +31,7 @@ properties:
     examples: [0.02]
   buildNumber:
     type: string
+    pattern: ^[0-9]+(\.[0-9]+)+(-[0-9A-Za-z][0-9A-Za-z\-\.]*)?$
     examples: [0.1.1]
   buildNumberInt:
     type: integer

--- a/apify-api/openapi/components/schemas/actor-builds/BuildShort.yaml
+++ b/apify-api/openapi/components/schemas/actor-builds/BuildShort.yaml
@@ -4,6 +4,7 @@ required:
   - status
   - startedAt
   - usageTotalUsd
+  - buildNumber
 type: object
 properties:
   id:
@@ -25,5 +26,8 @@ properties:
   usageTotalUsd:
     type: number
     examples: [0.02]
+  buildNumber:
+    type: string
+    examples: [0.1.1]
   meta:
     $ref: ./BuildsMeta.yaml

--- a/apify-api/openapi/components/schemas/actor-builds/BuildShort.yaml
+++ b/apify-api/openapi/components/schemas/actor-builds/BuildShort.yaml
@@ -31,7 +31,7 @@ properties:
     examples: [0.02]
   buildNumber:
     type: string
-    pattern: ^([0-9]|[1-9][0-9])\.([0-9]|[1-9][0-9])(\.[1-9][0-9]{0,4})?$
+    pattern: ^([0-9]|[1-9][0-9])\.([0-9]|[1-9][0-9])(\.[1-9][0-9]{0,4})$
     examples: [0.1.1]
   buildNumberInt:
     type: integer

--- a/apify-api/openapi/components/schemas/actor-builds/BuildStats.yaml
+++ b/apify-api/openapi/components/schemas/actor-builds/BuildStats.yaml
@@ -12,3 +12,6 @@ properties:
   computeUnits:
     type: number
     examples: [0.0126994444444444]
+  imageSizeBytes:
+    type: integer
+    examples: [975770223]

--- a/apify-api/openapi/components/schemas/actor-runs/Run.yaml
+++ b/apify-api/openapi/components/schemas/actor-runs/Run.yaml
@@ -133,7 +133,7 @@ properties:
           type: string
   buildNumber:
     type: [string, "null"]
-    pattern: ^([0-9]|[1-9][0-9])\.([0-9]|[1-9][0-9])(\.[1-9][0-9]{0,4})?$
+    pattern: ^([0-9]|[1-9][0-9])\.([0-9]|[1-9][0-9])(\.[1-9][0-9]{0,4})$
     examples: [0.0.36]
     description: Build number of the Actor build used for this run.
   containerUrl:

--- a/apify-api/openapi/components/schemas/actor-runs/Run.yaml
+++ b/apify-api/openapi/components/schemas/actor-runs/Run.yaml
@@ -133,7 +133,7 @@ properties:
           type: string
   buildNumber:
     type: [string, "null"]
-    pattern: ^(0|[1-9][0-9]?)\.(0|[1-9][0-9]?)(\.[1-9][0-9]{0,4})?$
+    pattern: ^([0-9]|[1-9][0-9])\.([0-9]|[1-9][0-9])(\.[1-9][0-9]{0,4})?$
     examples: [0.0.36]
     description: Build number of the Actor build used for this run.
   containerUrl:

--- a/apify-api/openapi/components/schemas/actor-runs/Run.yaml
+++ b/apify-api/openapi/components/schemas/actor-runs/Run.yaml
@@ -177,3 +177,7 @@ properties:
         items:
           $ref: ./Metamorph.yaml
       - type: "null"
+  platformUsageBillingModel:
+    type: string
+    description: Indicates which party covers platform usage costs for this run.
+    examples: [USER]

--- a/apify-api/openapi/components/schemas/actor-runs/Run.yaml
+++ b/apify-api/openapi/components/schemas/actor-runs/Run.yaml
@@ -133,7 +133,7 @@ properties:
           type: string
   buildNumber:
     type: [string, "null"]
-    pattern: ^[0-9]+(\.[0-9]+)+(-[0-9A-Za-z][0-9A-Za-z\-\.]*)?$
+    pattern: ^(0|[1-9][0-9]?)\.(0|[1-9][0-9]?)(\.[1-9][0-9]{0,4})?$
     examples: [0.0.36]
     description: Build number of the Actor build used for this run.
   containerUrl:

--- a/apify-api/openapi/components/schemas/actor-runs/Run.yaml
+++ b/apify-api/openapi/components/schemas/actor-runs/Run.yaml
@@ -133,6 +133,7 @@ properties:
           type: string
   buildNumber:
     type: [string, "null"]
+    pattern: ^[0-9]+(\.[0-9]+)+(-[0-9A-Za-z][0-9A-Za-z\-\.]*)?$
     examples: [0.0.36]
     description: Build number of the Actor build used for this run.
   containerUrl:

--- a/apify-api/openapi/components/schemas/actor-runs/RunShort.yaml
+++ b/apify-api/openapi/components/schemas/actor-runs/RunShort.yaml
@@ -39,7 +39,7 @@ properties:
     examples: [HG7ML7M8z78YcAPEB]
   buildNumber:
     type: string
-    pattern: ^[0-9]+(\.[0-9]+)+(-[0-9A-Za-z][0-9A-Za-z\-\.]*)?$
+    pattern: ^(0|[1-9][0-9]?)\.(0|[1-9][0-9]?)(\.[1-9][0-9]{0,4})?$
     examples: [0.0.2]
   buildNumberInt:
     type: integer

--- a/apify-api/openapi/components/schemas/actor-runs/RunShort.yaml
+++ b/apify-api/openapi/components/schemas/actor-runs/RunShort.yaml
@@ -39,7 +39,7 @@ properties:
     examples: [HG7ML7M8z78YcAPEB]
   buildNumber:
     type: string
-    pattern: ^(0|[1-9][0-9]?)\.(0|[1-9][0-9]?)(\.[1-9][0-9]{0,4})?$
+    pattern: ^([0-9]|[1-9][0-9])\.([0-9]|[1-9][0-9])(\.[1-9][0-9]{0,4})?$
     examples: [0.0.2]
   buildNumberInt:
     type: integer

--- a/apify-api/openapi/components/schemas/actor-runs/RunShort.yaml
+++ b/apify-api/openapi/components/schemas/actor-runs/RunShort.yaml
@@ -18,6 +18,9 @@ properties:
   actId:
     type: string
     examples: [HDSasDasz78YcAPEB]
+  userId:
+    type: string
+    examples: [7sT5jcggjjA9fNcxF]
   actorTaskId:
     type: [string, "null"]
     examples: [KJHSKHausidyaJKHs]
@@ -37,6 +40,9 @@ properties:
   buildNumber:
     type: string
     examples: [0.0.2]
+  buildNumberInt:
+    type: integer
+    examples: [10000]
   meta:
     $ref: ./RunMeta.yaml
   usageTotalUsd:

--- a/apify-api/openapi/components/schemas/actor-runs/RunShort.yaml
+++ b/apify-api/openapi/components/schemas/actor-runs/RunShort.yaml
@@ -39,7 +39,7 @@ properties:
     examples: [HG7ML7M8z78YcAPEB]
   buildNumber:
     type: string
-    pattern: ^([0-9]|[1-9][0-9])\.([0-9]|[1-9][0-9])(\.[1-9][0-9]{0,4})?$
+    pattern: ^([0-9]|[1-9][0-9])\.([0-9]|[1-9][0-9])(\.[1-9][0-9]{0,4})$
     examples: [0.0.2]
   buildNumberInt:
     type: integer

--- a/apify-api/openapi/components/schemas/actor-runs/RunShort.yaml
+++ b/apify-api/openapi/components/schemas/actor-runs/RunShort.yaml
@@ -39,6 +39,7 @@ properties:
     examples: [HG7ML7M8z78YcAPEB]
   buildNumber:
     type: string
+    pattern: ^[0-9]+(\.[0-9]+)+(-[0-9A-Za-z][0-9A-Za-z\-\.]*)?$
     examples: [0.0.2]
   buildNumberInt:
     type: integer

--- a/apify-api/openapi/components/schemas/actors/Actor.yaml
+++ b/apify-api/openapi/components/schemas/actors/Actor.yaml
@@ -81,3 +81,35 @@ properties:
   readmeSummary:
     type: string
     description: A brief, LLM-generated readme summary
+  seoTitle:
+    type: [string, "null"]
+    examples: [Web Scraper]
+  seoDescription:
+    type: [string, "null"]
+    examples: ["Crawls websites using Chrome and extracts data from pages using JavaScript."]
+  pictureUrl:
+    type: [string, "null"]
+    examples: ["https://apify-image-uploads-prod.s3.amazonaws.com/.../actor-picture.png"]
+  standbyUrl:
+    type: [string, "null"]
+    examples: ["https://my-actor.apify.actor"]
+  notice:
+    type: string
+    examples: [NONE]
+  categories:
+    type: array
+    items:
+      type: string
+    examples: [["DEVELOPER_TOOLS", "OPEN_SOURCE"]]
+  isCritical:
+    type: boolean
+    examples: [false]
+  isGeneric:
+    type: boolean
+    examples: [false]
+  isSourceCodeHidden:
+    type: boolean
+    examples: [false]
+  hasNoDataset:
+    type: boolean
+    examples: [false]

--- a/apify-api/openapi/components/schemas/actors/ActorStats.yaml
+++ b/apify-api/openapi/components/schemas/actors/ActorStats.yaml
@@ -26,3 +26,31 @@ properties:
     type: string
     format: date-time
     examples: ["2019-07-08T14:01:05.546Z"]
+  actorReviewCount:
+    type: integer
+    examples: [69]
+  actorReviewRating:
+    type: number
+    examples: [4.7]
+  bookmarkCount:
+    type: integer
+    examples: [1269]
+  publicActorRunStats30Days:
+    type: object
+    description: Run status counts over the past 30 days.
+    properties:
+      ABORTED:
+        type: integer
+        examples: [2542]
+      FAILED:
+        type: integer
+        examples: [1234]
+      SUCCEEDED:
+        type: integer
+        examples: [732805]
+      "TIMED-OUT":
+        type: integer
+        examples: [12556]
+      TOTAL:
+        type: integer
+        examples: [749137]

--- a/apify-api/openapi/components/schemas/actors/CreateOrUpdateVersionRequest.yaml
+++ b/apify-api/openapi/components/schemas/actors/CreateOrUpdateVersionRequest.yaml
@@ -3,6 +3,7 @@ type: object
 properties:
   versionNumber:
     type: [string, "null"]
+    pattern: ^[0-9]+(\.[0-9]+)+(-[0-9A-Za-z][0-9A-Za-z\-\.]*)?$
     examples: ["0.0"]
   sourceType:
     anyOf:

--- a/apify-api/openapi/components/schemas/actors/CreateOrUpdateVersionRequest.yaml
+++ b/apify-api/openapi/components/schemas/actors/CreateOrUpdateVersionRequest.yaml
@@ -3,7 +3,7 @@ type: object
 properties:
   versionNumber:
     type: [string, "null"]
-    pattern: ^(0|[1-9][0-9]?)\.(0|[1-9][0-9]?)$
+    pattern: ^([0-9]|[1-9][0-9])\.([0-9]|[1-9][0-9])$
     examples: ["0.0"]
   sourceType:
     anyOf:

--- a/apify-api/openapi/components/schemas/actors/CreateOrUpdateVersionRequest.yaml
+++ b/apify-api/openapi/components/schemas/actors/CreateOrUpdateVersionRequest.yaml
@@ -3,7 +3,7 @@ type: object
 properties:
   versionNumber:
     type: [string, "null"]
-    pattern: ^[0-9]+(\.[0-9]+)+(-[0-9A-Za-z][0-9A-Za-z\-\.]*)?$
+    pattern: ^(0|[1-9][0-9]?)\.(0|[1-9][0-9]?)$
     examples: ["0.0"]
   sourceType:
     anyOf:

--- a/apify-api/openapi/components/schemas/actors/TaggedBuildInfo.yaml
+++ b/apify-api/openapi/components/schemas/actors/TaggedBuildInfo.yaml
@@ -10,6 +10,10 @@ properties:
     type: string
     description: The build number/version string.
     examples: [0.0.2]
+  buildNumberInt:
+    type: integer
+    description: The build number encoded as a single integer.
+    examples: [42]
   finishedAt:
     type: [string, "null"]
     format: date-time

--- a/apify-api/openapi/components/schemas/actors/TaggedBuildInfo.yaml
+++ b/apify-api/openapi/components/schemas/actors/TaggedBuildInfo.yaml
@@ -8,6 +8,7 @@ properties:
     examples: [z2EryhbfhgSyqj6Hn]
   buildNumber:
     type: string
+    pattern: ^[0-9]+(\.[0-9]+)+(-[0-9A-Za-z][0-9A-Za-z\-\.]*)?$
     description: The build number/version string.
     examples: [0.0.2]
   buildNumberInt:

--- a/apify-api/openapi/components/schemas/actors/TaggedBuildInfo.yaml
+++ b/apify-api/openapi/components/schemas/actors/TaggedBuildInfo.yaml
@@ -8,7 +8,7 @@ properties:
     examples: [z2EryhbfhgSyqj6Hn]
   buildNumber:
     type: string
-    pattern: ^([0-9]|[1-9][0-9])\.([0-9]|[1-9][0-9])(\.[1-9][0-9]{0,4})?$
+    pattern: ^([0-9]|[1-9][0-9])\.([0-9]|[1-9][0-9])(\.[1-9][0-9]{0,4})$
     description: The build number/version string.
     examples: [0.0.2]
   buildNumberInt:

--- a/apify-api/openapi/components/schemas/actors/TaggedBuildInfo.yaml
+++ b/apify-api/openapi/components/schemas/actors/TaggedBuildInfo.yaml
@@ -8,7 +8,7 @@ properties:
     examples: [z2EryhbfhgSyqj6Hn]
   buildNumber:
     type: string
-    pattern: ^(0|[1-9][0-9]?)\.(0|[1-9][0-9]?)(\.[1-9][0-9]{0,4})?$
+    pattern: ^([0-9]|[1-9][0-9])\.([0-9]|[1-9][0-9])(\.[1-9][0-9]{0,4})?$
     description: The build number/version string.
     examples: [0.0.2]
   buildNumberInt:

--- a/apify-api/openapi/components/schemas/actors/TaggedBuildInfo.yaml
+++ b/apify-api/openapi/components/schemas/actors/TaggedBuildInfo.yaml
@@ -8,7 +8,7 @@ properties:
     examples: [z2EryhbfhgSyqj6Hn]
   buildNumber:
     type: string
-    pattern: ^[0-9]+(\.[0-9]+)+(-[0-9A-Za-z][0-9A-Za-z\-\.]*)?$
+    pattern: ^(0|[1-9][0-9]?)\.(0|[1-9][0-9]?)(\.[1-9][0-9]{0,4})?$
     description: The build number/version string.
     examples: [0.0.2]
   buildNumberInt:

--- a/apify-api/openapi/components/schemas/actors/TaggedBuilds.yaml
+++ b/apify-api/openapi/components/schemas/actors/TaggedBuilds.yaml
@@ -12,5 +12,5 @@ example:
     finishedAt: "2019-06-10T11:15:49.286Z"
   beta:
     buildId: abc123def456
-    buildNumber: 1.0.0-beta
+    buildNumber: 1.0.5
     finishedAt: "2019-07-15T14:30:00.000Z"

--- a/apify-api/openapi/components/schemas/actors/Version.yaml
+++ b/apify-api/openapi/components/schemas/actors/Version.yaml
@@ -6,7 +6,7 @@ required:
 properties:
   versionNumber:
     type: string
-    pattern: ^[0-9]+(\.[0-9]+)+(-[0-9A-Za-z][0-9A-Za-z\-\.]*)?$
+    pattern: ^(0|[1-9][0-9]?)\.(0|[1-9][0-9]?)$
     examples: ["0.0"]
   sourceType:
     anyOf:

--- a/apify-api/openapi/components/schemas/actors/Version.yaml
+++ b/apify-api/openapi/components/schemas/actors/Version.yaml
@@ -6,6 +6,7 @@ required:
 properties:
   versionNumber:
     type: string
+    pattern: ^[0-9]+(\.[0-9]+)+(-[0-9A-Za-z][0-9A-Za-z\-\.]*)?$
     examples: ["0.0"]
   sourceType:
     anyOf:

--- a/apify-api/openapi/components/schemas/actors/Version.yaml
+++ b/apify-api/openapi/components/schemas/actors/Version.yaml
@@ -6,7 +6,7 @@ required:
 properties:
   versionNumber:
     type: string
-    pattern: ^(0|[1-9][0-9]?)\.(0|[1-9][0-9]?)$
+    pattern: ^([0-9]|[1-9][0-9])\.([0-9]|[1-9][0-9])$
     examples: ["0.0"]
   sourceType:
     anyOf:

--- a/apify-api/openapi/components/schemas/actors/VersionSourceType.yaml
+++ b/apify-api/openapi/components/schemas/actors/VersionSourceType.yaml
@@ -4,4 +4,5 @@ enum:
   - GIT_REPO
   - TARBALL
   - GITHUB_GIST
+  - SOURCE_CODE
 type: string

--- a/apify-api/openapi/components/schemas/datasets/DatasetListItem.yaml
+++ b/apify-api/openapi/components/schemas/datasets/DatasetListItem.yaml
@@ -43,3 +43,13 @@ properties:
   actRunId:
     type: [string, "null"]
     examples: [HG7ML7M8z78YcAPEB]
+  title:
+    type: [string, "null"]
+    examples: [My Dataset]
+  username:
+    type: string
+    examples: [janedoe]
+  generalAccess:
+    $ref: ../common/GeneralAccess.yaml
+  stats:
+    $ref: ./DatasetStats.yaml

--- a/apify-api/openapi/components/schemas/datasets/DatasetStats.yaml
+++ b/apify-api/openapi/components/schemas/datasets/DatasetStats.yaml
@@ -1,8 +1,4 @@
 title: DatasetStats
-required:
-  - readCount
-  - writeCount
-  - storageBytes
 type: object
 properties:
   readCount:
@@ -13,4 +9,9 @@ properties:
     examples: [3]
   storageBytes:
     type: integer
+    description: Total storage size in bytes. Only returned by the single-dataset endpoint.
     examples: [783]
+  inflatedBytes:
+    type: integer
+    description: Uncompressed size in bytes. Only returned by the dataset list endpoint.
+    examples: [0]

--- a/apify-api/openapi/components/schemas/datasets/ListOfDatasets.yaml
+++ b/apify-api/openapi/components/schemas/datasets/ListOfDatasets.yaml
@@ -5,6 +5,10 @@ allOf:
     required:
       - items
     properties:
+      unnamed:
+        type: boolean
+        description: Whether the listing was filtered to only unnamed datasets.
+        examples: [false]
       items:
         type: array
         items:

--- a/apify-api/openapi/components/schemas/key-value-stores/KeyValueStore.yaml
+++ b/apify-api/openapi/components/schemas/key-value-stores/KeyValueStore.yaml
@@ -45,6 +45,14 @@ properties:
     format: uri
     description: A public link to access keys of the key-value store directly.
     examples: [https://api.apify.com/v2/key-value-stores/WkzbQMuFYuamGv3YF/keys?signature=abc123]
+  recordsPublicUrl:
+    type: string
+    format: uri
+    description: A public link to access records of the key-value store directly.
+    examples: [https://api.apify.com/v2/key-value-stores/WkzbQMuFYuamGv3YF/records]
+  schema:
+    type: [object, "null"]
+    description: Optional JSON schema describing the keys stored in the key-value store.
   urlSigningSecretKey:
     type: [string, "null"]
     description: A secret key for generating signed public URLs. It is only provided to clients with WRITE permission for the key-value store.

--- a/apify-api/openapi/components/schemas/key-value-stores/KeyValueStoreStats.yaml
+++ b/apify-api/openapi/components/schemas/key-value-stores/KeyValueStoreStats.yaml
@@ -21,3 +21,6 @@ properties:
   s3StorageBytes:
     type: integer
     examples: [18]
+  storageBytes:
+    type: integer
+    examples: [457225]

--- a/apify-api/openapi/components/schemas/key-value-stores/ListOfKeyValueStores.yaml
+++ b/apify-api/openapi/components/schemas/key-value-stores/ListOfKeyValueStores.yaml
@@ -5,6 +5,10 @@ allOf:
     required:
       - items
     properties:
+      unnamed:
+        type: boolean
+        description: Whether the listing was filtered to only unnamed key-value stores.
+        examples: [false]
       items:
         type: array
         items:

--- a/apify-api/openapi/components/schemas/request-queues/ListOfRequestQueues.yaml
+++ b/apify-api/openapi/components/schemas/request-queues/ListOfRequestQueues.yaml
@@ -6,6 +6,10 @@ allOf:
     required:
       - items
     properties:
+      unnamed:
+        type: boolean
+        description: Whether the listing was filtered to only unnamed request queues.
+        examples: [false]
       items:
         type: array
         description: The array of request queues.

--- a/apify-api/openapi/components/schemas/request-queues/RequestQueue.yaml
+++ b/apify-api/openapi/components/schemas/request-queues/RequestQueue.yaml
@@ -21,6 +21,12 @@ properties:
     examples: [some-name]
   userId:
     $ref: ./SharedProperties.yaml#/QueueUserId
+  actId:
+    type: [string, "null"]
+    description: The ID of the Actor that created this request queue.
+  actRunId:
+    type: [string, "null"]
+    description: The ID of the Actor run that created this request queue.
   createdAt:
     $ref: ./SharedProperties.yaml#/QueueCreatedAt
   modifiedAt:

--- a/apify-api/openapi/components/schemas/request-queues/RequestQueueShort.yaml
+++ b/apify-api/openapi/components/schemas/request-queues/RequestQueueShort.yaml
@@ -51,3 +51,7 @@ properties:
     description: The ID of the Actor run that created this request queue.
   hadMultipleClients:
     $ref: ./SharedProperties.yaml#/HadMultipleClients
+  generalAccess:
+    $ref: ../common/GeneralAccess.yaml
+  stats:
+    $ref: ./RequestQueueStats.yaml

--- a/apify-api/openapi/components/schemas/schedules/Schedule.yaml
+++ b/apify-api/openapi/components/schemas/schedules/Schedule.yaml
@@ -26,6 +26,7 @@ Schedule:
         title:
           type: [string, "null"]
         notifications:
+          title: ScheduleNotifications
           type: object
           description: Notification settings for this schedule.
           properties:

--- a/apify-api/openapi/components/schemas/schedules/Schedule.yaml
+++ b/apify-api/openapi/components/schemas/schedules/Schedule.yaml
@@ -25,6 +25,13 @@ Schedule:
           examples: [Schedule of actor ...]
         title:
           type: [string, "null"]
+        notifications:
+          type: object
+          description: Notification settings for this schedule.
+          properties:
+            email:
+              type: boolean
+              examples: [true]
         actions:
           type: array
           items:

--- a/apify-api/openapi/components/schemas/store/CurrentPricingInfo.yaml
+++ b/apify-api/openapi/components/schemas/store/CurrentPricingInfo.yaml
@@ -6,3 +6,50 @@ properties:
   pricingModel:
     type: string
     examples: [FREE]
+  apifyMarginPercentage:
+    type: number
+    examples: [0.2]
+  createdAt:
+    type: string
+    format: date-time
+    examples: ["2023-01-01T00:00:00.000Z"]
+  startedAt:
+    type: string
+    format: date-time
+    examples: ["2023-01-01T00:00:00.000Z"]
+  notifiedAboutChangeAt:
+    type: [string, "null"]
+    format: date-time
+    examples: [null]
+  notifiedAboutFutureChangeAt:
+    type: [string, "null"]
+    format: date-time
+    examples: [null]
+  isPriceChangeNotificationSuppressed:
+    type: boolean
+    examples: [false]
+  forceContainsSignificantPriceChange:
+    type: boolean
+    examples: [false]
+  isPPEPlatformUsagePaidByUser:
+    type: boolean
+    examples: [false]
+  reasonForChange:
+    type: [string, "null"]
+    examples: [null]
+  trialMinutes:
+    type: [integer, "null"]
+    examples: [null]
+  unitName:
+    type: [string, "null"]
+    examples: [null]
+  pricePerUnitUsd:
+    type: [number, "null"]
+    examples: [null]
+  minimalMaxTotalChargeUsd:
+    type: [number, "null"]
+    examples: [0.5]
+  pricingPerEvent:
+    type: [object, "null"]
+    description: Per-event pricing configuration for pay-per-event Actors.
+    additionalProperties: true

--- a/apify-api/openapi/components/schemas/store/ListOfActorsInStoreResponse.yaml
+++ b/apify-api/openapi/components/schemas/store/ListOfActorsInStoreResponse.yaml
@@ -33,7 +33,7 @@ example:
           lastRunStartedAt: "2019-07-08T14:01:05.546Z"
         currentPricingInfo:
           pricingModel: FREE
-        isWhiteListedForAgenticPayment: true
+        isWhiteListedForAgenticPayments: true
       - id: zdc3Pyhyz3m8vjDeM
         title: My Public Actor
         name: my-public-actor
@@ -57,4 +57,4 @@ example:
           lastRunStartedAt: "2019-07-08T14:01:05.546Z"
         currentPricingInfo:
           pricingModel: FREE
-        isWhiteListedForAgenticPayment: false
+        isWhiteListedForAgenticPayments: false

--- a/apify-api/openapi/components/schemas/store/StoreListActor.yaml
+++ b/apify-api/openapi/components/schemas/store/StoreListActor.yaml
@@ -56,6 +56,21 @@ properties:
   isWhiteListedForAgenticPayment:
     type: [boolean, "null"]
     description: Whether the Actor is whitelisted for agentic payment processing.
+  isWhiteListedForAgenticPayments:
+    type: [boolean, "null"]
+    description: Whether the Actor is whitelisted for agentic payment processing.
+  actorReviewCount:
+    type: integer
+    examples: [69]
+  actorReviewRating:
+    type: number
+    examples: [4.7]
+  bookmarkCount:
+    type: integer
+    examples: [1269]
+  badge:
+    type: [string, "null"]
+    examples: [null]
   readmeSummary:
     type: string
     description: A brief, LLM-generated readme summary

--- a/apify-api/openapi/components/schemas/store/StoreListActor.yaml
+++ b/apify-api/openapi/components/schemas/store/StoreListActor.yaml
@@ -53,9 +53,6 @@ properties:
     $ref: ../actors/ActorStats.yaml
   currentPricingInfo:
     $ref: ./CurrentPricingInfo.yaml
-  isWhiteListedForAgenticPayment:
-    type: [boolean, "null"]
-    description: Whether the Actor is whitelisted for agentic payment processing.
   isWhiteListedForAgenticPayments:
     type: [boolean, "null"]
     description: Whether the Actor is whitelisted for agentic payment processing.

--- a/apify-api/openapi/components/schemas/users/Current.yaml
+++ b/apify-api/openapi/components/schemas/users/Current.yaml
@@ -42,3 +42,6 @@ properties:
   teamAccountSeatCount:
     type: integer
     examples: [5]
+  scheduleCount:
+    type: integer
+    examples: [77]

--- a/apify-api/openapi/components/schemas/users/Limits.yaml
+++ b/apify-api/openapi/components/schemas/users/Limits.yaml
@@ -46,3 +46,6 @@ properties:
   dataRetentionDays:
     type: integer
     examples: [90]
+  maxScheduleCount:
+    type: integer
+    examples: [100]

--- a/apify-api/openapi/components/schemas/users/Plan.yaml
+++ b/apify-api/openapi/components/schemas/users/Plan.yaml
@@ -89,3 +89,19 @@ properties:
     items:
       type: string
     examples: [[]]
+  tier:
+    type: string
+    examples: [FREE]
+  apiRateLimitBoosts:
+    type: integer
+    examples: [0]
+  maxScheduleCount:
+    type: integer
+    examples: [100]
+  maxConcurrentActorRuns:
+    type: integer
+    examples: [25]
+  planPricing:
+    type: object
+    description: Pricing details for this plan.
+    additionalProperties: true

--- a/apify-api/openapi/components/schemas/users/ProxyGroup.yaml
+++ b/apify-api/openapi/components/schemas/users/ProxyGroup.yaml
@@ -9,7 +9,7 @@ properties:
     type: string
     examples: [Group1]
   description:
-    type: string
+    type: [string, "null"]
     examples: [Group1 description]
   availableCount:
     type: integer

--- a/apify-api/openapi/components/schemas/webhook-dispatches/WebhookDispatch.yaml
+++ b/apify-api/openapi/components/schemas/webhook-dispatches/WebhookDispatch.yaml
@@ -38,6 +38,24 @@ properties:
       actorRunId:
         type: string
         examples: [JgwXN9BdwxGcu9MMF]
+  webhook:
+    title: webhook
+    type: [object, "null"]
+    description: A summary of the webhook that triggered this dispatch.
+    properties:
+      actionType:
+        type: string
+        examples: [HTTP_REQUEST]
+      condition:
+        type: object
+        additionalProperties: true
+      requestUrl:
+        type: string
+        format: uri
+        examples: ["https://example.com/webhook"]
+      isAdHoc:
+        type: boolean
+        examples: [false]
   calls:
     title: calls
     type: array

--- a/apify-api/openapi/components/schemas/webhook-dispatches/WebhookDispatch.yaml
+++ b/apify-api/openapi/components/schemas/webhook-dispatches/WebhookDispatch.yaml
@@ -39,7 +39,7 @@ properties:
         type: string
         examples: [JgwXN9BdwxGcu9MMF]
   webhook:
-    title: webhook
+    title: WebhookDispatchWebhookSummary
     type: [object, "null"]
     description: A summary of the webhook that triggered this dispatch.
     properties:
@@ -47,8 +47,7 @@ properties:
         type: string
         examples: [HTTP_REQUEST]
       condition:
-        type: object
-        additionalProperties: true
+        $ref: ../webhooks/WebhookCondition.yaml
       requestUrl:
         type: string
         format: uri

--- a/apify-api/openapi/components/schemas/webhook-dispatches/WebhookDispatch.yaml
+++ b/apify-api/openapi/components/schemas/webhook-dispatches/WebhookDispatch.yaml
@@ -39,22 +39,9 @@ properties:
         type: string
         examples: [JgwXN9BdwxGcu9MMF]
   webhook:
-    title: WebhookDispatchWebhookSummary
-    type: [object, "null"]
-    description: A summary of the webhook that triggered this dispatch.
-    properties:
-      actionType:
-        type: string
-        examples: [HTTP_REQUEST]
-      condition:
-        $ref: ../webhooks/WebhookCondition.yaml
-      requestUrl:
-        type: string
-        format: uri
-        examples: ["https://example.com/webhook"]
-      isAdHoc:
-        type: boolean
-        examples: [false]
+    anyOf:
+      - $ref: ./WebhookDispatchWebhookSummary.yaml
+      - type: "null"
   calls:
     title: calls
     type: array

--- a/apify-api/openapi/components/schemas/webhook-dispatches/WebhookDispatchWebhookSummary.yaml
+++ b/apify-api/openapi/components/schemas/webhook-dispatches/WebhookDispatchWebhookSummary.yaml
@@ -1,0 +1,16 @@
+title: WebhookDispatchWebhookSummary
+description: A summary of the webhook that triggered this dispatch.
+type: object
+properties:
+  actionType:
+    type: string
+    examples: [HTTP_REQUEST]
+  condition:
+    $ref: ../webhooks/WebhookCondition.yaml
+  requestUrl:
+    type: string
+    format: uri
+    examples: ["https://example.com/webhook"]
+  isAdHoc:
+    type: boolean
+    examples: [false]

--- a/apify-api/openapi/components/schemas/webhooks/ExampleWebhookDispatch.yaml
+++ b/apify-api/openapi/components/schemas/webhooks/ExampleWebhookDispatch.yaml
@@ -9,3 +9,7 @@ properties:
     type: [string, "null"]
     format: date-time
     examples: ["2019-12-13T08:36:13.202Z"]
+  removedAt:
+    type: [string, "null"]
+    format: date-time
+    examples: [null]

--- a/apify-api/openapi/components/schemas/webhooks/WebhookShort.yaml
+++ b/apify-api/openapi/components/schemas/webhooks/WebhookShort.yaml
@@ -28,6 +28,15 @@ properties:
   isAdHoc:
     type: [boolean, "null"]
     examples: [false]
+  isApifyIntegration:
+    type: boolean
+    examples: [false]
+  isEnabled:
+    type: boolean
+    examples: [true]
+  actionType:
+    type: string
+    examples: [HTTP_REQUEST]
   shouldInterpolateStrings:
     type: [boolean, "null"]
     examples: [false]


### PR DESCRIPTION
Align OpenAPI schemas with what the live Apify API actually returns, so the generated `apify-client-python` Pydantic models declare every documented field. Originally reported as [apify-client-python#811](https://github.com/apify/apify-client-python/issues/811#issuecomment-4509984262) for `buildNumber` on `BuildShort`; broadened after running the Python integration suite with Pydantic `extra='forbid'` to surface the full gap across ~20 schemas (Actor, Build, KVS, Run, Schedule, Webhook, User plan/limits, store listings, …).