### PR TITLE
docs: reorganize environment variables table by category

### DIFF
--- a/sources/platform/actors/development/programming_interface/environment_variables.md
+++ b/sources/platform/actors/development/programming_interface/environment_variables.md
@@ -76,7 +76,6 @@ Variables prefixed with `APIFY_` are Apify-platform-specific extensions that go 
 | `APIFY_USER_ID` | ID of the user who started the Actor. May differ from the Actor owner. |
 | `APIFY_USER_IS_PAYING` | If it is `1`, it means that the user who started the Actor is a paying user. |
 | `APIFY_IS_AT_HOME` | Contains **1** if the Actor is running on Apify servers. |
-| `APIFY_HEADLESS` | _Deprecated_ - on the Apify platform this is always set to **1**, so web browsers inside the Actor always run in headless mode (no windowing system available). |
 | `APIFY_DEDICATED_CPUS` | Number of CPU cores reserved for the Actor, based on allocated memory. |
 | `APIFY_PROXY_PASSWORD` | Password for accessing Apify Proxy services. This password enables the Actor to utilize proxy servers on behalf of the user who initiated the Actor run. |
 | `APIFY_PROXY_PORT` | TCP port number to be used for connecting to Apify Proxy. |
@@ -87,6 +86,7 @@ Variables prefixed with `APIFY_` are Apify-platform-specific extensions that go 
 | `APIFY_META_ORIGIN` | Specifies how an Actor run was started. Possible values are in [Runs and builds](/platform/actors/running/runs-and-builds#origin) documentation. |
 | `APIFY_INPUT_SECRETS_PRIVATE_KEY_FILE` | Path to the secret key used to decrypt [Secret inputs](/platform/actors/development/actor-definition/input-schema/secret-input). |
 | `APIFY_INPUT_SECRETS_PRIVATE_KEY_PASSPHRASE` | Passphrase for the input secret key specified in `APIFY_INPUT_SECRETS_PRIVATE_KEY_FILE`. |
+| ~~`APIFY_HEADLESS`~~ | _Deprecated_ - on the Apify platform this is always set to **1**, so web browsers inside the Actor always run in headless mode (no windowing system available). |
 
 ## Custom environment variables
 

--- a/sources/platform/actors/development/programming_interface/environment_variables.md
+++ b/sources/platform/actors/development/programming_interface/environment_variables.md
@@ -57,6 +57,22 @@ Variables prefixed with `ACTOR_` are defined by the [Actor specification](https:
 | `ACTOR_STANDBY_URL` | URL for accessing web servers of Actor runs in the [Actor Standby](/platform/actors/development/programming-interface/standby) mode. |
 | `ACTOR_EVENTS_WEBSOCKET_URL` | Websocket URL where Actor may listen for [events](/platform/actors/development/programming-interface/system-events) from Actor platform. |
 
+For example, `ACTOR_STORAGES_JSON` holds the IDs of the run's default storages:
+
+```json
+{
+  "keyValueStores": {
+    "default": "GIieeLjB8eZ8Pso6d"
+  },
+  "datasets": {
+    "default": "Hh5C07EdRuzjkGogf"
+  },
+  "requestQueues": {
+    "default": "jaU9kRNpd3dofIBVs"
+  }
+}
+```
+
 <!-- vale Microsoft.RangeFormat = NO -->
 
 :::note Date format

--- a/sources/platform/actors/development/programming_interface/environment_variables.md
+++ b/sources/platform/actors/development/programming_interface/environment_variables.md
@@ -41,7 +41,7 @@ Variables prefixed with `ACTOR_` are defined by the [Actor specification](https:
 | `ACTOR_DEFAULT_KEY_VALUE_STORE_ID` | Unique identifier for the default key-value store associated with the current Actor run. |
 | `ACTOR_DEFAULT_REQUEST_QUEUE_ID` | Unique identifier for the default request queue associated with the current Actor run. |
 | `ACTOR_INPUT_KEY` | Key of the record in the default key-value store that holds the [Actor input](/platform/actors/running/input-and-output#input). |
-| `ACTOR_STORAGES_JSON` | JSON-encoded unique identifiers of storages associated with the current Actor run. |
+| `ACTOR_STORAGES_JSON` | JSON-encoded unique identifiers of storages associated with the current Actor run, e.g. `{ "keyValueStores": { "default": "<id>" }, "datasets": { "default": "<id>" }, "requestQueues": { "default": "<id>" } }`. |
 | `ACTOR_MEMORY_MBYTES` | Size of memory allocated for the Actor run, in megabytes. Can be used to optimize memory usage or finetuning of low-level external libraries. |
 | `ACTOR_MAX_TOTAL_CHARGE_USD` | For pay-per-event Actors, the user-set limit on run cost. Do not exceed this limit. |
 | `ACTOR_PERMISSION_LEVEL` | [Permission level](../../running/permissions.md) the Actor is run under (`LIMITED_PERMISSIONS` or `FULL_PERMISSIONS`). This determines what resources in the user’s account the Actor can access. |
@@ -56,22 +56,6 @@ Variables prefixed with `ACTOR_` are defined by the [Actor specification](https:
 | `ACTOR_WEB_SERVER_PORT` | TCP port for the Actor to start an HTTP server on. This server can be used to receive external messages or expose monitoring and control interfaces. The server also receives messages from the [Actor Standby](/platform/actors/development/programming-interface/standby) mode. |
 | `ACTOR_STANDBY_URL` | URL for accessing web servers of Actor runs in the [Actor Standby](/platform/actors/development/programming-interface/standby) mode. |
 | `ACTOR_EVENTS_WEBSOCKET_URL` | Websocket URL where Actor may listen for [events](/platform/actors/development/programming-interface/system-events) from Actor platform. |
-
-For example, `ACTOR_STORAGES_JSON` holds the IDs of the run's default storages:
-
-```json
-{
-  "keyValueStores": {
-    "default": "GIieeLjB8eZ8Pso6d"
-  },
-  "datasets": {
-    "default": "Hh5C07EdRuzjkGogf"
-  },
-  "requestQueues": {
-    "default": "jaU9kRNpd3dofIBVs"
-  }
-}
-```
 
 <!-- vale Microsoft.RangeFormat = NO -->
 

--- a/sources/platform/actors/development/programming_interface/environment_variables.md
+++ b/sources/platform/actors/development/programming_interface/environment_variables.md
@@ -20,13 +20,17 @@ Check out how you can [access environment variables in Actors](#access-environme
 
 ## System environment variables
 
-Apify sets several system environment variables for each Actor run. These variables provide essential context and information about the Actor's execution environment.
+Apify sets several system environment variables for each Actor run. They come in two groups, identified by their name prefix: standard `ACTOR_` variables defined by the Actor specification, and Apify-specific `APIFY_` variables that extend it.
 
 :::info Runtime only
 
 System variables apply only to Actor runs and are never passed to builds - not even when **Apply environment variables also to the build process** is enabled in **Code** > **Environment variables**. That option forwards only your custom variables.
 
 :::
+
+### Standard Actor variables
+
+Variables prefixed with `ACTOR_` are defined by the [Actor specification](https://whitepaper.actor/). They describe the run's execution context - identifiers, default storages, resource limits, and timing - and aren't specific to the Apify platform.
 
 | Environment variable | Description |
 | -------------------- | ----------- |
@@ -52,6 +56,22 @@ System variables apply only to Actor runs and are never passed to builds - not e
 | `ACTOR_WEB_SERVER_PORT` | TCP port for the Actor to start an HTTP server on. This server can be used to receive external messages or expose monitoring and control interfaces. The server also receives messages from the [Actor Standby](/platform/actors/development/programming-interface/standby) mode. |
 | `ACTOR_STANDBY_URL` | URL for accessing web servers of Actor runs in the [Actor Standby](/platform/actors/development/programming-interface/standby) mode. |
 | `ACTOR_EVENTS_WEBSOCKET_URL` | Websocket URL where Actor may listen for [events](/platform/actors/development/programming-interface/system-events) from Actor platform. |
+
+<!-- vale Microsoft.RangeFormat = NO -->
+
+:::note Date format
+
+All date-related variables use the UTC timezone and are in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format (e.g., _2022-07-13T14:23:37.281Z_).
+
+:::
+<!-- vale Microsoft.RangeFormat = YES -->
+
+### Apify platform variables
+
+Variables prefixed with `APIFY_` are Apify-platform-specific extensions that go beyond the Actor specification. They expose features unique to the Apify platform, such as your API token, Apify Proxy, and details about the user who started the run.
+
+| Environment variable | Description |
+| -------------------- | ----------- |
 | `APIFY_TOKEN` | API token of the user who started the Actor. |
 | `APIFY_USER_ID` | ID of the user who started the Actor. May differ from the Actor owner. |
 | `APIFY_USER_IS_PAYING` | If it is `1`, it means that the user who started the Actor is a paying user. |
@@ -67,16 +87,6 @@ System variables apply only to Actor runs and are never passed to builds - not e
 | `APIFY_META_ORIGIN` | Specifies how an Actor run was started. Possible values are in [Runs and builds](/platform/actors/running/runs-and-builds#origin) documentation. |
 | `APIFY_INPUT_SECRETS_PRIVATE_KEY_FILE` | Path to the secret key used to decrypt [Secret inputs](/platform/actors/development/actor-definition/input-schema/secret-input). |
 | `APIFY_INPUT_SECRETS_PRIVATE_KEY_PASSPHRASE` | Passphrase for the input secret key specified in `APIFY_INPUT_SECRETS_PRIVATE_KEY_FILE`. |
-
-
-<!-- vale Microsoft.RangeFormat = NO -->
-
-:::note Date format
-
-All date-related variables use the UTC timezone and are in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format (e.g., _2022-07-13T14:23:37.281Z_).
-
-:::
-<!-- vale Microsoft.RangeFormat = YES -->
 
 ## Custom environment variables
 

--- a/sources/platform/actors/development/programming_interface/environment_variables.md
+++ b/sources/platform/actors/development/programming_interface/environment_variables.md
@@ -76,7 +76,7 @@ Variables prefixed with `APIFY_` are Apify-platform-specific extensions that go 
 | `APIFY_USER_ID` | ID of the user who started the Actor. May differ from the Actor owner. |
 | `APIFY_USER_IS_PAYING` | If it is `1`, it means that the user who started the Actor is a paying user. |
 | `APIFY_IS_AT_HOME` | Contains **1** if the Actor is running on Apify servers. |
-| `APIFY_HEADLESS` | If **1**, web browsers inside the Actor should run in headless mode (no windowing system available). |
+| `APIFY_HEADLESS` | _Deprecated_ - on the Apify platform this is always set to **1**, so web browsers inside the Actor always run in headless mode (no windowing system available). |
 | `APIFY_DEDICATED_CPUS` | Number of CPU cores reserved for the Actor, based on allocated memory. |
 | `APIFY_PROXY_PASSWORD` | Password for accessing Apify Proxy services. This password enables the Actor to utilize proxy servers on behalf of the user who initiated the Actor run. |
 | `APIFY_PROXY_PORT` | TCP port number to be used for connecting to Apify Proxy. |

--- a/sources/platform/actors/development/programming_interface/environment_variables.md
+++ b/sources/platform/actors/development/programming_interface/environment_variables.md
@@ -30,7 +30,7 @@ System variables apply only to Actor runs and are never passed to builds - not e
 
 ### Standard Actor variables
 
-Variables prefixed with `ACTOR_` are defined by the [Actor specification](https://whitepaper.actor/). They describe the run's execution context - identifiers, default storages, resource limits, and timing - and aren't specific to the Apify platform.
+Variables prefixed with `ACTOR_` are defined by the [Actor specification](https://whitepaper.actor/#environment-variables). They describe the run's execution context - identifiers, default storages, resource limits, and timing - and aren't specific to the Apify platform.
 
 | Environment variable | Description |
 | -------------------- | ----------- |

--- a/sources/platform/actors/development/programming_interface/environment_variables.md
+++ b/sources/platform/actors/development/programming_interface/environment_variables.md
@@ -33,40 +33,40 @@ System variables apply only to Actor runs and are never passed to builds - not e
 | `ACTOR_ID` | ID of the Actor. |
 | `ACTOR_FULL_NAME` | Full technical name of the Actor, in the format `owner-username/actor-name`. |
 | `ACTOR_RUN_ID` | ID of the Actor run. |
-| `ACTOR_BUILD_ID` | ID of the Actor build used in the run. |
-| `ACTOR_BUILD_NUMBER` | Build number of the Actor build used in the run. |
-| `ACTOR_BUILD_TAGS` | A comma-separated list of tags of the Actor build used in the run. Note that this environment variable is assigned at the time of start of the Actor and doesn't change over time, even if the assigned build tags change. |
-| `ACTOR_TASK_ID` | ID of the Actor task. Empty if Actor is run outside of any task, e.g. directly using the API. |
-| `ACTOR_EVENTS_WEBSOCKET_URL` | Websocket URL where Actor may listen for [events](/platform/actors/development/programming-interface/system-events) from Actor platform. |
-| `ACTOR_STORAGES_JSON` | JSON-encoded unique identifiers of storages associated with the current Actor run. |
 | `ACTOR_DEFAULT_DATASET_ID` | Unique identifier for the default dataset associated with the current Actor run. |
 | `ACTOR_DEFAULT_KEY_VALUE_STORE_ID` | Unique identifier for the default key-value store associated with the current Actor run. |
 | `ACTOR_DEFAULT_REQUEST_QUEUE_ID` | Unique identifier for the default request queue associated with the current Actor run. |
 | `ACTOR_INPUT_KEY` | Key of the record in the default key-value store that holds the [Actor input](/platform/actors/running/input-and-output#input). |
-| `ACTOR_MAX_TOTAL_CHARGE_USD` | For pay-per-event Actors, the user-set limit on run cost. Do not exceed this limit. |
-| `ACTOR_RESTART_ON_ERROR` | If **1**, the Actor run will be restarted if it fails. |
-| `APIFY_HEADLESS` | If **1**, web browsers inside the Actor should run in headless mode (no windowing system available). |
-| `APIFY_IS_AT_HOME` | Contains **1** if the Actor is running on Apify servers. |
+| `ACTOR_STORAGES_JSON` | JSON-encoded unique identifiers of storages associated with the current Actor run. |
 | `ACTOR_MEMORY_MBYTES` | Size of memory allocated for the Actor run, in megabytes. Can be used to optimize memory usage or finetuning of low-level external libraries. |
+| `ACTOR_MAX_TOTAL_CHARGE_USD` | For pay-per-event Actors, the user-set limit on run cost. Do not exceed this limit. |
 | `ACTOR_PERMISSION_LEVEL` | [Permission level](../../running/permissions.md) the Actor is run under (`LIMITED_PERMISSIONS` or `FULL_PERMISSIONS`). This determines what resources in the user’s account the Actor can access. |
-| `APIFY_PROXY_PASSWORD` | Password for accessing Apify Proxy services. This password enables the Actor to utilize proxy servers on behalf of the user who initiated the Actor run. |
-| `APIFY_PROXY_PORT` | TCP port number to be used for connecting to Apify Proxy. |
-| `APIFY_PROXY_STATUS_URL` | URL for retrieving proxy status information. Appending `?format=json` to this URL returns the data in JSON format for programmatic processing. |
-| `ACTOR_STANDBY_URL` | URL for accessing web servers of Actor runs in the [Actor Standby](/platform/actors/development/programming-interface/standby) mode. |
+| `ACTOR_RESTART_ON_ERROR` | If **1**, the Actor run will be restarted if it fails. |
 | `ACTOR_STARTED_AT` | Date when the Actor was started. |
 | `ACTOR_TIMEOUT_AT` | Date when the Actor will time out. |
+| `ACTOR_BUILD_ID` | ID of the Actor build used in the run. |
+| `ACTOR_BUILD_NUMBER` | Build number of the Actor build used in the run. |
+| `ACTOR_BUILD_TAGS` | A comma-separated list of tags of the Actor build used in the run. Note that this environment variable is assigned at the time of start of the Actor and doesn't change over time, even if the assigned build tags change. |
+| `ACTOR_TASK_ID` | ID of the Actor task. Empty if Actor is run outside of any task, e.g. directly using the API. |
+| `ACTOR_WEB_SERVER_URL` | Unique public URL for accessing the Actor run web server from the outside world. |
+| `ACTOR_WEB_SERVER_PORT` | TCP port for the Actor to start an HTTP server on. This server can be used to receive external messages or expose monitoring and control interfaces. The server also receives messages from the [Actor Standby](/platform/actors/development/programming-interface/standby) mode. |
+| `ACTOR_STANDBY_URL` | URL for accessing web servers of Actor runs in the [Actor Standby](/platform/actors/development/programming-interface/standby) mode. |
+| `ACTOR_EVENTS_WEBSOCKET_URL` | Websocket URL where Actor may listen for [events](/platform/actors/development/programming-interface/system-events) from Actor platform. |
 | `APIFY_TOKEN` | API token of the user who started the Actor. |
 | `APIFY_USER_ID` | ID of the user who started the Actor. May differ from the Actor owner. |
 | `APIFY_USER_IS_PAYING` | If it is `1`, it means that the user who started the Actor is a paying user. |
-| `ACTOR_WEB_SERVER_PORT` | TCP port for the Actor to start an HTTP server on. This server can be used to receive external messages or expose monitoring and control interfaces. The server also receives messages from the [Actor Standby](/platform/actors/development/programming-interface/standby) mode. |
-| `ACTOR_WEB_SERVER_URL` | Unique public URL for accessing the Actor run web server from the outside world. |
-| `APIFY_API_PUBLIC_BASE_URL` | Public URL of the Apify API. May be used to interact with the platform programmatically. Typically set to `api.apify.com`. |
+| `APIFY_IS_AT_HOME` | Contains **1** if the Actor is running on Apify servers. |
+| `APIFY_HEADLESS` | If **1**, web browsers inside the Actor should run in headless mode (no windowing system available). |
 | `APIFY_DEDICATED_CPUS` | Number of CPU cores reserved for the Actor, based on allocated memory. |
+| `APIFY_PROXY_PASSWORD` | Password for accessing Apify Proxy services. This password enables the Actor to utilize proxy servers on behalf of the user who initiated the Actor run. |
+| `APIFY_PROXY_PORT` | TCP port number to be used for connecting to Apify Proxy. |
+| `APIFY_PROXY_STATUS_URL` | URL for retrieving proxy status information. Appending `?format=json` to this URL returns the data in JSON format for programmatic processing. |
+| `APIFY_API_PUBLIC_BASE_URL` | Public URL of the Apify API. May be used to interact with the platform programmatically. Typically set to `api.apify.com`. |
+| `APIFY_MCP_PROXY_URL` | Base URL of the Apify MCP Proxy. Connect to an [MCP connector](/platform/integrations/mcp-connectors) at `${APIFY_MCP_PROXY_URL}/<connectorId>` using `APIFY_TOKEN` as the bearer token. |
 | `APIFY_WORKFLOW_KEY` | Identifier used for grouping related runs and API calls together. |
 | `APIFY_META_ORIGIN` | Specifies how an Actor run was started. Possible values are in [Runs and builds](/platform/actors/running/runs-and-builds#origin) documentation. |
 | `APIFY_INPUT_SECRETS_PRIVATE_KEY_FILE` | Path to the secret key used to decrypt [Secret inputs](/platform/actors/development/actor-definition/input-schema/secret-input). |
 | `APIFY_INPUT_SECRETS_PRIVATE_KEY_PASSPHRASE` | Passphrase for the input secret key specified in `APIFY_INPUT_SECRETS_PRIVATE_KEY_FILE`. |
-| `APIFY_MCP_PROXY_URL` | Base URL of the Apify MCP Proxy. Connect to an [MCP connector](/platform/integrations/mcp-connectors) at `${APIFY_MCP_PROXY_URL}/<connectorId>` using `APIFY_TOKEN` as the bearer token. |
 
 
 <!-- vale Microsoft.RangeFormat = NO -->


### PR DESCRIPTION
Split the Actor system environment variables into two tables - standard `ACTOR_` variables defined by the [Actor specification](https://whitepaper.actor/#environment-variables) and Apify-specific `APIFY_` extensions - and order each by importance so the most commonly used variables come first.

https://claude.ai/code/session_018gWj99fzehLffLFaHxJEfb