### PR TITLE
docs: Clarify "Actor Standby mode" page title

### DIFF
--- a/sources/platform/actors/running/actor_standby.md
+++ b/sources/platform/actors/running/actor_standby.md
@@ -46,7 +46,7 @@ This approach can be useful if you cannot modify the request headers.
     https://rag-web-browser.apify.actor/search?query=apify&token=my_apify_token
     ```
 
-:::tip
+:::tip Scoped tokens
 You can use [scoped tokens](/platform/integrations/api#limited-permissions) to send standby requests. This is useful for allowing third-party services to interact with your Actor without granting access to your entire account.
 
 However, [restricting what an Actor can access](/platform/integrations/api#restricted-access-restrict-what-actors-can-access-using-the-scope-of-this-actor) using a scoped token is not supported when running in Standby mode.

--- a/sources/platform/actors/running/actor_standby.md
+++ b/sources/platform/actors/running/actor_standby.md
@@ -1,5 +1,5 @@
 ---
-title: Standby mode
+title: Actor Standby mode
 description: Use Actor Standby mode to keep an Actor ready in the background and serve real-time HTTP requests without waiting for a cold start each time.
 sidebar_position: 7.3
 slug: /actors/running/standby


### PR DESCRIPTION
Updated the page title from "Standby mode" to "Actor Standby mode" for better clarity and consistency with documentation naming conventions.

- Changed frontmatter title to explicitly reference "Actor Standby mode" instead of the generic "Standby mode"
- Improves discoverability and makes the feature's context immediately clear to readers

https://claude.ai/code/session_01EGB7ujKoUfWjNwzUN4WTD8