### PR TITLE
docs: update ChatGPT MCP integration guide for new flow

### DIFF
--- a/sources/platform/integrations/ai/mcp/chatgpt.md
+++ b/sources/platform/integrations/ai/mcp/chatgpt.md
@@ -22,10 +22,23 @@ In this tutorial, you'll learn how to connect _ChatGPT_ to the _Apify MCP server
 
 Before connecting ChatGPT to Apify, you'll need:
 
-- _An Apify account_ - If you don't have an Apify account already, you can [sign up](https://console.apify.com/sign-up)
-- _Apify API token_ - Get your API token from the **API & Integrations** section in [Apify Console](https://console.apify.com/settings/integrations). This token authorizes the MCP server to run Actors on your behalf. Make sure to keep it secure.
+- _An Apify account_ - If you don't have an Apify account already, you can [sign up](https://console.apify.com/sign-up). The MCP server authorizes ChatGPT to access your Apify account via OAuth, so no API token is required.
 - _An OpenAI account with access to ChatGPT_ - You need an OpenAI account to use ChatGPT.
 - _ChatGPT with Developer mode enabled_ - You must enable [Developer Mode](https://platform.openai.com/docs/guides/developer-mode) to add custom connectors (when the Developer mode is active, the message input box is outlined in orange).
+
+:::note ChatGPT Business and Enterprise workspaces
+If you're using ChatGPT Business or Enterprise, a workspace admin must enable the Apify connector for the organization before members can add it. See [Enable Apify for your organization](#enable-apify-for-your-organization) below.
+:::
+
+## Enable Apify for your organization
+
+ChatGPT Business and Enterprise workspaces require a workspace admin to allow the Apify connector before individual members can add it:
+
+1. Sign in to ChatGPT as a workspace owner or admin.
+1. Go to **Settings > Workspace > Connectors**.
+1. Add the Apify MCP server (`https://mcp.apify.com`) to the list of allowed connectors and save your changes.
+
+Once enabled, members of your workspace can create the connector by following the steps in the next section.
 
 ## Create an MCP connector
 
@@ -33,13 +46,14 @@ Before connecting ChatGPT to Apify, you'll need:
 
 1. Fill in the following fields:
 
-    - **Name** - a user-facing title, e.g., `apify-mcp`
-    - **Description** - a short description of what the connector does
+    - **Name** - a user-facing title, e.g., `Apify`
+    - **Description** - a short description of what the connector does, for example: `Extract data from any website with thousands of scrapers, crawlers, and automations from Apify Store`
+    - **Logo** - upload an image to identify the connector. ChatGPT requires the logo file to be under 10 KB.
     - **MCP Server URL** - choose one of the following:
         - `https://mcp.apify.com` - use the default set of Apify tools
         - `https://mcp.apify.com?tools=actors,docs,mtrunkat/url-list-download-html` - use specific tools
         - Refer to [mcp.apify.com](https://mcp.apify.com) for details
-    - **Authentication** - OAuth, you don’t need to provide a client ID or secret.
+    - **Authentication** - OAuth, you don't need to provide a client ID or secret.
 
 1. Select **Create** to proceed to the authentication page.
 You’ll be redirected to the Apify website to authorize ChatGPT to access your Apify account.


### PR DESCRIPTION
Refreshes the [ChatGPT MCP integration guide](https://docs.apify.com/platform/integrations/chatgpt) to match the current ChatGPT connector flow, as flagged by @jancurn in Slack.

Changes:

- Drop API token from prerequisites; OAuth is the supported flow.
- Add a section on enabling the Apify connector for ChatGPT Business and Enterprise workspaces.
- Document the connector **Logo** field and the 10 KB size limit.
- Provide a default connector description users can paste in.

Closes #2607.

### Notes for reviewers

- The org-level enablement steps (`Settings > Workspace > Connectors`) are written based on the typical ChatGPT admin flow — please double-check the exact UI labels in your workspace before merge.
- Jan attached a 9.4 KB Apify logo (`apify-symbol-colors-margin-small.png`) in the Slack thread that meets the 10 KB requirement. It's not bundled in this PR because the file lives in Slack; we may want to host it somewhere users can download, or just point them at the Apify brand assets.