### PR TITLE
docs(mcp): mention CLI install command

### DIFF
--- a/sources/platform/integrations/ai/mcp.md
+++ b/sources/platform/integrations/ai/mcp.md
@@ -104,24 +104,6 @@ _MCP server configuration for other clients_: Use the [UI configuration tool](ht
 
 Here's how to add the Apify MCP server to popular text editors and AI assistants:
 
-:::tip Configure with Apify CLI
-
-Run `apify mcp install <client>` to add the Apify MCP server to a supported local client. Replace `<client>` with `claude-code`, `cursor`, `vscode`, `vscode-insiders`, `codex`, `kiro`, or `antigravity`.
-
-For clients that need a token, the command uses the API token from `apify login`. Pass `--token <APIFY_TOKEN>` to use a specific token.
-
-```bash
-apify mcp install cursor
-```
-
-Use `--tools` to expose only selected tools or Actors:
-
-```bash
-apify mcp install vscode --tools search-actors,apify/rag-web-browser
-```
-
-:::
-
 <Tabs>
 <TabItem value="cursor" label="Cursor">
 
@@ -236,6 +218,31 @@ VS Code supports MCP through GitHub Copilot's agent mode (requires Copilot subsc
 You can also search for "Apify" in the connector directory and install it directly.
 
 For detailed setup options and troubleshooting, see the [Claude Desktop integration guide](/platform/integrations/claude-desktop).
+
+</TabItem>
+<TabItem value="apify-cli" label="Apify CLI">
+
+Use the Apify CLI to add the Apify MCP server to a supported local client:
+
+```bash
+apify mcp install cursor
+```
+
+Available clients are: `claude-code`, `cursor`, `vscode`, `vscode-insiders`, `codex`, `kiro`, and `antigravity`.
+
+The command creates or updates a user-level MCP server entry named `apify`. For Cursor, Kiro, and Antigravity, it writes to the client's MCP config file. For Claude Code, VS Code, VS Code Insiders, and Codex CLI, it uses the client's own install command.
+
+By default, the command uses the API token saved by `apify login`. To use a different token or Apify account than the one configured in the Apify CLI, pass `--token <APIFY_TOKEN>`:
+
+```bash
+apify mcp install cursor --token <APIFY_TOKEN>
+```
+
+Use `--tools` to expose only selected tools or Actors:
+
+```bash
+apify mcp install vscode --tools search-actors,apify/rag-web-browser
+```
 
 </TabItem>
 </Tabs>

--- a/sources/platform/integrations/ai/mcp.md
+++ b/sources/platform/integrations/ai/mcp.md
@@ -104,6 +104,24 @@ _MCP server configuration for other clients_: Use the [UI configuration tool](ht
 
 Here's how to add the Apify MCP server to popular text editors and AI assistants:
 
+:::tip Configure with Apify CLI
+
+Run `apify mcp install <client>` to add the Apify MCP server to a supported local client. Replace `<client>` with `claude-code`, `cursor`, `vscode`, `vscode-insiders`, `codex`, `kiro`, or `antigravity`.
+
+For clients that need a token, the command uses the API token from `apify login`. Pass `--token <APIFY_TOKEN>` to use a specific token.
+
+```bash
+apify mcp install cursor
+```
+
+Use `--tools` to expose only selected tools or Actors:
+
+```bash
+apify mcp install vscode --tools search-actors,apify/rag-web-browser
+```
+
+:::
+
 <Tabs>
 <TabItem value="cursor" label="Cursor">
 


### PR DESCRIPTION
## What
Adds the `apify mcp install <client>` setup path to the MCP server page's Client configuration section.

## Why
The command from apify/apify-cli#1145 gives users a direct CLI-based way to configure supported local MCP clients.

## Testing
- `/home/mq/.local/share/mise/installs/pnpm/latest/pnpm --dir /home/mq/workdir/apify/apify-docs exec markdownlint sources/platform/integrations/ai/mcp.md`
- `git -C /home/mq/workdir/apify/apify-docs diff --check`
