### PR TITLE
docs: reflect Apify-assigned Actor categories

### DIFF
--- a/sources/platform/actors/publishing/publish.mdx
+++ b/sources/platform/actors/publishing/publish.mdx
@@ -12,7 +12,7 @@ Before making your Actor public, it's important to ensure your Actor has a clear
 Once you've finished coding and testing your Actor, it's time to publish it. Follow these steps:
 
 1. From your Actor's page in Apify Console, go to **Publication** > **Display information**
-2. Fill in all the relevant fields for your Actor (e.g., **Icon**, **Actor name**, **Description**, **Categories**)
+2. Fill in all the relevant fields for your Actor (e.g., **Icon**, **Actor name**, **Description**)
 3. Save your changes
 
 ![Actor settings](./images/actor-display-information.webp)
@@ -44,6 +44,12 @@ When writing your Actor's description, you also have the option to provide an SE
 - Be between _40_ to _50_ characters for the title and _140_ to _156_ characters for description
 
 ![SEO title and description](./images/actor-SEO.webp)
+
+### Categories
+
+Apify assigns categories to each public Actor; there's no field for you to select categories yourself. Categories help users discover your Actor in [Apify Store](https://apify.com/store).
+
+If you strongly disagree with the categories assigned to your Actor, contact [Apify support](https://apify.com/contact).
 
 ### README
 


### PR DESCRIPTION
Refs #2581. Categories will now be Apify-assigned, not creator-selected.

Removes the **Categories** field from the publish steps in `publish.mdx` and adds a short *Categories* subsection explaining the new behaviour and how creators can dispute their assignment via Apify support.

### Open questions for Honza Kuželík (Discovery) — blocking final review

- [ ] **Rollout timing.** When does the creator-side UI for selecting categories actually go away? The doc edit lands creators "no field to select" — if Console still shows it for a window, we need to either gate this PR on the UI removal or add a temporary "rolling out" admonition.
- [ ] **REST API surface.** Does `categories` on `acts-post` / `act-put` still accept creator writes, get ignored, or get rejected? Affects whether to mark the parameter deprecated in the OpenAPI spec in a follow-up.
- [ ] **Support channel.** I used `https://apify.com/contact` (the canonical pattern in other publishing pages). Confirm that's the right route for category disputes vs. a specific email/form.

### Follow-ups (separate PRs, not this one)

- `images/actor-display-information.webp` will need re-capture once the **Categories** field is gone from Console.
- If creator writes to `categories` are being dropped, update the OpenAPI parameter doc on `acts-post` / `act-put`.

Draft until the three questions above are confirmed.