### PR TITLE
docs: document Store search ranking and Console personalization

### DIFF
--- a/sources/academy/build-and-publish/apify-store-basics/how_store_works.md
+++ b/sources/academy/build-and-publish/apify-store-basics/how_store_works.md
@@ -102,9 +102,9 @@ Learn more about how to handle the [Issues tab](/academy/actor-marketing-playboo
 
 ## How Apify Store search works
 
-Apify ranks Actors in [Apify Store](https://apify.com/store) search and the [Apify MCP server](/platform/integrations/mcp) `search-actors` tool using criteria similar to what the [Actor quality score](/platform/actors/publishing/quality-score) evaluates, with extra emphasis on popularity. A higher quality score makes your Actor more likely to place higher, though no specific position is guaranteed.
+Search ranking and the [Actor quality score](/platform/actors/publishing/quality-score) are separate systems, but they evaluate similar parameters, with extra emphasis on popularity. As a result, the two correlate strongly: Actors with higher quality scores tend to rank higher in [Apify Store](https://apify.com/store) search and the [Apify MCP server](/platform/integrations/mcp) `search-actors` tool. No specific position is guaranteed.
 
-To improve your Actor's visibility, focus on improving its quality score. See [Actor quality score](/platform/actors/publishing/quality-score) for what the score measures and how to influence each category.
+To improve your Actor's visibility in search, focus on improving its quality score. See [Actor quality score](/platform/actors/publishing/quality-score) for what the score measures and how to influence each category.
 
 ### Search in Apify Console is personalized
 

--- a/sources/academy/build-and-publish/apify-store-basics/how_store_works.md
+++ b/sources/academy/build-and-publish/apify-store-basics/how_store_works.md
@@ -102,7 +102,7 @@ Learn more about how to handle the [Issues tab](/academy/actor-marketing-playboo
 
 ## How Apify Store search works
 
-Search ranking and the [Actor quality score](/platform/actors/publishing/quality-score) are separate systems, but they evaluate similar parameters, with extra emphasis on popularity. As a result, the two correlate strongly: Actors with higher quality scores tend to rank higher in [Apify Store](https://apify.com/store) search and the [Apify MCP server](/platform/integrations/mcp) `search-actors` tool. No specific position is guaranteed.
+Search ranking and the [Actor quality score](/platform/actors/publishing/quality-score) are separate systems. Search ranking evaluates parameters similar to those in the quality score, with extra weight on popularity. As a result, the two correlate strongly: Actors with higher quality scores tend to rank higher in [Apify Store](https://apify.com/store) search and the [Apify MCP server](/platform/integrations/mcp) `search-actors` tool. No specific position is guaranteed.
 
 To improve your Actor's visibility in search, focus on improving its quality score. See [Actor quality score](/platform/actors/publishing/quality-score) for what the score measures and how to influence each category.
 

--- a/sources/academy/build-and-publish/apify-store-basics/how_store_works.md
+++ b/sources/academy/build-and-publish/apify-store-basics/how_store_works.md
@@ -102,7 +102,7 @@ Learn more about how to handle the [Issues tab](/academy/actor-marketing-playboo
 
 ## How Apify Store search works
 
-Search ranking and the [Actor quality score](/platform/actors/publishing/quality-score) are separate systems. Search ranking evaluates parameters similar to those in the quality score, with extra weight on popularity. As a result, the two correlate strongly: Actors with higher quality scores tend to rank higher in [Apify Store](https://apify.com/store) search and the [Apify MCP server](/platform/integrations/mcp) `search-actors` tool. No specific position is guaranteed.
+Search ranking evaluates parameters similar to those in the [Actor quality score](/platform/actors/publishing/quality-score). As a result, the two correlate strongly: Actors with higher quality scores tend to rank higher in [Apify Store](https://apify.com/store) search and the [Apify MCP server](/platform/integrations/mcp) `search-actors` tool, though no specific position is guaranteed.
 
 To improve your Actor's visibility in search, focus on improving its quality score. See [Actor quality score](/platform/actors/publishing/quality-score) for what the score measures and how to influence each category.
 

--- a/sources/academy/build-and-publish/apify-store-basics/how_store_works.md
+++ b/sources/academy/build-and-publish/apify-store-basics/how_store_works.md
@@ -100,6 +100,20 @@ Since the **Issues** tab is public, the level of activity - or lack thereof - ca
 
 Learn more about how to handle the [Issues tab](/academy/actor-marketing-playbook/interact-with-users/issues-tab)
 
+## How Apify Store search works
+
+Apify ranks Actors in [Apify Store](https://apify.com/store) search and the [Apify MCP server](/platform/integrations/mcp) `search-actors` tool using criteria similar to what the [Actor quality score](/platform/actors/publishing/quality-score) evaluates, with extra emphasis on popularity. A higher quality score makes your Actor more likely to place higher, though no specific position is guaranteed.
+
+To improve your Actor's visibility, focus on improving its quality score. See [Actor quality score](/platform/actors/publishing/quality-score) for what the score measures and how to influence each category.
+
+### Search in Apify Console is personalized
+
+Search in [Apify Console](https://console.apify.com) is an exception: results are personalized for each individual user. The ranking criteria are the same as the public Store, but the order is individual, so the same query can return different Actors than the public Store at [apify.com/store](https://apify.com/store).
+
+### Disputing Actor categories
+
+If you believe your Actor is in the wrong category, contact Apify support. In a later phase, you will be able to see and dispute categories directly in the Actor publication settings.
+
 ## Resources
 
 - Best practices on setting up [testing for your Actor](https://docs.apify.com/platform/actors/publishing/test)

--- a/sources/academy/build-and-publish/apify-store-basics/how_store_works.md
+++ b/sources/academy/build-and-publish/apify-store-basics/how_store_works.md
@@ -110,10 +110,6 @@ To improve your Actor's visibility in search, focus on improving its quality sco
 
 Search in [Apify Console](https://console.apify.com) is an exception: results are personalized for each individual user. The ranking criteria are the same as the public Store, but the order is individual, so the same query can return different Actors than the public Store at [apify.com/store](https://apify.com/store).
 
-### Disputing Actor categories
-
-If you believe your Actor is in the wrong category, contact Apify support. In a later phase, you will be able to see and dispute categories directly in the Actor publication settings.
-
 ## Resources
 
 - Best practices on setting up [testing for your Actor](https://docs.apify.com/platform/actors/publishing/test)

--- a/sources/academy/build-and-publish/apify-store-basics/how_store_works.md
+++ b/sources/academy/build-and-publish/apify-store-basics/how_store_works.md
@@ -108,7 +108,7 @@ To improve your Actor's visibility in search, focus on improving its quality sco
 
 ### Search in Apify Console is personalized
 
-Search in [Apify Console](https://console.apify.com) is an exception: results are personalized for each individual user, so the same query can return different Actors than the public Store at [apify.com/store](https://apify.com/store). Quality score still correlates with ranking - the order is just adjusted per user.
+In [Apify Console](https://console.apify.com), search results are personalized for each user. As a result, the same query can return different Actors than in [Apify Store](https://apify.com/store). Quality score still correlates with ranking, but the order is adjusted per user.
 
 ## Resources
 

--- a/sources/academy/build-and-publish/apify-store-basics/how_store_works.md
+++ b/sources/academy/build-and-publish/apify-store-basics/how_store_works.md
@@ -104,7 +104,7 @@ Learn more about how to handle the [Issues tab](/academy/actor-marketing-playboo
 
 Search ranking evaluates parameters similar to those in the [Actor quality score](/platform/actors/publishing/quality-score). As a result, the two correlate strongly: Actors with higher quality scores tend to rank higher in [Apify Store](https://apify.com/store) search and the [Apify MCP server](/platform/integrations/mcp) `search-actors` tool, though no specific position is guaranteed.
 
-To improve your Actor's visibility in search, focus on improving its quality score. See [Actor quality score](/platform/actors/publishing/quality-score) for what the score measures and how to influence each category.
+To improve your Actor's visibility in search, focus on improving its quality score. For what the score measures and how to influence each category, see [Actor quality score](/platform/actors/publishing/quality-score).
 
 ### Search in Apify Console is personalized
 

--- a/sources/academy/build-and-publish/apify-store-basics/how_store_works.md
+++ b/sources/academy/build-and-publish/apify-store-basics/how_store_works.md
@@ -108,7 +108,7 @@ To improve your Actor's visibility in search, focus on improving its quality sco
 
 ### Search in Apify Console is personalized
 
-Search in [Apify Console](https://console.apify.com) is an exception: results are personalized for each individual user. The ranking criteria are the same as the public Store, but the order is individual, so the same query can return different Actors than the public Store at [apify.com/store](https://apify.com/store).
+Search in [Apify Console](https://console.apify.com) is an exception: results are personalized for each individual user, so the same query can return different Actors than the public Store at [apify.com/store](https://apify.com/store). Quality score still correlates with ranking - the order is just adjusted per user.
 
 ## Resources
 

--- a/sources/platform/actors/publishing/quality_score.mdx
+++ b/sources/platform/actors/publishing/quality_score.mdx
@@ -11,7 +11,7 @@ The Actor quality score is a metric that evaluates your Actor's performance acro
 
 ## Quality score and search ranking
 
-The quality score and search ranking are separate systems, but they evaluate similar parameters, with extra emphasis on popularity. As a result, the two correlate strongly across Apify search surfaces:
+The quality score and search ranking are separate systems. Search ranking evaluates parameters similar to those in the quality score, with extra weight on popularity. As a result, the two correlate strongly across Apify search surfaces:
 
 - _Apify Store search_ at [apify.com/store](https://apify.com/store).
 - The _Apify MCP server_ `search-actors` tool used by external AI agents. See [Apify MCP server](/platform/integrations/mcp).

--- a/sources/platform/actors/publishing/quality_score.mdx
+++ b/sources/platform/actors/publishing/quality_score.mdx
@@ -11,7 +11,7 @@ The Actor quality score is a metric that evaluates your Actor's performance acro
 
 ## Quality score and search ranking
 
-The quality score and search ranking are separate systems. Search ranking evaluates parameters similar to those in the quality score, with extra weight on popularity. As a result, the two correlate strongly across Apify search surfaces:
+Search ranking evaluates parameters similar to those in the quality score. As a result, the two correlate strongly across Apify search surfaces:
 
 - _Apify Store search_ at [apify.com/store](https://apify.com/store).
 - The _Apify MCP server_ `search-actors` tool used by external AI agents. See [Apify MCP server](/platform/integrations/mcp).

--- a/sources/platform/actors/publishing/quality_score.mdx
+++ b/sources/platform/actors/publishing/quality_score.mdx
@@ -9,6 +9,15 @@ The Actor quality score is a metric that evaluates your Actor's performance acro
 
 ---
 
+## How the quality score affects ranking
+
+The quality score drives ranking across Apify search surfaces:
+
+- _Apify Store search_ at [apify.com/store](https://apify.com/store).
+- The _Apify MCP server_ `search-actors` tool used by external AI agents. See [Apify MCP server](/platform/integrations/mcp).
+
+All surfaces rank Actors using criteria similar to the quality score, with extra emphasis on popularity. A higher quality score makes your Actor more likely to place higher, though no specific position is guaranteed. Search in Apify Console is an exception: the ranking criteria are the same, but the order is personalized to each individual user. See [How Apify Store search works](/academy/actor-marketing-playbook/store-basics/how-store-works#how-apify-store-search-works) for the publisher-facing guidance.
+
 ## How to view your score
 
 Navigate to **Console > Insights > Actor quality**, and then select your Actor.

--- a/sources/platform/actors/publishing/quality_score.mdx
+++ b/sources/platform/actors/publishing/quality_score.mdx
@@ -16,7 +16,7 @@ The quality score and search ranking are separate systems, but they evaluate sim
 - _Apify Store search_ at [apify.com/store](https://apify.com/store).
 - The _Apify MCP server_ `search-actors` tool used by external AI agents. See [Apify MCP server](/platform/integrations/mcp).
 
-Actors with higher quality scores tend to rank higher on both surfaces, though no specific position is guaranteed. Search in Apify Console is an exception: the ranking criteria are the same, but the order is personalized to each individual user. See [How Apify Store search works](/academy/actor-marketing-playbook/store-basics/how-store-works#how-apify-store-search-works) for the publisher-facing guidance.
+Actors with higher quality scores tend to rank higher on both surfaces, though no specific position is guaranteed. Search in Apify Console is personalized to each individual user, so the same query can return different Actors than the public Store - quality score still correlates with ranking, the order is just adjusted per user. See [How Apify Store search works](/academy/actor-marketing-playbook/store-basics/how-store-works#how-apify-store-search-works) for the publisher-facing guidance.
 
 ## How to view your score
 

--- a/sources/platform/actors/publishing/quality_score.mdx
+++ b/sources/platform/actors/publishing/quality_score.mdx
@@ -9,14 +9,14 @@ The Actor quality score is a metric that evaluates your Actor's performance acro
 
 ---
 
-## How the quality score affects ranking
+## Quality score and search ranking
 
-The quality score drives ranking across Apify search surfaces:
+The quality score and search ranking are separate systems, but they evaluate similar parameters, with extra emphasis on popularity. As a result, the two correlate strongly across Apify search surfaces:
 
 - _Apify Store search_ at [apify.com/store](https://apify.com/store).
 - The _Apify MCP server_ `search-actors` tool used by external AI agents. See [Apify MCP server](/platform/integrations/mcp).
 
-All surfaces rank Actors using criteria similar to the quality score, with extra emphasis on popularity. A higher quality score makes your Actor more likely to place higher, though no specific position is guaranteed. Search in Apify Console is an exception: the ranking criteria are the same, but the order is personalized to each individual user. See [How Apify Store search works](/academy/actor-marketing-playbook/store-basics/how-store-works#how-apify-store-search-works) for the publisher-facing guidance.
+Actors with higher quality scores tend to rank higher on both surfaces, though no specific position is guaranteed. Search in Apify Console is an exception: the ranking criteria are the same, but the order is personalized to each individual user. See [How Apify Store search works](/academy/actor-marketing-playbook/store-basics/how-store-works#how-apify-store-search-works) for the publisher-facing guidance.
 
 ## How to view your score
 

--- a/sources/platform/console/store.md
+++ b/sources/platform/console/store.md
@@ -20,6 +20,6 @@ Once you select an Actor from the store, you'll be directed to its specific page
 
 ## Search
 
-Search results in Apify Console are personalized to each individual user, so the same query can return different Actors than the public Store at [apify.com/store](https://apify.com/store). Both surfaces rank Actors using parameters similar to those in the [Actor quality score](/platform/actors/publishing/quality-score).
+Search results in Apify Console are personalized to each individual user, so the same query can return different Actors than the public Store at [apify.com/store](https://apify.com/store). Both Console and the public Store rank Actors using parameters similar to those in the [Actor quality score](/platform/actors/publishing/quality-score).
 
 For more information, see [Actors in Store](/sources/platform/actors/running/store/index.md).

--- a/sources/platform/console/store.md
+++ b/sources/platform/console/store.md
@@ -20,6 +20,6 @@ Once you select an Actor from the store, you'll be directed to its specific page
 
 ## Search
 
-Search results in Apify Console are personalized to each individual user, so the same query can return different Actors than the public Store at [apify.com/store](https://apify.com/store). Ranking criteria on both surfaces are similar to what the [Actor quality score](/platform/actors/publishing/quality-score) evaluates, with extra emphasis on popularity.
+Search results in Apify Console are personalized to each individual user, so the same query can return different Actors than the public Store at [apify.com/store](https://apify.com/store). Both surfaces rank Actors using criteria similar to the [Actor quality score](/platform/actors/publishing/quality-score), with extra weight on popularity.
 
 For more information, see [Actors in Store](/sources/platform/actors/running/store/index.md).

--- a/sources/platform/console/store.md
+++ b/sources/platform/console/store.md
@@ -20,6 +20,6 @@ Once you select an Actor from the store, you'll be directed to its specific page
 
 ## Search
 
-Search results in Apify Console are personalized to each individual user, so the same query can return different Actors than the public Store at [apify.com/store](https://apify.com/store). Both surfaces rank Actors using criteria similar to the [Actor quality score](/platform/actors/publishing/quality-score), with extra weight on popularity.
+Search results in Apify Console are personalized to each individual user, so the same query can return different Actors than the public Store at [apify.com/store](https://apify.com/store). Both surfaces rank Actors using parameters similar to those in the [Actor quality score](/platform/actors/publishing/quality-score).
 
 For more information, see [Actors in Store](/sources/platform/actors/running/store/index.md).

--- a/sources/platform/console/store.md
+++ b/sources/platform/console/store.md
@@ -18,4 +18,8 @@ You can also organize the results from the store by different criteria, includin
 
 Once you select an Actor from the store, you'll be directed to its specific page. Here, you can configure the settings for your future Actor run, save these configurations for later use, or run the Actor immediately.
 
+## Search
+
+Search results in Apify Console are personalized to each individual user, so the same query can return different Actors than the public Store at [apify.com/store](https://apify.com/store). The ranking criteria are the same on both surfaces - similar to what the [Actor quality score](/platform/actors/publishing/quality-score) evaluates, with extra emphasis on popularity.
+
 For more information, see [Actors in Store](/sources/platform/actors/running/store/index.md).

--- a/sources/platform/console/store.md
+++ b/sources/platform/console/store.md
@@ -20,6 +20,6 @@ Once you select an Actor from the store, you'll be directed to its specific page
 
 ## Search
 
-Search results in Apify Console are personalized to each individual user, so the same query can return different Actors than the public Store at [apify.com/store](https://apify.com/store). The ranking criteria are the same on both surfaces - similar to what the [Actor quality score](/platform/actors/publishing/quality-score) evaluates, with extra emphasis on popularity.
+Search results in Apify Console are personalized to each individual user, so the same query can return different Actors than the public Store at [apify.com/store](https://apify.com/store). Ranking criteria on both surfaces are similar to what the [Actor quality score](/platform/actors/publishing/quality-score) evaluates, with extra emphasis on popularity.
 
 For more information, see [Actors in Store](/sources/platform/actors/running/store/index.md).


### PR DESCRIPTION
Adds publisher-facing guidance for Apify Store search.

- Ranking on Store search and the MCP server `search-actors` tool uses criteria similar to the Actor quality score, with extra emphasis on popularity. Higher score = more likely placement, no guarantees.
- Search in Apify Console is the personalization exception: same criteria, individual order per user.
- Adds a category-dispute note pointing publishers to support for now.