### PR TITLE
refactor: convert proxy type page blockquotes to admonitions

### DIFF
--- a/sources/platform/proxy/datacenter_proxy.md
+++ b/sources/platform/proxy/datacenter_proxy.md
@@ -311,7 +311,7 @@ You can find your proxy password on the [Proxy page](https://console.apify.com/p
 
 :::note Username field
 
-The `username` field is _not_ your Apify username. Instead, you specify proxy settings (for example, `groups-BUYPROXIES94952`, `session-123`). Use `auto` for default settings.
+Use the `username` field to specify your proxy settings (for example, `groups-BUYPROXIES94952`, `session-123`), or set it to `auto` for default settings. It is not your Apify username.
 
 :::
 

--- a/sources/platform/proxy/datacenter_proxy.md
+++ b/sources/platform/proxy/datacenter_proxy.md
@@ -311,7 +311,7 @@ You can find your proxy password on the [Proxy page](https://console.apify.com/p
 
 :::note Username field
 
-The `username` field is **not** your Apify username. Instead, you specify proxy settings (for example, `groups-BUYPROXIES94952`, `session-123`). Use `auto` for default settings.
+The `username` field is _not_ your Apify username. Instead, you specify proxy settings (for example, `groups-BUYPROXIES94952`, `session-123`). Use `auto` for default settings.
 
 :::
 

--- a/sources/platform/proxy/datacenter_proxy.md
+++ b/sources/platform/proxy/datacenter_proxy.md
@@ -311,7 +311,7 @@ You can find your proxy password on the [Proxy page](https://console.apify.com/p
 
 :::note Username field
 
-Use the `username` field to specify your proxy settings (for example, `groups-BUYPROXIES94952`, `session-123`), or set it to `auto` for default settings. It is not your Apify username.
+Use the `username` field to specify your proxy settings (for example, `groups-BUYPROXIES94952`, `session-123`), or set it to `auto` for default settings. It isn't your Apify username.
 
 :::
 

--- a/sources/platform/proxy/datacenter_proxy.md
+++ b/sources/platform/proxy/datacenter_proxy.md
@@ -309,9 +309,11 @@ await Actor.exit();
 
 You can find your proxy password on the [Proxy page](https://console.apify.com/proxy) of Apify Console.
 
-> The `username` field is **not** your Apify username.<br/>
-> Instead, you specify proxy settings (e.g. `groups-BUYPROXIES94952`, `session-123`).<br/>
-> Use `auto` for default settings.
+:::note Username field
+
+The `username` field is **not** your Apify username. Instead, you specify proxy settings (for example, `groups-BUYPROXIES94952`, `session-123`). Use `auto` for default settings.
+
+:::
 
 For examples using [PHP](https://www.php.net/), you need to have the [cURL](https://www.php.net/manual/en/book.curl.php) extension enabled in your PHP installation. See [installation instructions](https://www.php.net/manual/en/curl.installation.php) for more information.
 

--- a/sources/platform/proxy/google_serp_proxy.md
+++ b/sources/platform/proxy/google_serp_proxy.md
@@ -18,7 +18,7 @@ Our Google SERP proxy currently supports the below services.
 
 :::caution Google-only
 
-Google SERP proxy can **only** be used for Google Search and Shopping. It cannot be used to access other websites.
+Google SERP proxy can _only_ be used for Google Search and Shopping. It cannot be used to access other websites.
 
 :::
 
@@ -182,7 +182,7 @@ You can find your proxy password on the [Proxy page](https://console.apify.com/p
 
 :::note Username field
 
-The `username` field is **not** your Apify username. Instead, you specify proxy settings (for example, `groups-GOOGLE_SERP`). Use `groups-GOOGLE_SERP` to use proxies from all available countries.
+The `username` field is _not_ your Apify username. Instead, you specify proxy settings (for example, `groups-GOOGLE_SERP`). Use `groups-GOOGLE_SERP` to use proxies from all available countries.
 
 :::
 

--- a/sources/platform/proxy/google_serp_proxy.md
+++ b/sources/platform/proxy/google_serp_proxy.md
@@ -182,7 +182,7 @@ You can find your proxy password on the [Proxy page](https://console.apify.com/p
 
 :::note Username field
 
-Use the `username` field to specify your proxy settings (for example, `groups-GOOGLE_SERP`), or set it to `groups-GOOGLE_SERP` to use proxies from all available countries. It is not your Apify username.
+Use the `username` field to specify your proxy settings (for example, `groups-GOOGLE_SERP`), or set it to `groups-GOOGLE_SERP` to use proxies from all available countries. It isn't your Apify username.
 
 :::
 

--- a/sources/platform/proxy/google_serp_proxy.md
+++ b/sources/platform/proxy/google_serp_proxy.md
@@ -182,7 +182,7 @@ You can find your proxy password on the [Proxy page](https://console.apify.com/p
 
 :::note Username field
 
-The `username` field is _not_ your Apify username. Instead, you specify proxy settings (for example, `groups-GOOGLE_SERP`). Use `groups-GOOGLE_SERP` to use proxies from all available countries.
+Use the `username` field to specify your proxy settings (for example, `groups-GOOGLE_SERP`), or set it to `groups-GOOGLE_SERP` to use proxies from all available countries. It is not your Apify username.
 
 :::
 

--- a/sources/platform/proxy/google_serp_proxy.md
+++ b/sources/platform/proxy/google_serp_proxy.md
@@ -16,7 +16,11 @@ Our Google SERP proxy currently supports the below services.
 * Google Shopping (`http://www.google.<country domain>/shopping/product/<product ID>`).
 * Google Shopping Search (`http://www.google.<country domain>/search?tbm=shop`).
 
-> Google SERP proxy can **only** be used for Google Search and Shopping. It cannot be used to access other websites.
+:::caution Google-only
+
+Google SERP proxy can **only** be used for Google Search and Shopping. It cannot be used to access other websites.
+
+:::
 
 When using the proxy, **pricing is based on the number of requests made**.
 
@@ -176,9 +180,11 @@ await Actor.exit();
 
 You can find your proxy password on the [Proxy page](https://console.apify.com/proxy/access) of Apify Console.
 
-> The `username` field is **not** your Apify username.<br/>
-> Instead, you specify proxy settings (e.g. `groups-GOOGLE_SERP`).<br/>
-> Use `groups-GOOGLE_SERP` to use proxies from all available countries.
+:::note Username field
+
+The `username` field is **not** your Apify username. Instead, you specify proxy settings (for example, `groups-GOOGLE_SERP`). Use `groups-GOOGLE_SERP` to use proxies from all available countries.
+
+:::
 
 For examples using [PHP](https://www.php.net/), you need to have the [cURL](https://www.php.net/manual/en/book.curl.php) extension enabled in your PHP installation. See [installation instructions](https://www.php.net/manual/en/curl.installation.php) for more information.
 

--- a/sources/platform/proxy/residential_proxy.md
+++ b/sources/platform/proxy/residential_proxy.md
@@ -166,8 +166,11 @@ This IP/session ID combination is persisted for 1 minute. Each subsequent reques
 
 If the proxy server becomes unresponsive or the session expires, a new IP address is selected for the next request.
 
-> If you really need to persist the same session, you can try sending some data using that session (e.g. every 20 seconds) to keep it alive.<br/>
-> Provided the connection is not interrupted, this will let you keep the IP address for longer.
+:::tip Keep sessions alive
+
+If you really need to persist the same session, you can try sending some data using that session (for example, every 20 seconds) to keep it alive. Provided the connection is not interrupted, this will let you keep the IP address for longer.
+
+:::
 
 To learn more about [sessions](./usage.md#sessions) and [IP address rotation](./usage.md#ip-address-rotation), see the proxy [overview page](./index.md).
 

--- a/sources/platform/proxy/residential_proxy.md
+++ b/sources/platform/proxy/residential_proxy.md
@@ -168,7 +168,7 @@ If the proxy server becomes unresponsive or the session expires, a new IP addres
 
 :::tip Keep sessions alive
 
-If you really need to persist the same session, you can try sending some data using that session (for example, every 20 seconds) to keep it alive. Provided the connection is not interrupted, this will let you keep the IP address for longer.
+To keep a session active, send a request through it before its 1-minute timer expires (for example, every 20 seconds). Each request resets the timer, so as long as the connection isn't interrupted, the session persists.
 
 :::
 


### PR DESCRIPTION
Convert informal `> ...` blockquotes on the datacenter, residential, and Google SERP proxy pages into titled admonitions (:::note, :::tip, :::caution).