### PR TITLE
docs: Update Actorization playbook with badge link and resources

### DIFF
--- a/sources/academy/build-and-publish/how-to-build/actorization_playbook.mdx
+++ b/sources/academy/build-and-publish/how-to-build/actorization_playbook.mdx
@@ -6,7 +6,7 @@ category: build-and-publish
 slug: /actorization
 ---
 
-Apify is a cloud platform with a [marketplace](https://apify.com/store) of 6,000+ web scraping and automation tools called _Actors_. These tools are used for extracting data from social media, search engines, maps, e-commerce sites, travel portals, and general websites.
+Apify is a cloud platform with a [marketplace](https://apify.com/store) of web scraping and automation tools called _Actors_. These tools are used for extracting data from social media, search engines, maps, e-commerce sites, travel portals, and general websites.
 
 Most Actors are developed by a global creator community, and some are developed by Apify. We have 18k monthly active users/developers on the platform (growing 138% YoY). Last month, we paid out $170k to creators (growing 118% YoY), and in total, over the program's history, we paid out almost $2M to them.
 
@@ -37,7 +37,7 @@ For open-source developers, Actorization adds value without extra costs:
 
 :::
 
-For example, IBM’s [Docling project](https://github.com/docling-project/docling) merged our pull request that actorized their open-source GitHub repo (24k stars) and added the Apify Actor badge to the README:
+For example, IBM’s [Docling project](https://github.com/docling-project/docling) merged our pull request that actorized their open-source GitHub repo (24k stars) and added the [Apify Actor status badge](/platform/actors/publishing/status-badge) to the README:
 
 ![Docling Apify badge](images/actorization-playbook/docling-apify-badge.png)
 
@@ -53,6 +53,8 @@ You can Actorize various projects ranging from open-source libraries, throughout
 | Docling | Open source library | [https://github.com/docling-project/docling](https://github.com/docling-project/docling) | https://apify.com/vancura/docling/source-code |
 | Playwright MCP | Open source MCP server | [https://github.com/microsoft/playwright-mcp](https://github.com/microsoft/playwright-mcp) | [https://apify.com/jiri.spilka/playwright-mcp-server](https://apify.com/jiri.spilka/playwright-mcp-server) |
 | Browserbase MCP | SaaS MCP server | [https://www.browserbase.com/](https://www.browserbase.com/) | [https://apify.com/agentify/browserbase-mcp-server/api/mcp](https://apify.com/agentify/browserbase-mcp-server/api/mcp) |
+
+For more inspiration on which open-source libraries to wrap as Actors, see the [open-source libraries](/academy/build-and-publish/actor-ideas/find-actor-ideas#open-source-libraries) section in the guide on finding Actor ideas.
 
 ### What projects are suitable for Actorization
 

--- a/sources/academy/build-and-publish/how-to-build/actorization_playbook.mdx
+++ b/sources/academy/build-and-publish/how-to-build/actorization_playbook.mdx
@@ -8,7 +8,7 @@ slug: /actorization
 
 Apify is a cloud platform with a [marketplace](https://apify.com/store) of web scraping and automation tools called _Actors_. These tools are used for extracting data from social media, search engines, maps, e-commerce sites, travel portals, and general websites.
 
-Most Actors are developed by a global creator community, and some are developed by Apify. We have 18k monthly active users/developers on the platform (growing 138% YoY). Last month, we paid out $170k to creators (growing 118% YoY), and in total, over the program's history, we paid out almost $2M to them.
+Most Actors are developed by a global creator community, and some are developed by Apify. The platform has a growing base of monthly active users and developers, and creators earn money from their Actors through Apify's monetization program.
 
 ## What are Actors
 
@@ -33,11 +33,11 @@ For open-source developers, Actorization adds value without extra costs:
 - Host your code in the cloud for easy user trials (no local installs needed).
 - Avoid managing cloud infrastructure - users cover the costs.
 - Earn income through [Apify’s Open Source Fair Share program](https://apify.com/partners/open-source-fair-share) via GitHub Sponsors or direct payouts.
-- Publish and monetize 10x faster than building a micro-SaaS, with Apify handling infra, billing, and access to 700,000+ monthly visitors and 70,000 signups.
+- Publish and monetize 10x faster than building a micro-SaaS, with Apify handling infra, billing, and access to its established user base.
 
 :::
 
-For example, IBM’s [Docling project](https://github.com/docling-project/docling) merged our pull request that actorized their open-source GitHub repo (24k stars) and added the [Apify Actor status badge](/platform/actors/publishing/status-badge) to the README:
+For example, IBM’s [Docling project](https://github.com/docling-project/docling) merged our pull request that actorized their popular open-source GitHub repo and added the [Apify Actor status badge](/platform/actors/publishing/status-badge) to the README:
 
 ![Docling Apify badge](images/actorization-playbook/docling-apify-badge.png)
 
@@ -138,3 +138,5 @@ Deployment to the Apify platform can be done easily via `apify push` command of 
 ### 6. Publish and monetize
 
 For details on publishing the Actor in [Apify Store](https://apify.com/store) see the [Publishing and monetization](/platform/actors/publishing). You can also follow the guide on [How to create an Actor README](/academy/actor-marketing-playbook/actor-basics/how-to-create-an-actor-readme) and [Marketing checklist](/academy/actor-marketing-playbook/promote-your-actor/checklist).
+
+To show your Actor's current status and usage in your README or documentation, add the [Actor status badge](/platform/actors/publishing/status-badge).

--- a/sources/platform/actors/development/permissions/index.md
+++ b/sources/platform/actors/development/permissions/index.md
@@ -1,5 +1,6 @@
 ---
-title: Permissions
+title: Actor permissions
+sidebar_label: Permissions
 description: Learn how to declare and manage permissions for your Actor, what access levels mean, and how to build secure, trusted Actors for Apify users.
 sidebar_position: 7.5
 slug: /actors/development/permissions


### PR DESCRIPTION
Link the Actor ideas (open-source libraries) and Actor status badge pages from the actorization guide, and replace hard-coded stats with evergreen wording so the page won't drift. Also retitle the permissions page to "Actor permissions" while keeping its sidebar label as "Permissions".

https://claude.ai/code/session_01KHwbiX8ycRe4dkYy471oSg