### PR TITLE
refactor: parallelize Actors hub structure

### DIFF
--- a/sources/platform/actors/index.mdx
+++ b/sources/platform/actors/index.mdx
@@ -1,7 +1,6 @@
 ---
 title: Actors
 description: Learn how to develop, run and share serverless cloud programs. Create your own web scraping and automation tools and publish them on the Apify platform.
-sidebar_label: Overview
 sidebar_position: 7
 category: platform
 slug: /actors

--- a/sources/platform/actors/index.mdx
+++ b/sources/platform/actors/index.mdx
@@ -1,6 +1,7 @@
 ---
 title: Actors
 description: Learn how to develop, run and share serverless cloud programs. Create your own web scraping and automation tools and publish them on the Apify platform.
+sidebar_label: Overview
 sidebar_position: 7
 category: platform
 slug: /actors
@@ -8,6 +9,16 @@ slug: /actors
 
 import Card from "@site/src/components/Card";
 import CardGrid from "@site/src/components/CardGrid";
+
+Actors are serverless cloud programs that take a structured JSON input, perform a task (web scraping, browser automation, data processing, and more), and optionally produce a structured output. Run them manually in [Apify Console](https://console.apify.com/actors), through the [API](/api) or [CLI](/cli), or on a [schedule](/platform/schedules), and combine them into larger automations.
+
+:::info Additional context
+
+For more context, read the [Actor whitepaper](https://whitepaper.actor/).
+
+:::
+
+## Actor lifecycle
 
 <CardGrid>
     <Card
@@ -27,16 +38,6 @@ import CardGrid from "@site/src/components/CardGrid";
     />
 </CardGrid>
 
-## Actors overview
-
-Actors are serverless programs to automate workflows and extract data. Each Actor takes a structured JSON input, performs a task (like web scraping, browser automation, or data processing), and can optionally produce a structured output. Actors are easy to run manually, via API, or on a schedule, and you can combine them into larger automations.
-
-:::info Additional context
-
-For more context, read the [Actor whitepaper](https://whitepaper.actor/).
-
-:::
-
 ## Actor components
 
 Actors consist of these elements:
@@ -51,23 +52,6 @@ The documentation and input/output schemas help people understand what the Actor
 
 ![Apify Actor diagram](./images/apify-actor-drawing.png)
 
-## Build Actors
-
-Build Actors to automate tasks, scrape data, or create custom workflows. The Apify platform gives you everything you need to develop, test, and deploy your code.
-
-Ready to start? Check out the [Actor development documentation](/platform/actors/development).
-
-## Run Actors
-
-You can run Actors manually in [Apify Console](https://console.apify.com/actors), using the [API](/api), [CLI](/cli), or [scheduler](../schedules.md). You can easily [integrate Actors](../integrations/index.mdx) with other apps, [share](../collaboration/access_rights.md) them with other people, [publish](./publishing/index.mdx) them in [Apify Store](https://apify.com/store), and even [monetize](./publishing/monetize/index.mdx).
-
-:::tip Try Actors
-
-To get a better idea of what Apify Actors are, visit [Apify Store](https://apify.com/store) and try out some of them!
-
-:::
-
-
 ## Public and private Actors
 
-Actors can be [public](/actors/running/store/index.md) or private. Private Actors are yours to use and keep; no one will see them if you don't want them to. Public Actors are available to everyone in [Apify Store](https://apify.com/store). You can make them free to use, or you can [charge for them](https://blog.apify.com/make-regular-passive-income-developing-web-automation-actors-b0392278d085/).
+Actors can be [public](/platform/actors/running/actors-in-store) or private. Private Actors are yours to use and keep; no one will see them if you don't want them to. Public Actors are available to everyone in [Apify Store](https://apify.com/store). You can make them free to use, or you can [charge for them](https://blog.apify.com/make-regular-passive-income-developing-web-automation-actors-b0392278d085/).


### PR DESCRIPTION
intro paragraph -> ## Actor lifecycle (cards) -> detail sections. Add `sidebar_label: Overview`.

Drop three stub H2s (Actors overview, Build Actors, Run Actors) whose content the new intro now covers, and fix the stale store link to the canonical actors-in-store slug.