### PR TITLE
docs: reorder publishing sidebar to Publish, Publish task, Monetize

### DIFF
--- a/sources/platform/actors/publishing/monetize/index.mdx
+++ b/sources/platform/actors/publishing/monetize/index.mdx
@@ -2,7 +2,7 @@
 title: Monetize your Actor
 description: Monetize your Actors on Apify Store by choosing a pricing model such as pay per event or a flat monthly rental fee for users.
 slug: /actors/publishing/monetize
-sidebar_position: 2
+sidebar_position: 2.5
 ---
 
 import Tabs from '@theme/Tabs';


### PR DESCRIPTION
Both `publish-task.mdx` and `monetize/index.mdx` had `sidebar_position: 2`, so Docusaurus tiebroke alphabetically and rendered Monetize before Publish task. Bumping monetize to `2.5` puts the section in the intended order: Publish your Actor, Publish your Actor task, Monetize your Actor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)