### PR TITLE
docs: document MCP server tools usable without authentication

### DIFF
--- a/sources/platform/integrations/ai/mcp.md
+++ b/sources/platform/integrations/ai/mcp.md
@@ -267,7 +267,7 @@ Use the UI configurator `https://mcp.apify.com/` to select your tools visually, 
 
 ### Anonymous access
 
-The Apify MCP server accepts requests without an API token when the `tools` query parameter contains _only_ tools enabled for unauthenticated use. These tools cover Actor discovery and documentation lookup:
+The Apify MCP server accepts requests without an API token when the `tools` query parameter contains only tools enabled for unauthenticated use. These tools cover Actor discovery and documentation lookup:
 
 - `search-actors`
 - `fetch-actor-details`

--- a/sources/platform/integrations/ai/mcp.md
+++ b/sources/platform/integrations/ai/mcp.md
@@ -35,12 +35,6 @@ Before connecting your AI to Apify, you'll need three things:
 - _Apify API token_ - Get your API token from the **API & Integrations** section in [Apify Console](https://console.apify.com/settings/integrations). This token authorizes the MCP server to run Actors on your behalf. Make sure to keep it secure.
 - _MCP client_ - An AI agent or client that supports Model Context Protocol (MCP) This could be Anthropic's Claude for Desktop, a VS Code extension with MCP support, or any application that implements the MCP specification. The [official MCP documentation](https://modelcontextprotocol.io/clients) maintains a list of compatible clients.
 
-:::info Use without an account
-
-A core set of tools for Actor discovery and documentation lookup works without an Apify account or API token. Authentication is only required to run Actors and access storage or run data. See [Anonymous access](#anonymous-access) for the list of tools and how to enable token-free access.
-
-:::
-
 ## Quick start
 
 You can connect to the Apify MCP server in two ways: use our hosted service for a quick and easy setup using [Streamable HTTP with OAuth](#streamable-http-with-oauth-recommended), or run the server locally for development and testing using [local stdio](#local-stdio).
@@ -273,7 +267,7 @@ Use the UI configurator `https://mcp.apify.com/` to select your tools visually, 
 
 ### Anonymous access
 
-The hosted server accepts requests without an API token when the `tools` query parameter contains _only_ tools enabled for unauthenticated use. These tools cover Actor discovery and documentation lookup:
+The Apify MCP server accepts requests without an API token when the `tools` query parameter contains _only_ tools enabled for unauthenticated use. These tools cover Actor discovery and documentation lookup:
 
 - `search-actors`
 - `fetch-actor-details`

--- a/sources/platform/integrations/ai/mcp.md
+++ b/sources/platform/integrations/ai/mcp.md
@@ -35,6 +35,12 @@ Before connecting your AI to Apify, you'll need three things:
 - _Apify API token_ - Get your API token from the **API & Integrations** section in [Apify Console](https://console.apify.com/settings/integrations). This token authorizes the MCP server to run Actors on your behalf. Make sure to keep it secure.
 - _MCP client_ - An AI agent or client that supports Model Context Protocol (MCP) This could be Anthropic's Claude for Desktop, a VS Code extension with MCP support, or any application that implements the MCP specification. The [official MCP documentation](https://modelcontextprotocol.io/clients) maintains a list of compatible clients.
 
+:::info Use without an account
+
+A core set of tools for Actor discovery and documentation lookup works without an Apify account or API token. Authentication is only required to run Actors and access storage or run data. See [Anonymous access](#anonymous-access) for the list of tools and how to enable token-free access.
+
+:::
+
 ## Quick start
 
 You can connect to the Apify MCP server in two ways: use our hosted service for a quick and easy setup using [Streamable HTTP with OAuth](#streamable-http-with-oauth-recommended), or run the server locally for development and testing using [local stdio](#local-stdio).
@@ -264,6 +270,21 @@ This configuration approach works for both hosted and local setups. For the CLI 
 Use the UI configurator `https://mcp.apify.com/` to select your tools visually, then copy the configuration to your client.
 
 :::
+
+### Anonymous access
+
+The hosted server accepts requests without an API token when the `tools` query parameter contains _only_ tools enabled for unauthenticated use. These tools cover Actor discovery and documentation lookup:
+
+- `search-actors`
+- `fetch-actor-details`
+- `search-apify-docs`
+- `fetch-apify-docs`
+
+For example, the following URL connects without authentication:
+
+`https://mcp.apify.com?tools=search-actors,fetch-actor-details,search-apify-docs,fetch-apify-docs`
+
+If the `tools` parameter includes any other tool, or you connect to the default endpoint, the server requires an API token. Running Actors and accessing storage or run data always requires authentication.
 
 ### Available tools
 


### PR DESCRIPTION
Documents that a core set of MCP server tools (`search-actors`, `fetch-actor-details`, `search-apify-docs`, `fetch-apify-docs`) works without an Apify account or API token, which the Prerequisites section previously implied was always required. Token-free access applies only when the `tools` query parameter is limited to these tools; running Actors or accessing storage still requires authentication.

Verified against the README of `apify/apify-mcp-server` and by probing the live `mcp.apify.com` endpoint (allow-listed tools return 200 without a token; adding any other tool returns 401).

Closes #2672