### PR TITLE
fix(openapi): relax required fields on actor pricing info schemas

### DIFF
--- a/apify-api/openapi/components/schemas/actor-pricing-info/ActorChargeEvent.yaml
+++ b/apify-api/openapi/components/schemas/actor-pricing-info/ActorChargeEvent.yaml
@@ -5,7 +5,6 @@ description: |
 type: object
 required:
   - eventTitle
-  - eventDescription
 properties:
   eventTitle:
     type: string

--- a/apify-api/openapi/components/schemas/actor-pricing-info/CommonActorPricingInfo.yaml
+++ b/apify-api/openapi/components/schemas/actor-pricing-info/CommonActorPricingInfo.yaml
@@ -1,9 +1,5 @@
 title: CommonActorPricingInfo
 type: object
-required:
-  - apifyMarginPercentage
-  - createdAt
-  - startedAt
 properties:
   apifyMarginPercentage:
     type: number


### PR DESCRIPTION
The platform-set `APIFY_ACTOR_PRICING_INFO` env var omits `apifyMarginPercentage`, `createdAt`, `startedAt` and `eventDescription`, so consumers deserializing it via the generated pydantic models hit validation errors and resort to injecting placeholder defaults. Marking these optional matches reality and is consistent with the sibling `CurrentPricingInfo` schema, which already has these fields optional.

Triggers a pydantic model regeneration in `apify-client-python`; once merged, the SDK can drop the placeholder-injection workaround in `_normalize_actor_pricing_info`.