### PR TITLE
docs: remove experimental disclaimer from public tasks

### DIFF
--- a/sources/platform/actors/publishing/publish-task.mdx
+++ b/sources/platform/actors/publishing/publish-task.mdx
@@ -9,12 +9,6 @@ sidebar_position: 2
 
 You can create up to 50 tasks per Actor.
 
-:::caution Experimental feature
-
-Task publishing is an experimental feature and is not available to all users yet. To try it out, contact [Apify support](https://apify.com/contact).
-
-:::
-
 ## Prerequisites
 
 Before you publish a task, make sure you have:


### PR DESCRIPTION
reverts https://github.com/apify/apify-docs/pull/2635 as public tasks are now officially accessible for everyone