### PR TITLE
chore: remove Vale from review-docs skill

### DIFF
--- a/.agents/skills/review-docs/SKILL.md
+++ b/.agents/skills/review-docs/SKILL.md
@@ -13,8 +13,9 @@ argument-hint: file-path
 1. **Verify file version** - `git status` to confirm you have the latest
 2. **Run deterministic checks** (main process) - these are objective, no judgment needed:
    - `pnpm lint:md` (heading hierarchy, list numbering, spacing)
-   - `vale "<file>" --minAlertLevel=error` (prose style, pronouns, dashes, code fences, admonitions)
    - `.agents/skills/review-docs/scripts/check-frontmatter.sh "<file>"` (description char count)
+
+   Vale runs separately as a repo-level PR check and via the TW's local editor extension - don't invoke it here. The delegated standards review (step 3) covers the same prose-style ground.
 3. **Delegated standards review** - spawn one subagent per standards file to check compliance. Each subagent reads the file being reviewed plus one standards file, and returns violations with line numbers and suggested fixes:
    - Subagent 1: check against `standards/writing-style.md` (voice, tone, headings, links)
    - Subagent 2: check against `standards/content-standards.md` (front matter, admonitions, code blocks)

--- a/.agents/skills/review-docs/references/process.md
+++ b/.agents/skills/review-docs/references/process.md
@@ -12,8 +12,9 @@ Agent-agnostic workflow for reviewing Apify documentation.
 These are objective - no judgment needed. Report all failures. Run in the main process (not in subagents).
 
 - `pnpm lint:md` (markdownlint: heading hierarchy, double spaces, list numbering)
-- `vale "<file>" --minAlertLevel=error` (prose style, dashes, code fences, admonitions)
 - `.agents/skills/review-docs/scripts/check-frontmatter.sh "<file>"` (description char count)
+
+Vale is not part of this skill. It runs as a repo-level PR check and via the TW's local editor extension, but devs aren't expected to install it, so shipping it in the per-file review flow would create dead weight. Prose-style coverage comes from the delegated standards review in step 3.
 
 ## Step 3: Delegated standards review
 
@@ -60,4 +61,4 @@ Check that both JavaScript and Python examples are present and functionally equi
 
 ### Markdownlint false positives on admonitions
 
-Markdownlint doesn't understand Docusaurus `:::` syntax natively. Check `.markdownlint.json` for configured exceptions. Focus on Vale for prose quality.
+Markdownlint doesn't understand Docusaurus `:::` syntax natively. Check `.markdownlint.json` for configured exceptions. Rely on the delegated standards review for prose-style judgment.


### PR DESCRIPTION
Vale cannot be shipped like mdlint, so invoking it per-file in this skill was dead weight. Vale still runs as a repo-level PR check and via the TW's local editor extension; the delegated standards review covers prose-style ground for the skill itself.