### PR TITLE
docs: note publish task is experimental and gated

### DIFF
--- a/sources/platform/actors/publishing/publish-task.mdx
+++ b/sources/platform/actors/publishing/publish-task.mdx
@@ -11,7 +11,7 @@ This guide walks you through the publication process on the **Publication** tab 
 
 :::caution Experimental feature
 
-Task publication is an experimental feature and is not available to all users yet. To try it out, contact [Apify support](https://apify.com/contact).
+Task publishing is an experimental feature and is not available to all users yet. To try it out, contact [Apify support](https://apify.com/contact).
 
 :::
 

--- a/sources/platform/actors/publishing/publish-task.mdx
+++ b/sources/platform/actors/publishing/publish-task.mdx
@@ -9,6 +9,12 @@ sidebar_position: 2
 
 This guide walks you through the publication process on the **Publication** tab and the steps to make a task public.
 
+:::caution Experimental feature
+
+Task publication is an experimental feature and is not available to all users yet. To try it out, contact [Apify support](https://apify.com/contact).
+
+:::
+
 ## Prerequisites
 
 Before you publish a task, make sure you have:


### PR DESCRIPTION
Adds a caution admonition to the Publish task guide indicating the feature is experimental and gated, pointing users to support to request access.