### PR TITLE
fix(openapi): add missing ad-hoc webhook fields to WebhookRepresentation

### DIFF
--- a/apify-api/openapi/components/schemas/webhooks/WebhookRepresentation.yaml
+++ b/apify-api/openapi/components/schemas/webhooks/WebhookRepresentation.yaml
@@ -26,6 +26,10 @@ properties:
     type: [string, "null"]
     description: Optional template for the HTTP headers sent by the webhook.
     examples: ['{\n "Authorization": "Bearer ..."}']
+  shouldInterpolateStrings:
+    type: [boolean, "null"]
+    description: Optional flag to also interpolate `{{...}}` variables inside string values of the payload and headers templates.
+    examples: [false]
   idempotencyKey:
     type: [string, "null"]
     description: Optional key that prevents creating duplicate webhooks, e.g. when the run-starting request is retried.

--- a/apify-api/openapi/components/schemas/webhooks/WebhookRepresentation.yaml
+++ b/apify-api/openapi/components/schemas/webhooks/WebhookRepresentation.yaml
@@ -28,17 +28,17 @@ properties:
     examples: ['{\n "Authorization": "Bearer ..."}']
   shouldInterpolateStrings:
     type: [boolean, "null"]
-    description: Optional flag to also interpolate `{{...}}` variables inside string values of the payload and headers templates.
+    description: Flag to also interpolate `{{...}}` variables inside string values of the payload and headers templates.
     examples: [false]
   idempotencyKey:
     type: [string, "null"]
-    description: Optional key that prevents creating duplicate webhooks, e.g. when the run-starting request is retried.
+    description: Key that prevents creating duplicate webhooks, e.g. when the run-starting request is retried.
     examples: [fdSJmdP3nfs7sfk3y]
   ignoreSslErrors:
     type: [boolean, "null"]
-    description: Optional flag to ignore SSL errors when the webhook sends the request.
+    description: Flag to ignore SSL errors when the webhook sends the request.
     examples: [false]
   doNotRetry:
     type: [boolean, "null"]
-    description: Optional flag to skip retrying the webhook request on failure.
+    description: Flag to skip retrying the webhook request on failure.
     examples: [false]

--- a/apify-api/openapi/components/schemas/webhooks/WebhookRepresentation.yaml
+++ b/apify-api/openapi/components/schemas/webhooks/WebhookRepresentation.yaml
@@ -26,3 +26,15 @@ properties:
     type: [string, "null"]
     description: Optional template for the HTTP headers sent by the webhook.
     examples: ['{\n "Authorization": "Bearer ..."}']
+  idempotencyKey:
+    type: [string, "null"]
+    description: Optional key that prevents creating duplicate webhooks, e.g. when the run-starting request is retried.
+    examples: [fdSJmdP3nfs7sfk3y]
+  ignoreSslErrors:
+    type: [boolean, "null"]
+    description: Optional flag to ignore SSL errors when the webhook sends the request.
+    examples: [false]
+  doNotRetry:
+    type: [boolean, "null"]
+    description: Optional flag to skip retrying the webhook request on failure.
+    examples: [false]


### PR DESCRIPTION
## Description

- The `WebhookRepresentation` schema (items of the Base64-encoded `webhooks` query parameter on the run/build endpoints) declared only `eventTypes`, `requestUrl`, `payloadTemplate` and `headersTemplate`, but the platform accepts and honors more fields for ad-hoc webhooks: the run-start handler spreads each webhook object into the same `insertWebhook` path used by the create-webhook endpoint, including the `idempotencyKey` dedup logic.
- This adds the missing `idempotencyKey`, `ignoreSslErrors` and `doNotRetry` properties to the schema, so generated API clients (e.g. `apify-client-python`) stop dropping them.
- The Python client and SDK changes that build on this:
  - https://github.com/apify/apify-sdk-python/pull/963
  - https://github.com/apify/apify-client-python/pull/855