### PR TITLE
fix(nginx): noindex preview hostnames at the edge

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -810,6 +810,12 @@ server {
     resolver 172.20.0.10;
     server_name ~^(?<subdomain>[^.]+)\.preview\.docs\.apify\.com$;
 
+    # Block search indexing on every response from preview hostnames, including the
+    # apify.github.io proxy_passes (SDK/Client/CLI) that have no preview bucket and
+    # would otherwise serve production content under the preview hostname.
+    # `always` keeps the header on 4xx/5xx so error pages aren't indexed either.
+    add_header X-Robots-Tag "noindex, nofollow, noarchive" always;
+
     # add trailing slashes to the root of GH pages docs
     rewrite ^/api/client/js$ /api/client/js/ redirect;
     rewrite ^/api/client/python$ /api/client/python/ redirect;


### PR DESCRIPTION
Adds a server-level `X-Robots-Tag: noindex, nofollow, noarchive` header to the preview hostname server block (`*.preview.docs.apify.com`) so search engines stop indexing preview URLs — including the SDK/Client/CLI paths that `proxy_pass` to `apify.github.io` and have no preview bucket to clean up. Complements the canonical-rewrite plugin from #2566, which only covers paths served from the apify-docs build.

The `always` flag keeps the header on 4xx/5xx so error pages aren't indexed either. Production `docs.apify.com` is unaffected (separate server block).