### PR TITLE
docs(x402): clarify the payment signature is reusable until balance runs out

### DIFF
--- a/sources/platform/integrations/ai/x402.md
+++ b/sources/platform/integrations/ai/x402.md
@@ -112,12 +112,18 @@ curl -s \
 
 You can replace `apify~instagram-post-scraper` with any supported Actor from [Apify Store](https://apify.com/store).
 
+:::note Reuse the same signature
+
+The signed `PAYMENT-SIGNATURE` stays valid while your prepaid balance lasts. Send it with every subsequent request - each call draws from the balance with no new signing and no new on-chain settlement. When the balance is exhausted, the API responds with `402` again; repeat step 2 to sign a fresh payment and continue.
+
+:::
+
 ## Pricing and refunds
 
 Both paths (MCP server and direct API) share the same pricing model:
 
 - Minimum transaction: $1 in USDC.
-- The payment is tracked as a prepaid balance. Subsequent calls draw from it without new on-chain transactions.
+- The payment is tracked as a prepaid balance. Subsequent calls reuse the same signature and draw from it without re-signing or any new on-chain transaction.
 - When using the MCP server, `mcpc` signs a new payment automatically when the balance runs out.
 - After 60 minutes of inactivity (no running Actors), any remaining balance is refunded on-chain to your wallet, minus a small [gas fee (network cost)](https://docs.base.org/base-chain/network-information/network-fees) charged by the Base network to process the transaction.
 

--- a/sources/platform/integrations/ai/x402.md
+++ b/sources/platform/integrations/ai/x402.md
@@ -81,6 +81,12 @@ You can also send x402 payments directly against the Apify REST API. This works 
 1. Resend the request with two headers: `X-APIFY-PAYMENT-PROTOCOL: X402` and `PAYMENT-SIGNATURE: <signed payload>`.
 1. The API settles the payment on-chain, runs the Actor, and returns the dataset items directly.
 
+:::note Reuse the same signature
+
+The signed `PAYMENT-SIGNATURE` stays valid while your prepaid balance lasts. Send it with every subsequent request - each call draws from the balance with no new signing and no new on-chain settlement. When the balance is exhausted, the API responds with `402` again; sign the payment again to continue.
+
+:::
+
 ### Example
 
 :::caution Actor name format
@@ -111,12 +117,6 @@ curl -s \
 ```
 
 You can replace `apify~instagram-post-scraper` with any supported Actor from [Apify Store](https://apify.com/store).
-
-:::note Reuse the same signature
-
-The signed `PAYMENT-SIGNATURE` stays valid while your prepaid balance lasts. Send it with every subsequent request - each call draws from the balance with no new signing and no new on-chain settlement. When the balance is exhausted, the API responds with `402` again; repeat step 2 to sign a fresh payment and continue.
-
-:::
 
 ## Pricing and refunds
 


### PR DESCRIPTION
## Context

The x402 page doesn't state that the signed `PAYMENT-SIGNATURE` can be reused across calls. A reader following the direct-API steps may assume each call needs a fresh signature and a new on-chain settlement.

## Solution

- Add a `:::note` in the direct-API section: the same `PAYMENT-SIGNATURE` stays valid while the prepaid balance lasts; resend it on every call with no re-signing or new settlement, and only sign again when the API returns `402` (balance exhausted) — the manual equivalent of what `mcpc` does automatically on the MCP path.
- Tighten the prepaid-balance bullet to say subsequent calls reuse the same signature.