### PR TITLE
docs: fix broken webhook links on Slack integration page

### DIFF
--- a/sources/platform/integrations/workflows-and-notifications/slack.md
+++ b/sources/platform/integrations/workflows-and-notifications/slack.md
@@ -49,7 +49,7 @@ You're all set! If you have questions or need help, reach out on the [Apify Disc
 
 The **Message** field on the Slack integration setup screen accepts a [Handlebars](https://handlebarsjs.com/) template. When the integration fires, Apify renders the template with data from the triggering event and posts the result to the configured channel.
 
-The Slack integration uses Handlebars, so all built-in helpers (`{{#if}}`, `{{#each}}`, `{{#unless}}`, and so on) work in your template. [Webhook actions](/integrations/webhooks/actions) use a separate JSON payload template engine; don't mix the two.
+The Slack integration uses Handlebars, so all built-in helpers (`{{#if}}`, `{{#each}}`, `{{#unless}}`, and so on) work in your template. [Webhook actions](/platform/integrations/webhooks/actions) use a separate JSON payload template engine; don't mix the two.
 
 A few rules apply to every template:
 
@@ -66,7 +66,7 @@ The following variables are available in every template. Reference nested fields
 | Variable      | Type     | Description                                                                                                                |
 |---------------|----------|----------------------------------------------------------------------------------------------------------------------------|
 | `userId`      | string   | ID of the Apify user who owns the integration.                                                                             |
-| `eventType`   | string   | Type of the trigger event. See [Webhook events](/integrations/webhooks/events) for the full list.                          |
+| `eventType`   | string   | Type of the trigger event. See [Webhook events](/platform/integrations/webhooks/events) for the full list.                 |
 | `createdAt`   | string   | ISO 8601 timestamp of when the event was dispatched.                                                                       |
 | `eventData`   | object   | Identifiers of the entities involved in the event.                                                                         |
 | `resource`    | object   | Full snapshot of the triggering resource (an Actor run or an Actor build).                                                 |


### PR DESCRIPTION
## Summary
- Both links to webhook actions/events on `/platform/integrations/slack` were missing the `/platform` route base prefix, which broke the production build after #2504 was merged and is failing the `Test` job on every PR opened since.
- This PR adds the prefix on both links so the build passes again.

## Test plan
- [x] `npx markdownlint sources/platform/integrations/workflows-and-notifications/slack.md` passes
- [ ] CI `Test` job (Docs build) passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)