### PR TITLE
docs(openapi): Add missing descriptions to Actor object

### DIFF
--- a/apify-api/openapi/components/schemas/actors/ActorPermissionLevel.yaml
+++ b/apify-api/openapi/components/schemas/actors/ActorPermissionLevel.yaml
@@ -1,7 +1,7 @@
 type: string
 description: >
-  Determines permissions that the Actor requires to run.
-  For more information, see the [Actor permissions documentation](https://docs.apify.com/platform/actors/development/permissions).
+  Determines the permission level that the Actor requires to run.
+  For details, see [Actor permissions](https://docs.apify.com/platform/actors/development/permissions).
 enum:
   - LIMITED_PERMISSIONS
   - FULL_PERMISSIONS

--- a/apify-api/openapi/components/schemas/actors/ActorStandby.yaml
+++ b/apify-api/openapi/components/schemas/actors/ActorStandby.yaml
@@ -3,17 +3,26 @@ type: object
 properties:
   isEnabled:
     type: [boolean, "null"]
+    description: Whether standby mode is enabled for the Actor.
   desiredRequestsPerActorRun:
     type: [integer, "null"]
+    description: Target number of concurrent HTTP requests a single run is configured to handle.
   maxRequestsPerActorRun:
     type: [integer, "null"]
+    description: Maximum number of concurrent HTTP requests that can be routed to a single run.
   idleTimeoutSecs:
     type: [integer, "null"]
+    description: In seconds, how long a run can stay idle without incoming requests before it's terminated.
   build:
     type: [string, "null"]
+    description: Which build to run in standby mode. Either a build tag or a version number.
   memoryMbytes:
     type: [integer, "null"]
+    description: In MB, the amount of memory allocated to the run.
   disableStandbyFieldsOverride:
     type: [boolean, "null"]
+    description: If `true`, prevents the standby mode configuration from being overridden elsewhere.
   shouldPassActorInput:
     type: [boolean, "null"]
+    description: Whether to pass the Actor's input to the standby run. If `false`, the run relays
+      on per-request data.

--- a/apify-api/openapi/components/schemas/actors/ActorStandby.yaml
+++ b/apify-api/openapi/components/schemas/actors/ActorStandby.yaml
@@ -24,5 +24,5 @@ properties:
     description: If `true`, prevents the standby mode configuration from being overridden elsewhere.
   shouldPassActorInput:
     type: [boolean, "null"]
-    description: Whether to pass the Actor's input to the standby run. If `false`, the run relays
-      on per-request data.
+    description: Whether to pass the Actor's input to the standby run. If `false`, the standby runs
+      start with no input.

--- a/apify-api/openapi/components/schemas/actors/CreateActorRequest.yaml
+++ b/apify-api/openapi/components/schemas/actors/CreateActorRequest.yaml
@@ -3,22 +3,34 @@ type: object
 properties:
   name:
     type: [string, "null"]
-    examples: [MyActor]
+    examples: [instagram-scraper]
+    description: The identifier of the Actor. Use lowercase letters, numbers, and hyphens.
+      Spaces or special characters aren't allowed. Must be unique across your account.
   description:
     type: [string, "null"]
-    examples: [My favourite actor!]
+    examples: [This scraper extracts posts and comments from Instagram.]
+    description: Short description of the Actor, displayed in Apify Store and Console.
   title:
     type: [string, "null"]
-    examples: [My actor]
+    examples: [Instagram scraper]
+    description: Human-readable name of the Actor, displayed in Apify Store and Console.
+      Can contain spaces and capital letters. Recommended length is 40-50 characters.
+      You can change this title without affecting the Actor's URL or SEO.
   isPublic:
     type: [boolean, "null"]
     examples: [false]
+    description: Whether the Actor is available to users in Apify Store. If `false`, the Actor is private
+      and only visible to you.
   seoTitle:
     type: [string, "null"]
-    examples: [My actor]
+    examples: [Free Instagram scraper]
+    description: Name of the Actor to display by search engines such as Google. Can be different
+      from the Actor's name displayed in Apify Store and Console. Recommended length is 40-50 characters.
   seoDescription:
     type: [string, "null"]
-    examples: [My actor is the best]
+    examples: [The best scraper for Instagram]
+    description: Description of the Actor to display by search engines such as Google.
+      Recommended length is 140-156 characters.
   restartOnError:
     type: boolean
     examples: [false]
@@ -27,25 +39,31 @@ properties:
     type: [array, "null"]
     items:
       $ref: ./Version.yaml
-    description: ""
+    description: "An array of `Version` objects. Each object represents a specific version of the
+      Actor's source code: its location, builds, and environment configuration."
   pricingInfos:
     type: array
     items:
       $ref: ../actor-pricing-info/ActorRunPricingInfo.yaml
   categories:
     type: [array, "null"]
+    examples: ["SOCIAL_MEDIA"]
     items:
       type: string
-    description: ""
+    description: A list of categories that best define the Actor. Reflected in Apify Store's search and filtering options.
   defaultRunOptions:
     $ref: ./DefaultRunOptions.yaml
   actorStandby:
     anyOf:
       - $ref: ./ActorStandby.yaml
       - type: "null"
+    description: The configuration of the Actor's standby mode. For details, see [Standby mode](https://docs.apify.com/platform/actors/development/programming-interface/standby).
   exampleRunInput:
     anyOf:
       - $ref: ./ExampleRunInput.yaml
       - type: "null"
+    description: Sample input payload that demonstrates what a typical run input for an Actor
+      looks like. Used when no explicit input for a run is provided.
   isDeprecated:
     type: [boolean, "null"]
+    description: Whether the Actor is deprecated.

--- a/apify-api/openapi/components/schemas/actors/CreateActorRequest.yaml
+++ b/apify-api/openapi/components/schemas/actors/CreateActorRequest.yaml
@@ -47,7 +47,7 @@ properties:
       $ref: ../actor-pricing-info/ActorRunPricingInfo.yaml
   categories:
     type: [array, "null"]
-    examples: ["SOCIAL_MEDIA"]
+    examples: [["SOCIAL_MEDIA"]]
     items:
       type: string
     description: A list of categories that best define the Actor. Reflected in Apify Store's search and filtering options.

--- a/apify-api/openapi/components/schemas/actors/CreateActorRequest.yaml
+++ b/apify-api/openapi/components/schemas/actors/CreateActorRequest.yaml
@@ -36,7 +36,9 @@ properties:
     examples: [false]
     deprecated: true # Use defaultRunOptions.restartOnError instead
   versions:
-    type: [array, "null"]
+    anyOf:
+      - $ref: ./Version.yaml
+      - type: "null"
     items:
       $ref: ./Version.yaml
     description: "An array of `Version` objects. Each object represents a specific version of the

--- a/apify-api/openapi/components/schemas/actors/CreateActorRequest.yaml
+++ b/apify-api/openapi/components/schemas/actors/CreateActorRequest.yaml
@@ -37,10 +37,10 @@ properties:
     deprecated: true # Use defaultRunOptions.restartOnError instead
   versions:
     anyOf:
-      - $ref: ./Version.yaml
+      - type: array
+        items:
+          $ref: ./Version.yaml
       - type: "null"
-    items:
-      $ref: ./Version.yaml
     description: "An array of `Version` objects. Each object represents a specific version of the
       Actor's source code: its location, builds, and environment configuration."
   pricingInfos:

--- a/apify-api/openapi/components/schemas/actors/DefaultRunOptions.yaml
+++ b/apify-api/openapi/components/schemas/actors/DefaultRunOptions.yaml
@@ -1,20 +1,26 @@
 title: DefaultRunOptions
 type: object
+description: The default settings applied to an Actor run. Can be overridden elsewhere.
 properties:
   build:
     type: string
     examples: [latest]
+    description: Which build to run. Either a build tag or a version number.
   timeoutSecs:
     type: integer
     examples: [3600]
+    description: Timeout in seconds. 0 if no timeout.
   memoryMbytes:
     type: integer
     examples: [2048]
+    description: In MB, the amount of memory allocated to the run.
   restartOnError:
     type: boolean
     examples: [false]
+    description: Whether to automatically restart the run if it fails.
   maxItems:
     type: [integer, "null"]
+    description: Maximum number of items the run might produce.
   forcePermissionLevel:
     anyOf:
       - $ref: ./ActorPermissionLevel.yaml

--- a/apify-api/openapi/components/schemas/actors/EnvVar.yaml
+++ b/apify-api/openapi/components/schemas/actors/EnvVar.yaml
@@ -6,10 +6,12 @@ properties:
   name:
     type: string
     examples: [MY_ENV_VAR]
+    description: The name of the environment variable.
   value:
     type: string
-    description: The environment variable value. This field is absent in responses when `isSecret` is `true`, as secret values are never returned by the API.
     examples: [my-value]
+    description: The value of the environment variable. If `isSecret` is `true`, this value isn't returned by the API.
   isSecret:
     type: [boolean, "null"]
     examples: [false]
+    description: Whether the environment variable is encrypted. Secret values aren't returned by the API.

--- a/apify-api/openapi/components/schemas/actors/ExampleRunInput.yaml
+++ b/apify-api/openapi/components/schemas/actors/ExampleRunInput.yaml
@@ -4,6 +4,8 @@ properties:
   body:
     type: string
     example: '{ "helloWorld": 123 }'
+    description: Sample input, serialized as a string.
   contentType:
     type: string
     examples: [application/json; charset=utf-8]
+    description: MIME type of `body`.

--- a/apify-api/openapi/components/schemas/actors/SourceCodeFile.yaml
+++ b/apify-api/openapi/components/schemas/actors/SourceCodeFile.yaml
@@ -1,13 +1,17 @@
 title: SourceCodeFile
 type: object
+description: Represents a single file in the Actor's source code.
 required:
   - name
 properties:
   format:
     $ref: ../common/SourceCodeFileFormat.yaml
+    description: Format of the file's content, `TEXT` for plain text and `BASE64` for encoded content.
   content:
     type: string
     examples: ["console.log('This is the main.js file');"]
+    description: The contents of the file. Interpreted based on the value of `format`.
   name:
     type: string
     examples: [src/main.js]
+    description: The path of the file relative to the Actor's root directory.

--- a/apify-api/openapi/components/schemas/actors/SourceCodeFolder.yaml
+++ b/apify-api/openapi/components/schemas/actors/SourceCodeFolder.yaml
@@ -9,9 +9,9 @@ required:
 properties:
   name:
     type: string
-    description: The folder path relative to the Actor's root directory.
+    description: The path of the folder relative to the Actor's root directory.
     examples: [src/utils]
   folder:
     type: boolean
-    description: Always `true` for folders. Used to distinguish folders from files.
+    description: Whether it's a folder. Distinguishes folders from files.
     examples: [true]

--- a/apify-api/openapi/components/schemas/actors/Version.yaml
+++ b/apify-api/openapi/components/schemas/actors/Version.yaml
@@ -8,29 +8,35 @@ properties:
     type: string
     pattern: ^([0-9]|[1-9][0-9])\.([0-9]|[1-9][0-9])$
     examples: ["0.0"]
+    description: The version number of the Actor. Must be a dot-separated sequence of numbers.
   sourceType:
     anyOf:
       - $ref: ./VersionSourceType.yaml
       - type: "null"
+    description: Where the source code of the version lives.
   envVars:
     type: [array, "null"]
     items:
       $ref: ./EnvVar.yaml
-    description: ""
+    description: Environment variables for the version.
   applyEnvVarsToBuild:
     type: [boolean, "null"]
     examples: [false]
+    description: Whether to inject the environment variables at build time.
   buildTag:
     type: string
     examples: [latest]
+    description: The tag name to apply to a successful build of the Actor.
   sourceFiles:
     $ref: ./VersionSourceFiles.yaml
+    description: Applies when the `sourceType` is `SOURCE_FILES`. Represents the Actor's
+      file structure as an array of files and folders.
   gitRepoUrl:
     type: [string, "null"]
-    description: URL of the Git repository when sourceType is GIT_REPO.
+    description: URL of the Git repository to clone the source code from. Applies when the `sourceType` is `GIT_REPO`.
   tarballUrl:
     type: [string, "null"]
-    description: URL of the tarball when sourceType is TARBALL.
+    description: URL to download the source code from as a tarball or ZIP file. Applies when the `sourceType` is `TARBALL`.
   gitHubGistUrl:
     type: [string, "null"]
-    description: URL of the GitHub Gist when sourceType is GITHUB_GIST.
+    description: URL to the GitHub Gist to clone the source code from. Applies when the `sourceType` is `GITHUB_GIST`.

--- a/apify-api/openapi/components/schemas/actors/Version.yaml
+++ b/apify-api/openapi/components/schemas/actors/Version.yaml
@@ -39,4 +39,4 @@ properties:
     description: URL to download the source code from as a tarball or ZIP file. Applies when the `sourceType` is `TARBALL`.
   gitHubGistUrl:
     type: [string, "null"]
-    description: URL to the GitHub Gist to clone the source code from. Applies when the `sourceType` is `GITHUB_GIST`.
+    description: URL of the GitHub Gist to clone the source code from. Applies when the `sourceType` is `GITHUB_GIST`.

--- a/apify-api/openapi/components/schemas/actors/Version.yaml
+++ b/apify-api/openapi/components/schemas/actors/Version.yaml
@@ -26,7 +26,7 @@ properties:
   buildTag:
     type: string
     examples: [latest]
-    description: The tag name to apply to a successful build of the Actor.
+    description: The tag name to apply to a successful build of this version.
   sourceFiles:
     $ref: ./VersionSourceFiles.yaml
     description: Applies when the `sourceType` is `SOURCE_FILES`. Represents the Actor's

--- a/apify-api/openapi/components/schemas/actors/Version.yaml
+++ b/apify-api/openapi/components/schemas/actors/Version.yaml
@@ -16,10 +16,10 @@ properties:
     description: Where the source code of the version lives.
   envVars:
     anyOf:
-    - $ref: ./EnvVar.yaml
-    - type: "null"
-    items:
-      $ref: ./EnvVar.yaml
+      - type: array
+        items:
+          $ref: ./EnvVar.yaml
+      - type: "null"
     description: Environment variables for the version.
   applyEnvVarsToBuild:
     type: [boolean, "null"]

--- a/apify-api/openapi/components/schemas/actors/Version.yaml
+++ b/apify-api/openapi/components/schemas/actors/Version.yaml
@@ -15,7 +15,9 @@ properties:
       - type: "null"
     description: Where the source code of the version lives.
   envVars:
-    type: [array, "null"]
+    anyOf:
+    - $ref: ./EnvVar.yaml
+    - type: "null"
     items:
       $ref: ./EnvVar.yaml
     description: Environment variables for the version.

--- a/apify-api/openapi/paths/actors/acts.yaml
+++ b/apify-api/openapi/paths/actors/acts.yaml
@@ -93,22 +93,26 @@ post:
     - Actors
   summary: Create Actor
   description: |
-    Creates a new Actor with settings specified in an Actor object passed as
+    Creates an Actor with the settings specified in an `Actor` object passed as
     JSON in the POST payload.
-    The response is the full Actor object as returned by the
-    [Get Actor](#/reference/actors/actor-object/get-actor) endpoint.
 
-    The HTTP request must have the `Content-Type: application/json` HTTP header!
+    Returns the full `Actor` object, the same as the
+    [Get Actor](/api/v2/act-get) endpoint.
 
-    The Actor needs to define at least one version of the source code.
-    For more information, see [Version object](#/reference/actors/version-object).
+    In the HTTP request, set the `Content-Type` header to `application/json`.
 
-    If you want to make your Actor
-    [public](https://docs.apify.com/platform/actors/publishing) using `isPublic:
-    true`, you will need to provide the Actor's `title` and the `categories`
-    under which that Actor will be classified in Apify Store. For this, it's
-    best to use the [constants from our `apify-shared-js`
-    package](https://github.com/apify/apify-shared-js/blob/2d43ebc41ece9ad31cd6525bd523fb86939bf860/packages/consts/src/consts.ts#L452-L471).
+    ### Define a source code version
+
+    An Actor must specify at least one version of the source code.
+    For details, see [Actor versions](/api/v2/actors-actor-versions).
+
+    ### Create a public Actor
+
+    To make your Actor [public](https://docs.apify.com/platform/actors/publishing):
+    - Set `isPublic` to `true`.
+    - Provide `title` and `categories`. For reference, see [constants from the `apify-shared-js`
+    package](https://github.com/apify/apify-shared-js/blob/2d43ebc41ece9ad31cd6525bd523fb86939bf860/packages/consts/src/consts.ts#L452-L471)
+
   operationId: acts_post
   requestBody:
     description: ""


### PR DESCRIPTION
- Adds missing description to the `Actor` object. (`pricingInfos` will follow as a separate PR)
- Cleans up the `Create Actor` endpoint description.

Part of #2684.