### PR TITLE
docs(mastra): point MCP client at mcp.apify.com (drop /sse)

### DIFF
--- a/sources/platform/integrations/ai/mastra.md
+++ b/sources/platform/integrations/ai/mastra.md
@@ -59,7 +59,7 @@ Instantiate the Mastra MCP client:
 const mcpClient = new MastraMCPClient({
     name: 'apify-client',
     server: {
-        url: new URL('https://mcp.apify.com/sse'),
+        url: new URL('https://mcp.apify.com'),
         requestInit: {
             headers: { Authorization: `Bearer ${process.env.APIFY_TOKEN}` }
         },
@@ -165,7 +165,7 @@ process.env.OPENAI_API_KEY = "your-openai-api-key";
 const mcpClient = new MastraMCPClient({
     name: 'apify-client',
     server: {
-        url: new URL('https://mcp.apify.com/sse'),
+        url: new URL('https://mcp.apify.com'),
         requestInit: {
             headers: { Authorization: `Bearer ${process.env.APIFY_TOKEN}` }
         },


### PR DESCRIPTION
## What
Update the Mastra MCP integration guide to connect to `https://mcp.apify.com` (Streamable HTTP) instead of the legacy `https://mcp.apify.com/sse` endpoint.

## Why
The legacy SSE transport (`/sse`) is being removed from the Apify MCP server (apify/apify-mcp-server-internal#591, apify/apify-mcp-server#960). The hosted endpoint is `mcp.apify.com`.

## Testing
Docs-only change; both Mastra code samples now point at `https://mcp.apify.com`.
