### PR TITLE
docs: clarify Standby health-check behavior

### DIFF
--- a/sources/platform/actors/development/programming_interface/actor_standby.md
+++ b/sources/platform/actors/development/programming_interface/actor_standby.md
@@ -131,6 +131,8 @@ async def main() -> None:
 </TabItem>
 </Tabs>
 
+After the readiness probe completes, the platform performs no further health checks against your Standby server. A run only restarts when the process exits or the run is migrated, so on unrecoverable errors, exit the process rather than swallow the error. That triggers the normal end-of-run restart path.
+
 ## Determining an Actor is started in Standby
 
 Actors that support Actor Standby can still be started in standard mode, for example from the Console or via the API.

--- a/sources/platform/actors/running/actor_standby.md
+++ b/sources/platform/actors/running/actor_standby.md
@@ -46,7 +46,8 @@ This approach can be useful if you cannot modify the request headers.
     https://rag-web-browser.apify.actor/search?query=apify&token=my_apify_token
     ```
 
-:::tip
+:::tip Scoped tokens
+
 You can use [scoped tokens](/platform/integrations/api#limited-permissions) to send standby requests. This is useful for allowing third-party services to interact with your Actor without granting access to your entire account.
 
 However, [restricting what an Actor can access](/platform/integrations/api#restricted-access-restrict-what-actors-can-access-using-the-scope-of-this-actor) using a scoped token is not supported when running in Standby mode.
@@ -62,6 +63,12 @@ it well. Please head to the Actor README to learn more about the capabilities of
 
 When you use the Actor in Standby mode, the system automatically scales the Actor to accommodate the incoming requests. Under the hood,
 the system starts new Actor runs, which you will see in the Actor runs tab, with the origin set to Standby.
+
+## Health checks and stuck runs
+
+The platform checks a Standby run's readiness once, before marking it ready to receive requests. After that, no further health checks run for the lifetime of the run.
+
+A Standby run restarts only when its process exits or the run is migrated to a different machine. If the server stays alive but stops responding, the platform does not detect the failure. To avoid stuck runs, design your Actor to exit the process on unrecoverable errors. See the [Standby development guide](../development/programming_interface/actor_standby.md#readiness-probe) for details.
 
 ## What is the timeout for incoming requests
 

--- a/sources/platform/actors/running/actor_standby.md
+++ b/sources/platform/actors/running/actor_standby.md
@@ -68,7 +68,7 @@ the system starts new Actor runs, which you will see in the Actor runs tab, with
 
 The platform checks a Standby run's readiness once, before marking it ready to receive requests. After that, no further health checks run for the lifetime of the run.
 
-A Standby run restarts only when its process exits or the run is migrated to a different machine. If the server stays alive but stops responding, the platform does not detect the failure. To avoid stuck runs, design your Actor to exit the process on unrecoverable errors. See the [Standby development guide](../development/programming_interface/actor_standby.md#readiness-probe) for details.
+A Standby run restarts only when its process exits or the run is migrated to a different machine. If the server stays alive but stops responding, the platform does not detect the failure. For related Actor build guidance, see the [Standby development guide](../development/programming_interface/actor_standby.md#readiness-probe).
 
 ## What is the timeout for incoming requests
 

--- a/sources/platform/actors/running/actor_standby.md
+++ b/sources/platform/actors/running/actor_standby.md
@@ -66,7 +66,7 @@ the system starts new Actor runs, which you will see in the Actor runs tab, with
 
 ## Health checks and stuck runs
 
-The platform checks a Standby run's readiness once, before marking it ready to receive requests. After that, no further health checks run for the lifetime of the run.
+The platform checks a Standby run's readiness once, before marking it ready to receive requests. After that, the run is considered healthy and no further health checks are performed for the lifetime of the run.
 
 A Standby run restarts only when its process exits or the run is migrated to a different machine. If the server stays alive but stops responding, the platform does not detect the failure. For related Actor build guidance, see the [Standby development guide](../development/programming_interface/actor_standby.md#readiness-probe).
 


### PR DESCRIPTION
Document that Standby runs receive a single readiness probe at startup and no further health checks while running. Restart only triggers on process exit or migration. Advise authors to exit on unrecoverable errors so the platform restarts via the normal end-of-run path.

Closes #2562