### PR TITLE
fix: Stop truncating headings in TOC

### DIFF
--- a/apify-docs-theme/src/theme/custom.css
+++ b/apify-docs-theme/src/theme/custom.css
@@ -679,7 +679,6 @@ article .card h2 {
     display: inline-block !important;
     width: 100%;
     overflow: hidden;
-    white-space: nowrap;
 }
 
 .tsd-flag {
@@ -718,10 +717,6 @@ article .card h2 {
 
 aside button[class*='collapseSidebarButton'] svg {
     transform: scale(0.7) rotate(180deg);
-}
-
-.table-of-contents__link {
-    height: 20px;
 }
 
 .navbar .dropdown--hoverable::after {


### PR DESCRIPTION
Truncating headings in the table of contents makes it basically useless. We don't even provide a tooltip to see the whole thing (and that would be annoying in its own way). 

Before ([doc](https://docs.apify.com/platform/actors/publishing/monetize/pay-per-event)):
<img width="271" height="380" alt="Screenshot 2026-06-19 at 10 11 57" src="https://github.com/user-attachments/assets/8183d7c6-c1a2-4b17-9078-357d038aaada" />

Now:
<img width="281" height="447" alt="Screenshot 2026-06-19 at 10 12 20" src="https://github.com/user-attachments/assets/d1cd7a4d-4274-42dd-bd12-64a3aa85ee64" />

On mobile:
<img width="321" height="573" alt="Screenshot 2026-06-19 at 10 12 48" src="https://github.com/user-attachments/assets/a54117ed-217a-438c-829a-538d0598f1a8" />
