### PR TITLE
docs: rename Actor-to-Actor integrations title and label

### DIFF
--- a/sources/platform/integrations/actors/index.md
+++ b/sources/platform/integrations/actors/index.md
@@ -1,7 +1,7 @@
 ---
-title: What are Actor integrations?
+title: Actor-to-Actor integrations
 description: Learn how to connect Actors together and trigger tasks from other Actors, enabling you to build automated multi-step workflows on the Apify platform.
-sidebar_label: Actor-to-Actor
+sidebar_label: Actor-to-Actor integrations
 sidebar_position: 0
 slug: /integrations/actors
 ---


### PR DESCRIPTION
Renames the page title from "What are Actor integrations?" to "Actor-to-Actor integrations" and updates the sidebar label to match, so the page is clearly distinguishable from the broader "Actor integrations" framing used elsewhere in the docs.