### PR TITLE
docs(openapi): Document `origin` query parameter for last run endpoints

### DIFF
--- a/apify-api/openapi/components/objects/actor-runs/abort.yaml
+++ b/apify-api/openapi/components/objects/actor-runs/abort.yaml
@@ -88,8 +88,8 @@ lastRunByActor:
   operationId: act_runs_last_abort_post
   parameters:
     - $ref: "../../parameters/runAndBuildParameters.yaml#/actorId"
-    - $ref: "../../parameters/runAndBuildParameters.yaml#/statusLastRun"
-    - $ref: "../../parameters/runAndBuildParameters.yaml#/originLastRun"
+    - $ref: "../../parameters/lastRunParameters.yaml#/status"
+    - $ref: "../../parameters/lastRunParameters.yaml#/origin"
     - $ref: "../../parameters/runAndBuildParameters.yaml#/gracefully"
 
 lastRunByActorTask:
@@ -108,6 +108,6 @@ lastRunByActorTask:
   operationId: actorTask_runs_last_abort_post
   parameters:
     - $ref: "../../parameters/runAndBuildParameters.yaml#/actorTaskId"
-    - $ref: "../../parameters/runAndBuildParameters.yaml#/statusLastRun"
-    - $ref: "../../parameters/runAndBuildParameters.yaml#/originLastRun"
+    - $ref: "../../parameters/lastRunParameters.yaml#/status"
+    - $ref: "../../parameters/lastRunParameters.yaml#/origin"
     - $ref: "../../parameters/runAndBuildParameters.yaml#/gracefully"

--- a/apify-api/openapi/components/objects/actor-runs/abort.yaml
+++ b/apify-api/openapi/components/objects/actor-runs/abort.yaml
@@ -89,6 +89,7 @@ lastRunByActor:
   parameters:
     - $ref: "../../parameters/runAndBuildParameters.yaml#/actorId"
     - $ref: "../../parameters/runAndBuildParameters.yaml#/statusLastRun"
+    - $ref: "../../parameters/runAndBuildParameters.yaml#/originLastRun"
     - $ref: "../../parameters/runAndBuildParameters.yaml#/gracefully"
 
 lastRunByActorTask:
@@ -108,4 +109,5 @@ lastRunByActorTask:
   parameters:
     - $ref: "../../parameters/runAndBuildParameters.yaml#/actorTaskId"
     - $ref: "../../parameters/runAndBuildParameters.yaml#/statusLastRun"
+    - $ref: "../../parameters/runAndBuildParameters.yaml#/originLastRun"
     - $ref: "../../parameters/runAndBuildParameters.yaml#/gracefully"

--- a/apify-api/openapi/components/objects/actor-runs/metamorph.yaml
+++ b/apify-api/openapi/components/objects/actor-runs/metamorph.yaml
@@ -126,6 +126,7 @@ lastRunByActor:
   parameters:
     - $ref: "../../parameters/runAndBuildParameters.yaml#/actorId"
     - $ref: "../../parameters/runAndBuildParameters.yaml#/statusLastRun"
+    - $ref: "../../parameters/runAndBuildParameters.yaml#/originLastRun"
     - $ref: "../../parameters/runAndBuildParameters.yaml#/targetActorId"
     - *buildQueryParameter
 
@@ -144,5 +145,6 @@ lastRunByActorTask:
   parameters:
     - $ref: "../../parameters/runAndBuildParameters.yaml#/actorTaskId"
     - $ref: "../../parameters/runAndBuildParameters.yaml#/statusLastRun"
+    - $ref: "../../parameters/runAndBuildParameters.yaml#/originLastRun"
     - $ref: "../../parameters/runAndBuildParameters.yaml#/targetActorId"
     - *buildQueryParameter

--- a/apify-api/openapi/components/objects/actor-runs/metamorph.yaml
+++ b/apify-api/openapi/components/objects/actor-runs/metamorph.yaml
@@ -125,8 +125,8 @@ lastRunByActor:
   operationId: act_runs_last_metamorph_post
   parameters:
     - $ref: "../../parameters/runAndBuildParameters.yaml#/actorId"
-    - $ref: "../../parameters/runAndBuildParameters.yaml#/statusLastRun"
-    - $ref: "../../parameters/runAndBuildParameters.yaml#/originLastRun"
+    - $ref: "../../parameters/lastRunParameters.yaml#/status"
+    - $ref: "../../parameters/lastRunParameters.yaml#/origin"
     - $ref: "../../parameters/runAndBuildParameters.yaml#/targetActorId"
     - *buildQueryParameter
 
@@ -144,7 +144,7 @@ lastRunByActorTask:
   operationId: actorTask_runs_last_metamorph_post
   parameters:
     - $ref: "../../parameters/runAndBuildParameters.yaml#/actorTaskId"
-    - $ref: "../../parameters/runAndBuildParameters.yaml#/statusLastRun"
-    - $ref: "../../parameters/runAndBuildParameters.yaml#/originLastRun"
+    - $ref: "../../parameters/lastRunParameters.yaml#/status"
+    - $ref: "../../parameters/lastRunParameters.yaml#/origin"
     - $ref: "../../parameters/runAndBuildParameters.yaml#/targetActorId"
     - *buildQueryParameter

--- a/apify-api/openapi/components/objects/actor-runs/reboot.yaml
+++ b/apify-api/openapi/components/objects/actor-runs/reboot.yaml
@@ -65,6 +65,7 @@ lastRunByActor:
   parameters:
     - $ref: "../../parameters/runAndBuildParameters.yaml#/actorId"
     - $ref: "../../parameters/runAndBuildParameters.yaml#/statusLastRun"
+    - $ref: "../../parameters/runAndBuildParameters.yaml#/originLastRun"
 
 lastRunByActorTask:
   <<: *sharedReboot
@@ -83,3 +84,4 @@ lastRunByActorTask:
   parameters:
     - $ref: "../../parameters/runAndBuildParameters.yaml#/actorTaskId"
     - $ref: "../../parameters/runAndBuildParameters.yaml#/statusLastRun"
+    - $ref: "../../parameters/runAndBuildParameters.yaml#/originLastRun"

--- a/apify-api/openapi/components/objects/actor-runs/reboot.yaml
+++ b/apify-api/openapi/components/objects/actor-runs/reboot.yaml
@@ -64,8 +64,8 @@ lastRunByActor:
   operationId: act_runs_last_reboot_post
   parameters:
     - $ref: "../../parameters/runAndBuildParameters.yaml#/actorId"
-    - $ref: "../../parameters/runAndBuildParameters.yaml#/statusLastRun"
-    - $ref: "../../parameters/runAndBuildParameters.yaml#/originLastRun"
+    - $ref: "../../parameters/lastRunParameters.yaml#/status"
+    - $ref: "../../parameters/lastRunParameters.yaml#/origin"
 
 lastRunByActorTask:
   <<: *sharedReboot
@@ -83,5 +83,5 @@ lastRunByActorTask:
   operationId: actorTask_runs_last_reboot_post
   parameters:
     - $ref: "../../parameters/runAndBuildParameters.yaml#/actorTaskId"
-    - $ref: "../../parameters/runAndBuildParameters.yaml#/statusLastRun"
-    - $ref: "../../parameters/runAndBuildParameters.yaml#/originLastRun"
+    - $ref: "../../parameters/lastRunParameters.yaml#/status"
+    - $ref: "../../parameters/lastRunParameters.yaml#/origin"

--- a/apify-api/openapi/components/objects/datasets/dataset-items.yaml
+++ b/apify-api/openapi/components/objects/datasets/dataset-items.yaml
@@ -308,6 +308,7 @@ listLastRun:
   parameters:
     - $ref: "../../parameters/runAndBuildParameters.yaml#/actorId"
     - $ref: "../../parameters/runAndBuildParameters.yaml#/statusLastRun"
+    - $ref: "../../parameters/runAndBuildParameters.yaml#/originLastRun"
     - $ref: "../../parameters/datasetParameters.yaml#/format"
     - $ref: "../../parameters/datasetParameters.yaml#/clean"
     - $ref: "../../parameters/paginationParameters.yaml#/offset"
@@ -345,6 +346,7 @@ listTaskLastRun:
   parameters:
     - $ref: "../../parameters/runAndBuildParameters.yaml#/actorTaskId"
     - $ref: "../../parameters/runAndBuildParameters.yaml#/statusLastRun"
+    - $ref: "../../parameters/runAndBuildParameters.yaml#/originLastRun"
     - $ref: "../../parameters/datasetParameters.yaml#/format"
     - $ref: "../../parameters/datasetParameters.yaml#/clean"
     - $ref: "../../parameters/paginationParameters.yaml#/offset"
@@ -479,6 +481,7 @@ postLastRun:
   parameters:
     - $ref: "../../parameters/runAndBuildParameters.yaml#/actorId"
     - $ref: "../../parameters/runAndBuildParameters.yaml#/statusLastRun"
+    - $ref: "../../parameters/runAndBuildParameters.yaml#/originLastRun"
 
 postTaskLastRun:
   <<: [*sharedPost, *sharedTagTaskLastRun]
@@ -493,3 +496,4 @@ postTaskLastRun:
   parameters:
     - $ref: "../../parameters/runAndBuildParameters.yaml#/actorTaskId"
     - $ref: "../../parameters/runAndBuildParameters.yaml#/statusLastRun"
+    - $ref: "../../parameters/runAndBuildParameters.yaml#/originLastRun"

--- a/apify-api/openapi/components/objects/datasets/dataset-items.yaml
+++ b/apify-api/openapi/components/objects/datasets/dataset-items.yaml
@@ -307,8 +307,8 @@ listLastRun:
   operationId: act_runs_last_dataset_items_get
   parameters:
     - $ref: "../../parameters/runAndBuildParameters.yaml#/actorId"
-    - $ref: "../../parameters/runAndBuildParameters.yaml#/statusLastRun"
-    - $ref: "../../parameters/runAndBuildParameters.yaml#/originLastRun"
+    - $ref: "../../parameters/lastRunParameters.yaml#/status"
+    - $ref: "../../parameters/lastRunParameters.yaml#/origin"
     - $ref: "../../parameters/datasetParameters.yaml#/format"
     - $ref: "../../parameters/datasetParameters.yaml#/clean"
     - $ref: "../../parameters/paginationParameters.yaml#/offset"
@@ -345,8 +345,8 @@ listTaskLastRun:
   operationId: actorTask_runs_last_dataset_items_get
   parameters:
     - $ref: "../../parameters/runAndBuildParameters.yaml#/actorTaskId"
-    - $ref: "../../parameters/runAndBuildParameters.yaml#/statusLastRun"
-    - $ref: "../../parameters/runAndBuildParameters.yaml#/originLastRun"
+    - $ref: "../../parameters/lastRunParameters.yaml#/status"
+    - $ref: "../../parameters/lastRunParameters.yaml#/origin"
     - $ref: "../../parameters/datasetParameters.yaml#/format"
     - $ref: "../../parameters/datasetParameters.yaml#/clean"
     - $ref: "../../parameters/paginationParameters.yaml#/offset"
@@ -480,8 +480,8 @@ postLastRun:
   operationId: act_runs_last_dataset_items_post
   parameters:
     - $ref: "../../parameters/runAndBuildParameters.yaml#/actorId"
-    - $ref: "../../parameters/runAndBuildParameters.yaml#/statusLastRun"
-    - $ref: "../../parameters/runAndBuildParameters.yaml#/originLastRun"
+    - $ref: "../../parameters/lastRunParameters.yaml#/status"
+    - $ref: "../../parameters/lastRunParameters.yaml#/origin"
 
 postTaskLastRun:
   <<: [*sharedPost, *sharedTagTaskLastRun]
@@ -495,5 +495,5 @@ postTaskLastRun:
   operationId: actorTask_runs_last_dataset_items_post
   parameters:
     - $ref: "../../parameters/runAndBuildParameters.yaml#/actorTaskId"
-    - $ref: "../../parameters/runAndBuildParameters.yaml#/statusLastRun"
-    - $ref: "../../parameters/runAndBuildParameters.yaml#/originLastRun"
+    - $ref: "../../parameters/lastRunParameters.yaml#/status"
+    - $ref: "../../parameters/lastRunParameters.yaml#/origin"

--- a/apify-api/openapi/components/objects/datasets/dataset-statistics.yaml
+++ b/apify-api/openapi/components/objects/datasets/dataset-statistics.yaml
@@ -60,8 +60,8 @@ getLastRun:
   operationId: act_runs_last_dataset_statistics_get
   parameters:
     - $ref: "../../parameters/runAndBuildParameters.yaml#/actorId"
-    - $ref: "../../parameters/runAndBuildParameters.yaml#/statusLastRun"
-    - $ref: "../../parameters/runAndBuildParameters.yaml#/originLastRun"
+    - $ref: "../../parameters/lastRunParameters.yaml#/status"
+    - $ref: "../../parameters/lastRunParameters.yaml#/origin"
 
 getTaskLastRun:
   <<: *sharedGet
@@ -76,5 +76,5 @@ getTaskLastRun:
   operationId: actorTask_runs_last_dataset_statistics_get
   parameters:
     - $ref: "../../parameters/runAndBuildParameters.yaml#/actorTaskId"
-    - $ref: "../../parameters/runAndBuildParameters.yaml#/statusLastRun"
-    - $ref: "../../parameters/runAndBuildParameters.yaml#/originLastRun"
+    - $ref: "../../parameters/lastRunParameters.yaml#/status"
+    - $ref: "../../parameters/lastRunParameters.yaml#/origin"

--- a/apify-api/openapi/components/objects/datasets/dataset-statistics.yaml
+++ b/apify-api/openapi/components/objects/datasets/dataset-statistics.yaml
@@ -61,6 +61,7 @@ getLastRun:
   parameters:
     - $ref: "../../parameters/runAndBuildParameters.yaml#/actorId"
     - $ref: "../../parameters/runAndBuildParameters.yaml#/statusLastRun"
+    - $ref: "../../parameters/runAndBuildParameters.yaml#/originLastRun"
 
 getTaskLastRun:
   <<: *sharedGet
@@ -76,3 +77,4 @@ getTaskLastRun:
   parameters:
     - $ref: "../../parameters/runAndBuildParameters.yaml#/actorTaskId"
     - $ref: "../../parameters/runAndBuildParameters.yaml#/statusLastRun"
+    - $ref: "../../parameters/runAndBuildParameters.yaml#/originLastRun"

--- a/apify-api/openapi/components/objects/datasets/dataset.yaml
+++ b/apify-api/openapi/components/objects/datasets/dataset.yaml
@@ -38,16 +38,16 @@ sharedLastRun: &sharedLastRun
     - Last Actor run's default dataset
   parameters:
     - $ref: "../../parameters/runAndBuildParameters.yaml#/actorId"
-    - $ref: "../../parameters/runAndBuildParameters.yaml#/statusLastRun"
-    - $ref: "../../parameters/runAndBuildParameters.yaml#/originLastRun"
+    - $ref: "../../parameters/lastRunParameters.yaml#/status"
+    - $ref: "../../parameters/lastRunParameters.yaml#/origin"
 
 sharedTaskLastRun: &sharedTaskLastRun
   tags:
     - Last Actor task run's default dataset
   parameters:
     - $ref: "../../parameters/runAndBuildParameters.yaml#/actorTaskId"
-    - $ref: "../../parameters/runAndBuildParameters.yaml#/statusLastRun"
-    - $ref: "../../parameters/runAndBuildParameters.yaml#/originLastRun"
+    - $ref: "../../parameters/lastRunParameters.yaml#/status"
+    - $ref: "../../parameters/lastRunParameters.yaml#/origin"
 
 sharedGet: &sharedGet
   responses:

--- a/apify-api/openapi/components/objects/datasets/dataset.yaml
+++ b/apify-api/openapi/components/objects/datasets/dataset.yaml
@@ -39,6 +39,7 @@ sharedLastRun: &sharedLastRun
   parameters:
     - $ref: "../../parameters/runAndBuildParameters.yaml#/actorId"
     - $ref: "../../parameters/runAndBuildParameters.yaml#/statusLastRun"
+    - $ref: "../../parameters/runAndBuildParameters.yaml#/originLastRun"
 
 sharedTaskLastRun: &sharedTaskLastRun
   tags:
@@ -46,6 +47,7 @@ sharedTaskLastRun: &sharedTaskLastRun
   parameters:
     - $ref: "../../parameters/runAndBuildParameters.yaml#/actorTaskId"
     - $ref: "../../parameters/runAndBuildParameters.yaml#/statusLastRun"
+    - $ref: "../../parameters/runAndBuildParameters.yaml#/originLastRun"
 
 sharedGet: &sharedGet
   responses:

--- a/apify-api/openapi/components/objects/key-value-stores/key-value-store-keys.yaml
+++ b/apify-api/openapi/components/objects/key-value-stores/key-value-store-keys.yaml
@@ -96,8 +96,8 @@ listLastRun:
   operationId: act_runs_last_keyValueStore_keys_get
   parameters:
     - $ref: "../../parameters/runAndBuildParameters.yaml#/actorId"
-    - $ref: "../../parameters/runAndBuildParameters.yaml#/statusLastRun"
-    - $ref: "../../parameters/runAndBuildParameters.yaml#/originLastRun"
+    - $ref: "../../parameters/lastRunParameters.yaml#/status"
+    - $ref: "../../parameters/lastRunParameters.yaml#/origin"
     - $ref: "../../parameters/keyValueStoreParameters.yaml#/exclusiveStartKey"
     - $ref: "../../parameters/keyValueStoreParameters.yaml#/limit"
     - $ref: "../../parameters/keyValueStoreParameters.yaml#/collectionKeys"
@@ -115,8 +115,8 @@ listTaskLastRun:
   operationId: actorTask_runs_last_keyValueStore_keys_get
   parameters:
     - $ref: "../../parameters/runAndBuildParameters.yaml#/actorTaskId"
-    - $ref: "../../parameters/runAndBuildParameters.yaml#/statusLastRun"
-    - $ref: "../../parameters/runAndBuildParameters.yaml#/originLastRun"
+    - $ref: "../../parameters/lastRunParameters.yaml#/status"
+    - $ref: "../../parameters/lastRunParameters.yaml#/origin"
     - $ref: "../../parameters/keyValueStoreParameters.yaml#/exclusiveStartKey"
     - $ref: "../../parameters/keyValueStoreParameters.yaml#/limit"
     - $ref: "../../parameters/keyValueStoreParameters.yaml#/collectionKeys"

--- a/apify-api/openapi/components/objects/key-value-stores/key-value-store-keys.yaml
+++ b/apify-api/openapi/components/objects/key-value-stores/key-value-store-keys.yaml
@@ -97,6 +97,7 @@ listLastRun:
   parameters:
     - $ref: "../../parameters/runAndBuildParameters.yaml#/actorId"
     - $ref: "../../parameters/runAndBuildParameters.yaml#/statusLastRun"
+    - $ref: "../../parameters/runAndBuildParameters.yaml#/originLastRun"
     - $ref: "../../parameters/keyValueStoreParameters.yaml#/exclusiveStartKey"
     - $ref: "../../parameters/keyValueStoreParameters.yaml#/limit"
     - $ref: "../../parameters/keyValueStoreParameters.yaml#/collectionKeys"
@@ -115,6 +116,7 @@ listTaskLastRun:
   parameters:
     - $ref: "../../parameters/runAndBuildParameters.yaml#/actorTaskId"
     - $ref: "../../parameters/runAndBuildParameters.yaml#/statusLastRun"
+    - $ref: "../../parameters/runAndBuildParameters.yaml#/originLastRun"
     - $ref: "../../parameters/keyValueStoreParameters.yaml#/exclusiveStartKey"
     - $ref: "../../parameters/keyValueStoreParameters.yaml#/limit"
     - $ref: "../../parameters/keyValueStoreParameters.yaml#/collectionKeys"

--- a/apify-api/openapi/components/objects/key-value-stores/key-value-store-record.yaml
+++ b/apify-api/openapi/components/objects/key-value-stores/key-value-store-record.yaml
@@ -155,8 +155,8 @@ getLastRun:
   operationId: act_runs_last_keyValueStore_record_get
   parameters:
     - $ref: "../../parameters/runAndBuildParameters.yaml#/actorId"
-    - $ref: "../../parameters/runAndBuildParameters.yaml#/statusLastRun"
-    - $ref: "../../parameters/runAndBuildParameters.yaml#/originLastRun"
+    - $ref: "../../parameters/lastRunParameters.yaml#/status"
+    - $ref: "../../parameters/lastRunParameters.yaml#/origin"
     - $ref: "../../parameters/keyValueStoreParameters.yaml#/recordKey"
     - $ref: "../../parameters/storageParameters.yaml#/signature"
     - $ref: "../../parameters/keyValueStoreParameters.yaml#/attachment"
@@ -172,8 +172,8 @@ getTaskLastRun:
   operationId: actorTask_runs_last_keyValueStore_record_get
   parameters:
     - $ref: "../../parameters/runAndBuildParameters.yaml#/actorTaskId"
-    - $ref: "../../parameters/runAndBuildParameters.yaml#/statusLastRun"
-    - $ref: "../../parameters/runAndBuildParameters.yaml#/originLastRun"
+    - $ref: "../../parameters/lastRunParameters.yaml#/status"
+    - $ref: "../../parameters/lastRunParameters.yaml#/origin"
     - $ref: "../../parameters/keyValueStoreParameters.yaml#/recordKey"
     - $ref: "../../parameters/storageParameters.yaml#/signature"
     - $ref: "../../parameters/keyValueStoreParameters.yaml#/attachment"
@@ -261,8 +261,8 @@ putLastRun:
   operationId: act_runs_last_keyValueStore_record_put
   parameters:
     - $ref: "../../parameters/runAndBuildParameters.yaml#/actorId"
-    - $ref: "../../parameters/runAndBuildParameters.yaml#/statusLastRun"
-    - $ref: "../../parameters/runAndBuildParameters.yaml#/originLastRun"
+    - $ref: "../../parameters/lastRunParameters.yaml#/status"
+    - $ref: "../../parameters/lastRunParameters.yaml#/origin"
     - $ref: "../../parameters/keyValueStoreParameters.yaml#/recordKey"
     - $ref: "../../parameters/keyValueStoreParameters.yaml#/Content-Encoding"
 
@@ -277,8 +277,8 @@ putTaskLastRun:
   operationId: actorTask_runs_last_keyValueStore_record_put
   parameters:
     - $ref: "../../parameters/runAndBuildParameters.yaml#/actorTaskId"
-    - $ref: "../../parameters/runAndBuildParameters.yaml#/statusLastRun"
-    - $ref: "../../parameters/runAndBuildParameters.yaml#/originLastRun"
+    - $ref: "../../parameters/lastRunParameters.yaml#/status"
+    - $ref: "../../parameters/lastRunParameters.yaml#/origin"
     - $ref: "../../parameters/keyValueStoreParameters.yaml#/recordKey"
     - $ref: "../../parameters/keyValueStoreParameters.yaml#/Content-Encoding"
 
@@ -324,8 +324,8 @@ postLastRun:
   operationId: act_runs_last_keyValueStore_record_post
   parameters:
     - $ref: "../../parameters/runAndBuildParameters.yaml#/actorId"
-    - $ref: "../../parameters/runAndBuildParameters.yaml#/statusLastRun"
-    - $ref: "../../parameters/runAndBuildParameters.yaml#/originLastRun"
+    - $ref: "../../parameters/lastRunParameters.yaml#/status"
+    - $ref: "../../parameters/lastRunParameters.yaml#/origin"
     - $ref: "../../parameters/keyValueStoreParameters.yaml#/recordKey"
     - $ref: "../../parameters/keyValueStoreParameters.yaml#/Content-Encoding"
 
@@ -340,8 +340,8 @@ postTaskLastRun:
   operationId: actorTask_runs_last_keyValueStore_record_post
   parameters:
     - $ref: "../../parameters/runAndBuildParameters.yaml#/actorTaskId"
-    - $ref: "../../parameters/runAndBuildParameters.yaml#/statusLastRun"
-    - $ref: "../../parameters/runAndBuildParameters.yaml#/originLastRun"
+    - $ref: "../../parameters/lastRunParameters.yaml#/status"
+    - $ref: "../../parameters/lastRunParameters.yaml#/origin"
     - $ref: "../../parameters/keyValueStoreParameters.yaml#/recordKey"
     - $ref: "../../parameters/keyValueStoreParameters.yaml#/Content-Encoding"
 
@@ -388,8 +388,8 @@ deleteLastRun:
   operationId: act_runs_last_keyValueStore_record_delete
   parameters:
     - $ref: "../../parameters/runAndBuildParameters.yaml#/actorId"
-    - $ref: "../../parameters/runAndBuildParameters.yaml#/statusLastRun"
-    - $ref: "../../parameters/runAndBuildParameters.yaml#/originLastRun"
+    - $ref: "../../parameters/lastRunParameters.yaml#/status"
+    - $ref: "../../parameters/lastRunParameters.yaml#/origin"
     - $ref: "../../parameters/keyValueStoreParameters.yaml#/recordKey"
 
 deleteTaskLastRun:
@@ -403,6 +403,6 @@ deleteTaskLastRun:
   operationId: actorTask_runs_last_keyValueStore_record_delete
   parameters:
     - $ref: "../../parameters/runAndBuildParameters.yaml#/actorTaskId"
-    - $ref: "../../parameters/runAndBuildParameters.yaml#/statusLastRun"
-    - $ref: "../../parameters/runAndBuildParameters.yaml#/originLastRun"
+    - $ref: "../../parameters/lastRunParameters.yaml#/status"
+    - $ref: "../../parameters/lastRunParameters.yaml#/origin"
     - $ref: "../../parameters/keyValueStoreParameters.yaml#/recordKey"

--- a/apify-api/openapi/components/objects/key-value-stores/key-value-store-record.yaml
+++ b/apify-api/openapi/components/objects/key-value-stores/key-value-store-record.yaml
@@ -156,6 +156,7 @@ getLastRun:
   parameters:
     - $ref: "../../parameters/runAndBuildParameters.yaml#/actorId"
     - $ref: "../../parameters/runAndBuildParameters.yaml#/statusLastRun"
+    - $ref: "../../parameters/runAndBuildParameters.yaml#/originLastRun"
     - $ref: "../../parameters/keyValueStoreParameters.yaml#/recordKey"
     - $ref: "../../parameters/storageParameters.yaml#/signature"
     - $ref: "../../parameters/keyValueStoreParameters.yaml#/attachment"
@@ -172,6 +173,7 @@ getTaskLastRun:
   parameters:
     - $ref: "../../parameters/runAndBuildParameters.yaml#/actorTaskId"
     - $ref: "../../parameters/runAndBuildParameters.yaml#/statusLastRun"
+    - $ref: "../../parameters/runAndBuildParameters.yaml#/originLastRun"
     - $ref: "../../parameters/keyValueStoreParameters.yaml#/recordKey"
     - $ref: "../../parameters/storageParameters.yaml#/signature"
     - $ref: "../../parameters/keyValueStoreParameters.yaml#/attachment"
@@ -260,6 +262,7 @@ putLastRun:
   parameters:
     - $ref: "../../parameters/runAndBuildParameters.yaml#/actorId"
     - $ref: "../../parameters/runAndBuildParameters.yaml#/statusLastRun"
+    - $ref: "../../parameters/runAndBuildParameters.yaml#/originLastRun"
     - $ref: "../../parameters/keyValueStoreParameters.yaml#/recordKey"
     - $ref: "../../parameters/keyValueStoreParameters.yaml#/Content-Encoding"
 
@@ -275,6 +278,7 @@ putTaskLastRun:
   parameters:
     - $ref: "../../parameters/runAndBuildParameters.yaml#/actorTaskId"
     - $ref: "../../parameters/runAndBuildParameters.yaml#/statusLastRun"
+    - $ref: "../../parameters/runAndBuildParameters.yaml#/originLastRun"
     - $ref: "../../parameters/keyValueStoreParameters.yaml#/recordKey"
     - $ref: "../../parameters/keyValueStoreParameters.yaml#/Content-Encoding"
 
@@ -321,6 +325,7 @@ postLastRun:
   parameters:
     - $ref: "../../parameters/runAndBuildParameters.yaml#/actorId"
     - $ref: "../../parameters/runAndBuildParameters.yaml#/statusLastRun"
+    - $ref: "../../parameters/runAndBuildParameters.yaml#/originLastRun"
     - $ref: "../../parameters/keyValueStoreParameters.yaml#/recordKey"
     - $ref: "../../parameters/keyValueStoreParameters.yaml#/Content-Encoding"
 
@@ -336,6 +341,7 @@ postTaskLastRun:
   parameters:
     - $ref: "../../parameters/runAndBuildParameters.yaml#/actorTaskId"
     - $ref: "../../parameters/runAndBuildParameters.yaml#/statusLastRun"
+    - $ref: "../../parameters/runAndBuildParameters.yaml#/originLastRun"
     - $ref: "../../parameters/keyValueStoreParameters.yaml#/recordKey"
     - $ref: "../../parameters/keyValueStoreParameters.yaml#/Content-Encoding"
 
@@ -383,6 +389,7 @@ deleteLastRun:
   parameters:
     - $ref: "../../parameters/runAndBuildParameters.yaml#/actorId"
     - $ref: "../../parameters/runAndBuildParameters.yaml#/statusLastRun"
+    - $ref: "../../parameters/runAndBuildParameters.yaml#/originLastRun"
     - $ref: "../../parameters/keyValueStoreParameters.yaml#/recordKey"
 
 deleteTaskLastRun:
@@ -397,4 +404,5 @@ deleteTaskLastRun:
   parameters:
     - $ref: "../../parameters/runAndBuildParameters.yaml#/actorTaskId"
     - $ref: "../../parameters/runAndBuildParameters.yaml#/statusLastRun"
+    - $ref: "../../parameters/runAndBuildParameters.yaml#/originLastRun"
     - $ref: "../../parameters/keyValueStoreParameters.yaml#/recordKey"

--- a/apify-api/openapi/components/objects/key-value-stores/key-value-store-records.yaml
+++ b/apify-api/openapi/components/objects/key-value-stores/key-value-store-records.yaml
@@ -85,6 +85,7 @@ listLastRun:
   parameters:
     - $ref: "../../parameters/runAndBuildParameters.yaml#/actorId"
     - $ref: "../../parameters/runAndBuildParameters.yaml#/statusLastRun"
+    - $ref: "../../parameters/runAndBuildParameters.yaml#/originLastRun"
     - $ref: "../../parameters/keyValueStoreParameters.yaml#/collectionRecords"
     - $ref: "../../parameters/keyValueStoreParameters.yaml#/prefixRecords"
     - $ref: "../../parameters/storageParameters.yaml#/signature"
@@ -101,6 +102,7 @@ listTaskLastRun:
   parameters:
     - $ref: "../../parameters/runAndBuildParameters.yaml#/actorTaskId"
     - $ref: "../../parameters/runAndBuildParameters.yaml#/statusLastRun"
+    - $ref: "../../parameters/runAndBuildParameters.yaml#/originLastRun"
     - $ref: "../../parameters/keyValueStoreParameters.yaml#/collectionRecords"
     - $ref: "../../parameters/keyValueStoreParameters.yaml#/prefixRecords"
     - $ref: "../../parameters/storageParameters.yaml#/signature"

--- a/apify-api/openapi/components/objects/key-value-stores/key-value-store-records.yaml
+++ b/apify-api/openapi/components/objects/key-value-stores/key-value-store-records.yaml
@@ -84,8 +84,8 @@ listLastRun:
   operationId: act_runs_last_keyValueStore_records_get
   parameters:
     - $ref: "../../parameters/runAndBuildParameters.yaml#/actorId"
-    - $ref: "../../parameters/runAndBuildParameters.yaml#/statusLastRun"
-    - $ref: "../../parameters/runAndBuildParameters.yaml#/originLastRun"
+    - $ref: "../../parameters/lastRunParameters.yaml#/status"
+    - $ref: "../../parameters/lastRunParameters.yaml#/origin"
     - $ref: "../../parameters/keyValueStoreParameters.yaml#/collectionRecords"
     - $ref: "../../parameters/keyValueStoreParameters.yaml#/prefixRecords"
     - $ref: "../../parameters/storageParameters.yaml#/signature"
@@ -101,8 +101,8 @@ listTaskLastRun:
   operationId: actorTask_runs_last_keyValueStore_records_get
   parameters:
     - $ref: "../../parameters/runAndBuildParameters.yaml#/actorTaskId"
-    - $ref: "../../parameters/runAndBuildParameters.yaml#/statusLastRun"
-    - $ref: "../../parameters/runAndBuildParameters.yaml#/originLastRun"
+    - $ref: "../../parameters/lastRunParameters.yaml#/status"
+    - $ref: "../../parameters/lastRunParameters.yaml#/origin"
     - $ref: "../../parameters/keyValueStoreParameters.yaml#/collectionRecords"
     - $ref: "../../parameters/keyValueStoreParameters.yaml#/prefixRecords"
     - $ref: "../../parameters/storageParameters.yaml#/signature"

--- a/apify-api/openapi/components/objects/key-value-stores/key-value-store.yaml
+++ b/apify-api/openapi/components/objects/key-value-stores/key-value-store.yaml
@@ -39,6 +39,7 @@ sharedLastRun: &sharedLastRun
   parameters:
     - $ref: "../../parameters/runAndBuildParameters.yaml#/actorId"
     - $ref: "../../parameters/runAndBuildParameters.yaml#/statusLastRun"
+    - $ref: "../../parameters/runAndBuildParameters.yaml#/originLastRun"
 
 sharedTaskLastRun: &sharedTaskLastRun
   tags:
@@ -46,6 +47,7 @@ sharedTaskLastRun: &sharedTaskLastRun
   parameters:
     - $ref: "../../parameters/runAndBuildParameters.yaml#/actorTaskId"
     - $ref: "../../parameters/runAndBuildParameters.yaml#/statusLastRun"
+    - $ref: "../../parameters/runAndBuildParameters.yaml#/originLastRun"
 
 sharedGet: &sharedGet
   responses:

--- a/apify-api/openapi/components/objects/key-value-stores/key-value-store.yaml
+++ b/apify-api/openapi/components/objects/key-value-stores/key-value-store.yaml
@@ -38,16 +38,16 @@ sharedLastRun: &sharedLastRun
     - Last Actor run's default key-value store
   parameters:
     - $ref: "../../parameters/runAndBuildParameters.yaml#/actorId"
-    - $ref: "../../parameters/runAndBuildParameters.yaml#/statusLastRun"
-    - $ref: "../../parameters/runAndBuildParameters.yaml#/originLastRun"
+    - $ref: "../../parameters/lastRunParameters.yaml#/status"
+    - $ref: "../../parameters/lastRunParameters.yaml#/origin"
 
 sharedTaskLastRun: &sharedTaskLastRun
   tags:
     - Last Actor task run's default key-value store
   parameters:
     - $ref: "../../parameters/runAndBuildParameters.yaml#/actorTaskId"
-    - $ref: "../../parameters/runAndBuildParameters.yaml#/statusLastRun"
-    - $ref: "../../parameters/runAndBuildParameters.yaml#/originLastRun"
+    - $ref: "../../parameters/lastRunParameters.yaml#/status"
+    - $ref: "../../parameters/lastRunParameters.yaml#/origin"
 
 sharedGet: &sharedGet
   responses:

--- a/apify-api/openapi/components/objects/logs/log.yaml
+++ b/apify-api/openapi/components/objects/logs/log.yaml
@@ -101,6 +101,7 @@ getLastRun:
   parameters:
     - $ref: "../../parameters/runAndBuildParameters.yaml#/actorId"
     - $ref: "../../parameters/runAndBuildParameters.yaml#/statusLastRun"
+    - $ref: "../../parameters/runAndBuildParameters.yaml#/originLastRun"
     - $ref: "../../parameters/logParameters.yaml#/stream"
     - $ref: "../../parameters/logParameters.yaml#/download"
     - $ref: "../../parameters/logParameters.yaml#/raw"
@@ -118,6 +119,7 @@ getTaskLastRun:
   parameters:
     - $ref: "../../parameters/runAndBuildParameters.yaml#/actorTaskId"
     - $ref: "../../parameters/runAndBuildParameters.yaml#/statusLastRun"
+    - $ref: "../../parameters/runAndBuildParameters.yaml#/originLastRun"
     - $ref: "../../parameters/logParameters.yaml#/stream"
     - $ref: "../../parameters/logParameters.yaml#/download"
     - $ref: "../../parameters/logParameters.yaml#/raw"

--- a/apify-api/openapi/components/objects/logs/log.yaml
+++ b/apify-api/openapi/components/objects/logs/log.yaml
@@ -100,8 +100,8 @@ getLastRun:
   operationId: act_runs_last_log_get
   parameters:
     - $ref: "../../parameters/runAndBuildParameters.yaml#/actorId"
-    - $ref: "../../parameters/runAndBuildParameters.yaml#/statusLastRun"
-    - $ref: "../../parameters/runAndBuildParameters.yaml#/originLastRun"
+    - $ref: "../../parameters/lastRunParameters.yaml#/status"
+    - $ref: "../../parameters/lastRunParameters.yaml#/origin"
     - $ref: "../../parameters/logParameters.yaml#/stream"
     - $ref: "../../parameters/logParameters.yaml#/download"
     - $ref: "../../parameters/logParameters.yaml#/raw"
@@ -118,8 +118,8 @@ getTaskLastRun:
   operationId: actorTask_last_log_get
   parameters:
     - $ref: "../../parameters/runAndBuildParameters.yaml#/actorTaskId"
-    - $ref: "../../parameters/runAndBuildParameters.yaml#/statusLastRun"
-    - $ref: "../../parameters/runAndBuildParameters.yaml#/originLastRun"
+    - $ref: "../../parameters/lastRunParameters.yaml#/status"
+    - $ref: "../../parameters/lastRunParameters.yaml#/origin"
     - $ref: "../../parameters/logParameters.yaml#/stream"
     - $ref: "../../parameters/logParameters.yaml#/download"
     - $ref: "../../parameters/logParameters.yaml#/raw"

--- a/apify-api/openapi/components/objects/request-queues/request-queue-head-lock.yaml
+++ b/apify-api/openapi/components/objects/request-queues/request-queue-head-lock.yaml
@@ -88,8 +88,8 @@ postLastRun:
   operationId: act_runs_last_requestQueue_head_lock_post
   parameters:
     - $ref: "../../parameters/runAndBuildParameters.yaml#/actorId"
-    - $ref: "../../parameters/runAndBuildParameters.yaml#/statusLastRun"
-    - $ref: "../../parameters/runAndBuildParameters.yaml#/originLastRun"
+    - $ref: "../../parameters/lastRunParameters.yaml#/status"
+    - $ref: "../../parameters/lastRunParameters.yaml#/origin"
     - $ref: "../../parameters/requestQueueParameters.yaml#/lockSecs"
     - $ref: "../../parameters/requestQueueParameters.yaml#/headLockLimit"
     - $ref: "../../parameters/requestQueueParameters.yaml#/clientKey"
@@ -108,8 +108,8 @@ postTaskLastRun:
   operationId: actorTask_runs_last_requestQueue_head_lock_post
   parameters:
     - $ref: "../../parameters/runAndBuildParameters.yaml#/actorTaskId"
-    - $ref: "../../parameters/runAndBuildParameters.yaml#/statusLastRun"
-    - $ref: "../../parameters/runAndBuildParameters.yaml#/originLastRun"
+    - $ref: "../../parameters/lastRunParameters.yaml#/status"
+    - $ref: "../../parameters/lastRunParameters.yaml#/origin"
     - $ref: "../../parameters/requestQueueParameters.yaml#/lockSecs"
     - $ref: "../../parameters/requestQueueParameters.yaml#/headLockLimit"
     - $ref: "../../parameters/requestQueueParameters.yaml#/clientKey"

--- a/apify-api/openapi/components/objects/request-queues/request-queue-head-lock.yaml
+++ b/apify-api/openapi/components/objects/request-queues/request-queue-head-lock.yaml
@@ -89,6 +89,7 @@ postLastRun:
   parameters:
     - $ref: "../../parameters/runAndBuildParameters.yaml#/actorId"
     - $ref: "../../parameters/runAndBuildParameters.yaml#/statusLastRun"
+    - $ref: "../../parameters/runAndBuildParameters.yaml#/originLastRun"
     - $ref: "../../parameters/requestQueueParameters.yaml#/lockSecs"
     - $ref: "../../parameters/requestQueueParameters.yaml#/headLockLimit"
     - $ref: "../../parameters/requestQueueParameters.yaml#/clientKey"
@@ -108,6 +109,7 @@ postTaskLastRun:
   parameters:
     - $ref: "../../parameters/runAndBuildParameters.yaml#/actorTaskId"
     - $ref: "../../parameters/runAndBuildParameters.yaml#/statusLastRun"
+    - $ref: "../../parameters/runAndBuildParameters.yaml#/originLastRun"
     - $ref: "../../parameters/requestQueueParameters.yaml#/lockSecs"
     - $ref: "../../parameters/requestQueueParameters.yaml#/headLockLimit"
     - $ref: "../../parameters/requestQueueParameters.yaml#/clientKey"

--- a/apify-api/openapi/components/objects/request-queues/request-queue-head.yaml
+++ b/apify-api/openapi/components/objects/request-queues/request-queue-head.yaml
@@ -93,8 +93,8 @@ listLastRun:
   operationId: act_runs_last_requestQueue_head_get
   parameters:
     - $ref: "../../parameters/runAndBuildParameters.yaml#/actorId"
-    - $ref: "../../parameters/runAndBuildParameters.yaml#/statusLastRun"
-    - $ref: "../../parameters/runAndBuildParameters.yaml#/originLastRun"
+    - $ref: "../../parameters/lastRunParameters.yaml#/status"
+    - $ref: "../../parameters/lastRunParameters.yaml#/origin"
     - $ref: "../../parameters/requestQueueParameters.yaml#/headLimit"
     - $ref: "../../parameters/requestQueueParameters.yaml#/clientKey"
 
@@ -109,7 +109,7 @@ listTaskLastRun:
   operationId: actorTask_runs_last_requestQueue_head_get
   parameters:
     - $ref: "../../parameters/runAndBuildParameters.yaml#/actorTaskId"
-    - $ref: "../../parameters/runAndBuildParameters.yaml#/statusLastRun"
-    - $ref: "../../parameters/runAndBuildParameters.yaml#/originLastRun"
+    - $ref: "../../parameters/lastRunParameters.yaml#/status"
+    - $ref: "../../parameters/lastRunParameters.yaml#/origin"
     - $ref: "../../parameters/requestQueueParameters.yaml#/headLimit"
     - $ref: "../../parameters/requestQueueParameters.yaml#/clientKey"

--- a/apify-api/openapi/components/objects/request-queues/request-queue-head.yaml
+++ b/apify-api/openapi/components/objects/request-queues/request-queue-head.yaml
@@ -94,6 +94,7 @@ listLastRun:
   parameters:
     - $ref: "../../parameters/runAndBuildParameters.yaml#/actorId"
     - $ref: "../../parameters/runAndBuildParameters.yaml#/statusLastRun"
+    - $ref: "../../parameters/runAndBuildParameters.yaml#/originLastRun"
     - $ref: "../../parameters/requestQueueParameters.yaml#/headLimit"
     - $ref: "../../parameters/requestQueueParameters.yaml#/clientKey"
 
@@ -109,5 +110,6 @@ listTaskLastRun:
   parameters:
     - $ref: "../../parameters/runAndBuildParameters.yaml#/actorTaskId"
     - $ref: "../../parameters/runAndBuildParameters.yaml#/statusLastRun"
+    - $ref: "../../parameters/runAndBuildParameters.yaml#/originLastRun"
     - $ref: "../../parameters/requestQueueParameters.yaml#/headLimit"
     - $ref: "../../parameters/requestQueueParameters.yaml#/clientKey"

--- a/apify-api/openapi/components/objects/request-queues/request-queue-request-lock.yaml
+++ b/apify-api/openapi/components/objects/request-queues/request-queue-request-lock.yaml
@@ -95,8 +95,8 @@ putLastRun:
   operationId: act_runs_last_requestQueue_request_lock_put
   parameters:
     - $ref: "../../parameters/runAndBuildParameters.yaml#/actorId"
-    - $ref: "../../parameters/runAndBuildParameters.yaml#/statusLastRun"
-    - $ref: "../../parameters/runAndBuildParameters.yaml#/originLastRun"
+    - $ref: "../../parameters/lastRunParameters.yaml#/status"
+    - $ref: "../../parameters/lastRunParameters.yaml#/origin"
     - $ref: "../../parameters/requestQueueParameters.yaml#/requestId"
     - $ref: "../../parameters/requestQueueParameters.yaml#/lockSecs"
     - $ref: "../../parameters/requestQueueParameters.yaml#/clientKey"
@@ -113,8 +113,8 @@ putTaskLastRun:
   operationId: actorTask_runs_last_requestQueue_request_lock_put
   parameters:
     - $ref: "../../parameters/runAndBuildParameters.yaml#/actorTaskId"
-    - $ref: "../../parameters/runAndBuildParameters.yaml#/statusLastRun"
-    - $ref: "../../parameters/runAndBuildParameters.yaml#/originLastRun"
+    - $ref: "../../parameters/lastRunParameters.yaml#/status"
+    - $ref: "../../parameters/lastRunParameters.yaml#/origin"
     - $ref: "../../parameters/requestQueueParameters.yaml#/requestId"
     - $ref: "../../parameters/requestQueueParameters.yaml#/lockSecs"
     - $ref: "../../parameters/requestQueueParameters.yaml#/clientKey"
@@ -180,8 +180,8 @@ deleteLastRun:
   operationId: act_runs_last_requestQueue_request_lock_delete
   parameters:
     - $ref: "../../parameters/runAndBuildParameters.yaml#/actorId"
-    - $ref: "../../parameters/runAndBuildParameters.yaml#/statusLastRun"
-    - $ref: "../../parameters/runAndBuildParameters.yaml#/originLastRun"
+    - $ref: "../../parameters/lastRunParameters.yaml#/status"
+    - $ref: "../../parameters/lastRunParameters.yaml#/origin"
     - $ref: "../../parameters/requestQueueParameters.yaml#/requestId"
     - $ref: "../../parameters/requestQueueParameters.yaml#/clientKey"
     - $ref: "../../parameters/requestQueueParameters.yaml#/deleteForefront"
@@ -197,8 +197,8 @@ deleteTaskLastRun:
   operationId: actorTask_runs_last_requestQueue_request_lock_delete
   parameters:
     - $ref: "../../parameters/runAndBuildParameters.yaml#/actorTaskId"
-    - $ref: "../../parameters/runAndBuildParameters.yaml#/statusLastRun"
-    - $ref: "../../parameters/runAndBuildParameters.yaml#/originLastRun"
+    - $ref: "../../parameters/lastRunParameters.yaml#/status"
+    - $ref: "../../parameters/lastRunParameters.yaml#/origin"
     - $ref: "../../parameters/requestQueueParameters.yaml#/requestId"
     - $ref: "../../parameters/requestQueueParameters.yaml#/clientKey"
     - $ref: "../../parameters/requestQueueParameters.yaml#/deleteForefront"

--- a/apify-api/openapi/components/objects/request-queues/request-queue-request-lock.yaml
+++ b/apify-api/openapi/components/objects/request-queues/request-queue-request-lock.yaml
@@ -96,6 +96,7 @@ putLastRun:
   parameters:
     - $ref: "../../parameters/runAndBuildParameters.yaml#/actorId"
     - $ref: "../../parameters/runAndBuildParameters.yaml#/statusLastRun"
+    - $ref: "../../parameters/runAndBuildParameters.yaml#/originLastRun"
     - $ref: "../../parameters/requestQueueParameters.yaml#/requestId"
     - $ref: "../../parameters/requestQueueParameters.yaml#/lockSecs"
     - $ref: "../../parameters/requestQueueParameters.yaml#/clientKey"
@@ -113,6 +114,7 @@ putTaskLastRun:
   parameters:
     - $ref: "../../parameters/runAndBuildParameters.yaml#/actorTaskId"
     - $ref: "../../parameters/runAndBuildParameters.yaml#/statusLastRun"
+    - $ref: "../../parameters/runAndBuildParameters.yaml#/originLastRun"
     - $ref: "../../parameters/requestQueueParameters.yaml#/requestId"
     - $ref: "../../parameters/requestQueueParameters.yaml#/lockSecs"
     - $ref: "../../parameters/requestQueueParameters.yaml#/clientKey"
@@ -179,6 +181,7 @@ deleteLastRun:
   parameters:
     - $ref: "../../parameters/runAndBuildParameters.yaml#/actorId"
     - $ref: "../../parameters/runAndBuildParameters.yaml#/statusLastRun"
+    - $ref: "../../parameters/runAndBuildParameters.yaml#/originLastRun"
     - $ref: "../../parameters/requestQueueParameters.yaml#/requestId"
     - $ref: "../../parameters/requestQueueParameters.yaml#/clientKey"
     - $ref: "../../parameters/requestQueueParameters.yaml#/deleteForefront"
@@ -195,6 +198,7 @@ deleteTaskLastRun:
   parameters:
     - $ref: "../../parameters/runAndBuildParameters.yaml#/actorTaskId"
     - $ref: "../../parameters/runAndBuildParameters.yaml#/statusLastRun"
+    - $ref: "../../parameters/runAndBuildParameters.yaml#/originLastRun"
     - $ref: "../../parameters/requestQueueParameters.yaml#/requestId"
     - $ref: "../../parameters/requestQueueParameters.yaml#/clientKey"
     - $ref: "../../parameters/requestQueueParameters.yaml#/deleteForefront"

--- a/apify-api/openapi/components/objects/request-queues/request-queue-request.yaml
+++ b/apify-api/openapi/components/objects/request-queues/request-queue-request.yaml
@@ -83,8 +83,8 @@ getLastRun:
   operationId: act_runs_last_requestQueue_request_get
   parameters:
     - $ref: "../../parameters/runAndBuildParameters.yaml#/actorId"
-    - $ref: "../../parameters/runAndBuildParameters.yaml#/statusLastRun"
-    - $ref: "../../parameters/runAndBuildParameters.yaml#/originLastRun"
+    - $ref: "../../parameters/lastRunParameters.yaml#/status"
+    - $ref: "../../parameters/lastRunParameters.yaml#/origin"
     - $ref: "../../parameters/requestQueueParameters.yaml#/requestId"
 
 getTaskLastRun:
@@ -98,8 +98,8 @@ getTaskLastRun:
   operationId: actorTask_runs_last_requestQueue_request_get
   parameters:
     - $ref: "../../parameters/runAndBuildParameters.yaml#/actorTaskId"
-    - $ref: "../../parameters/runAndBuildParameters.yaml#/statusLastRun"
-    - $ref: "../../parameters/runAndBuildParameters.yaml#/originLastRun"
+    - $ref: "../../parameters/lastRunParameters.yaml#/status"
+    - $ref: "../../parameters/lastRunParameters.yaml#/origin"
     - $ref: "../../parameters/requestQueueParameters.yaml#/requestId"
 
 sharedPut: &sharedPut
@@ -175,8 +175,8 @@ putLastRun:
   operationId: act_runs_last_requestQueue_request_put
   parameters:
     - $ref: "../../parameters/runAndBuildParameters.yaml#/actorId"
-    - $ref: "../../parameters/runAndBuildParameters.yaml#/statusLastRun"
-    - $ref: "../../parameters/runAndBuildParameters.yaml#/originLastRun"
+    - $ref: "../../parameters/lastRunParameters.yaml#/status"
+    - $ref: "../../parameters/lastRunParameters.yaml#/origin"
     - $ref: "../../parameters/requestQueueParameters.yaml#/requestId"
     - $ref: "../../parameters/requestQueueParameters.yaml#/forefront"
     - $ref: "../../parameters/requestQueueParameters.yaml#/clientKey"
@@ -192,8 +192,8 @@ putTaskLastRun:
   operationId: actorTask_runs_last_requestQueue_request_put
   parameters:
     - $ref: "../../parameters/runAndBuildParameters.yaml#/actorTaskId"
-    - $ref: "../../parameters/runAndBuildParameters.yaml#/statusLastRun"
-    - $ref: "../../parameters/runAndBuildParameters.yaml#/originLastRun"
+    - $ref: "../../parameters/lastRunParameters.yaml#/status"
+    - $ref: "../../parameters/lastRunParameters.yaml#/origin"
     - $ref: "../../parameters/requestQueueParameters.yaml#/requestId"
     - $ref: "../../parameters/requestQueueParameters.yaml#/forefront"
     - $ref: "../../parameters/requestQueueParameters.yaml#/clientKey"
@@ -247,8 +247,8 @@ deleteLastRun:
   operationId: act_runs_last_requestQueue_request_delete
   parameters:
     - $ref: "../../parameters/runAndBuildParameters.yaml#/actorId"
-    - $ref: "../../parameters/runAndBuildParameters.yaml#/statusLastRun"
-    - $ref: "../../parameters/runAndBuildParameters.yaml#/originLastRun"
+    - $ref: "../../parameters/lastRunParameters.yaml#/status"
+    - $ref: "../../parameters/lastRunParameters.yaml#/origin"
     - $ref: "../../parameters/requestQueueParameters.yaml#/requestId"
     - $ref: "../../parameters/requestQueueParameters.yaml#/clientKey"
 
@@ -263,7 +263,7 @@ deleteTaskLastRun:
   operationId: actorTask_runs_last_requestQueue_request_delete
   parameters:
     - $ref: "../../parameters/runAndBuildParameters.yaml#/actorTaskId"
-    - $ref: "../../parameters/runAndBuildParameters.yaml#/statusLastRun"
-    - $ref: "../../parameters/runAndBuildParameters.yaml#/originLastRun"
+    - $ref: "../../parameters/lastRunParameters.yaml#/status"
+    - $ref: "../../parameters/lastRunParameters.yaml#/origin"
     - $ref: "../../parameters/requestQueueParameters.yaml#/requestId"
     - $ref: "../../parameters/requestQueueParameters.yaml#/clientKey"

--- a/apify-api/openapi/components/objects/request-queues/request-queue-request.yaml
+++ b/apify-api/openapi/components/objects/request-queues/request-queue-request.yaml
@@ -84,6 +84,7 @@ getLastRun:
   parameters:
     - $ref: "../../parameters/runAndBuildParameters.yaml#/actorId"
     - $ref: "../../parameters/runAndBuildParameters.yaml#/statusLastRun"
+    - $ref: "../../parameters/runAndBuildParameters.yaml#/originLastRun"
     - $ref: "../../parameters/requestQueueParameters.yaml#/requestId"
 
 getTaskLastRun:
@@ -98,6 +99,7 @@ getTaskLastRun:
   parameters:
     - $ref: "../../parameters/runAndBuildParameters.yaml#/actorTaskId"
     - $ref: "../../parameters/runAndBuildParameters.yaml#/statusLastRun"
+    - $ref: "../../parameters/runAndBuildParameters.yaml#/originLastRun"
     - $ref: "../../parameters/requestQueueParameters.yaml#/requestId"
 
 sharedPut: &sharedPut
@@ -174,6 +176,7 @@ putLastRun:
   parameters:
     - $ref: "../../parameters/runAndBuildParameters.yaml#/actorId"
     - $ref: "../../parameters/runAndBuildParameters.yaml#/statusLastRun"
+    - $ref: "../../parameters/runAndBuildParameters.yaml#/originLastRun"
     - $ref: "../../parameters/requestQueueParameters.yaml#/requestId"
     - $ref: "../../parameters/requestQueueParameters.yaml#/forefront"
     - $ref: "../../parameters/requestQueueParameters.yaml#/clientKey"
@@ -190,6 +193,7 @@ putTaskLastRun:
   parameters:
     - $ref: "../../parameters/runAndBuildParameters.yaml#/actorTaskId"
     - $ref: "../../parameters/runAndBuildParameters.yaml#/statusLastRun"
+    - $ref: "../../parameters/runAndBuildParameters.yaml#/originLastRun"
     - $ref: "../../parameters/requestQueueParameters.yaml#/requestId"
     - $ref: "../../parameters/requestQueueParameters.yaml#/forefront"
     - $ref: "../../parameters/requestQueueParameters.yaml#/clientKey"
@@ -244,6 +248,7 @@ deleteLastRun:
   parameters:
     - $ref: "../../parameters/runAndBuildParameters.yaml#/actorId"
     - $ref: "../../parameters/runAndBuildParameters.yaml#/statusLastRun"
+    - $ref: "../../parameters/runAndBuildParameters.yaml#/originLastRun"
     - $ref: "../../parameters/requestQueueParameters.yaml#/requestId"
     - $ref: "../../parameters/requestQueueParameters.yaml#/clientKey"
 
@@ -259,5 +264,6 @@ deleteTaskLastRun:
   parameters:
     - $ref: "../../parameters/runAndBuildParameters.yaml#/actorTaskId"
     - $ref: "../../parameters/runAndBuildParameters.yaml#/statusLastRun"
+    - $ref: "../../parameters/runAndBuildParameters.yaml#/originLastRun"
     - $ref: "../../parameters/requestQueueParameters.yaml#/requestId"
     - $ref: "../../parameters/requestQueueParameters.yaml#/clientKey"

--- a/apify-api/openapi/components/objects/request-queues/request-queue-requests-batch.yaml
+++ b/apify-api/openapi/components/objects/request-queues/request-queue-requests-batch.yaml
@@ -109,8 +109,8 @@ postLastRun:
   operationId: act_runs_last_requestQueue_requests_batch_post
   parameters:
     - $ref: "../../parameters/runAndBuildParameters.yaml#/actorId"
-    - $ref: "../../parameters/runAndBuildParameters.yaml#/statusLastRun"
-    - $ref: "../../parameters/runAndBuildParameters.yaml#/originLastRun"
+    - $ref: "../../parameters/lastRunParameters.yaml#/status"
+    - $ref: "../../parameters/lastRunParameters.yaml#/origin"
     - $ref: "../../parameters/requestQueueParameters.yaml#/clientKey"
     - $ref: "../../parameters/requestQueueParameters.yaml#/forefront"
 
@@ -125,8 +125,8 @@ postTaskLastRun:
   operationId: actorTask_runs_last_requestQueue_requests_batch_post
   parameters:
     - $ref: "../../parameters/runAndBuildParameters.yaml#/actorTaskId"
-    - $ref: "../../parameters/runAndBuildParameters.yaml#/statusLastRun"
-    - $ref: "../../parameters/runAndBuildParameters.yaml#/originLastRun"
+    - $ref: "../../parameters/lastRunParameters.yaml#/status"
+    - $ref: "../../parameters/lastRunParameters.yaml#/origin"
     - $ref: "../../parameters/requestQueueParameters.yaml#/clientKey"
     - $ref: "../../parameters/requestQueueParameters.yaml#/forefront"
 
@@ -211,8 +211,8 @@ deleteLastRun:
   operationId: act_runs_last_requestQueue_requests_batch_delete
   parameters:
     - $ref: "../../parameters/runAndBuildParameters.yaml#/actorId"
-    - $ref: "../../parameters/runAndBuildParameters.yaml#/statusLastRun"
-    - $ref: "../../parameters/runAndBuildParameters.yaml#/originLastRun"
+    - $ref: "../../parameters/lastRunParameters.yaml#/status"
+    - $ref: "../../parameters/lastRunParameters.yaml#/origin"
     - $ref: "../../parameters/requestQueueParameters.yaml#/contentTypeJson"
     - $ref: "../../parameters/requestQueueParameters.yaml#/clientKey"
 
@@ -227,7 +227,7 @@ deleteTaskLastRun:
   operationId: actorTask_runs_last_requestQueue_requests_batch_delete
   parameters:
     - $ref: "../../parameters/runAndBuildParameters.yaml#/actorTaskId"
-    - $ref: "../../parameters/runAndBuildParameters.yaml#/statusLastRun"
-    - $ref: "../../parameters/runAndBuildParameters.yaml#/originLastRun"
+    - $ref: "../../parameters/lastRunParameters.yaml#/status"
+    - $ref: "../../parameters/lastRunParameters.yaml#/origin"
     - $ref: "../../parameters/requestQueueParameters.yaml#/contentTypeJson"
     - $ref: "../../parameters/requestQueueParameters.yaml#/clientKey"

--- a/apify-api/openapi/components/objects/request-queues/request-queue-requests-batch.yaml
+++ b/apify-api/openapi/components/objects/request-queues/request-queue-requests-batch.yaml
@@ -110,6 +110,7 @@ postLastRun:
   parameters:
     - $ref: "../../parameters/runAndBuildParameters.yaml#/actorId"
     - $ref: "../../parameters/runAndBuildParameters.yaml#/statusLastRun"
+    - $ref: "../../parameters/runAndBuildParameters.yaml#/originLastRun"
     - $ref: "../../parameters/requestQueueParameters.yaml#/clientKey"
     - $ref: "../../parameters/requestQueueParameters.yaml#/forefront"
 
@@ -125,6 +126,7 @@ postTaskLastRun:
   parameters:
     - $ref: "../../parameters/runAndBuildParameters.yaml#/actorTaskId"
     - $ref: "../../parameters/runAndBuildParameters.yaml#/statusLastRun"
+    - $ref: "../../parameters/runAndBuildParameters.yaml#/originLastRun"
     - $ref: "../../parameters/requestQueueParameters.yaml#/clientKey"
     - $ref: "../../parameters/requestQueueParameters.yaml#/forefront"
 
@@ -210,6 +212,7 @@ deleteLastRun:
   parameters:
     - $ref: "../../parameters/runAndBuildParameters.yaml#/actorId"
     - $ref: "../../parameters/runAndBuildParameters.yaml#/statusLastRun"
+    - $ref: "../../parameters/runAndBuildParameters.yaml#/originLastRun"
     - $ref: "../../parameters/requestQueueParameters.yaml#/contentTypeJson"
     - $ref: "../../parameters/requestQueueParameters.yaml#/clientKey"
 
@@ -225,5 +228,6 @@ deleteTaskLastRun:
   parameters:
     - $ref: "../../parameters/runAndBuildParameters.yaml#/actorTaskId"
     - $ref: "../../parameters/runAndBuildParameters.yaml#/statusLastRun"
+    - $ref: "../../parameters/runAndBuildParameters.yaml#/originLastRun"
     - $ref: "../../parameters/requestQueueParameters.yaml#/contentTypeJson"
     - $ref: "../../parameters/requestQueueParameters.yaml#/clientKey"

--- a/apify-api/openapi/components/objects/request-queues/request-queue-requests-unlock.yaml
+++ b/apify-api/openapi/components/objects/request-queues/request-queue-requests-unlock.yaml
@@ -83,6 +83,7 @@ postLastRun:
   parameters:
     - $ref: "../../parameters/runAndBuildParameters.yaml#/actorId"
     - $ref: "../../parameters/runAndBuildParameters.yaml#/statusLastRun"
+    - $ref: "../../parameters/runAndBuildParameters.yaml#/originLastRun"
     - $ref: "../../parameters/requestQueueParameters.yaml#/clientKey"
 
 postTaskLastRun:
@@ -97,4 +98,5 @@ postTaskLastRun:
   parameters:
     - $ref: "../../parameters/runAndBuildParameters.yaml#/actorTaskId"
     - $ref: "../../parameters/runAndBuildParameters.yaml#/statusLastRun"
+    - $ref: "../../parameters/runAndBuildParameters.yaml#/originLastRun"
     - $ref: "../../parameters/requestQueueParameters.yaml#/clientKey"

--- a/apify-api/openapi/components/objects/request-queues/request-queue-requests-unlock.yaml
+++ b/apify-api/openapi/components/objects/request-queues/request-queue-requests-unlock.yaml
@@ -82,8 +82,8 @@ postLastRun:
   operationId: act_runs_last_requestQueue_requests_unlock_post
   parameters:
     - $ref: "../../parameters/runAndBuildParameters.yaml#/actorId"
-    - $ref: "../../parameters/runAndBuildParameters.yaml#/statusLastRun"
-    - $ref: "../../parameters/runAndBuildParameters.yaml#/originLastRun"
+    - $ref: "../../parameters/lastRunParameters.yaml#/status"
+    - $ref: "../../parameters/lastRunParameters.yaml#/origin"
     - $ref: "../../parameters/requestQueueParameters.yaml#/clientKey"
 
 postTaskLastRun:
@@ -97,6 +97,6 @@ postTaskLastRun:
   operationId: actorTask_runs_last_requestQueue_requests_unlock_post
   parameters:
     - $ref: "../../parameters/runAndBuildParameters.yaml#/actorTaskId"
-    - $ref: "../../parameters/runAndBuildParameters.yaml#/statusLastRun"
-    - $ref: "../../parameters/runAndBuildParameters.yaml#/originLastRun"
+    - $ref: "../../parameters/lastRunParameters.yaml#/status"
+    - $ref: "../../parameters/lastRunParameters.yaml#/origin"
     - $ref: "../../parameters/requestQueueParameters.yaml#/clientKey"

--- a/apify-api/openapi/components/objects/request-queues/request-queue-requests.yaml
+++ b/apify-api/openapi/components/objects/request-queues/request-queue-requests.yaml
@@ -94,6 +94,7 @@ listLastRun:
   parameters:
     - $ref: "../../parameters/runAndBuildParameters.yaml#/actorId"
     - $ref: "../../parameters/runAndBuildParameters.yaml#/statusLastRun"
+    - $ref: "../../parameters/runAndBuildParameters.yaml#/originLastRun"
     - $ref: "../../parameters/requestQueueParameters.yaml#/clientKey"
     - $ref: "../../parameters/requestQueueParameters.yaml#/exclusiveStartId"
     - $ref: "../../parameters/requestQueueParameters.yaml#/listLimit"
@@ -112,6 +113,7 @@ listTaskLastRun:
   parameters:
     - $ref: "../../parameters/runAndBuildParameters.yaml#/actorTaskId"
     - $ref: "../../parameters/runAndBuildParameters.yaml#/statusLastRun"
+    - $ref: "../../parameters/runAndBuildParameters.yaml#/originLastRun"
     - $ref: "../../parameters/requestQueueParameters.yaml#/clientKey"
     - $ref: "../../parameters/requestQueueParameters.yaml#/exclusiveStartId"
     - $ref: "../../parameters/requestQueueParameters.yaml#/listLimit"
@@ -192,6 +194,7 @@ postLastRun:
   parameters:
     - $ref: "../../parameters/runAndBuildParameters.yaml#/actorId"
     - $ref: "../../parameters/runAndBuildParameters.yaml#/statusLastRun"
+    - $ref: "../../parameters/runAndBuildParameters.yaml#/originLastRun"
     - $ref: "../../parameters/requestQueueParameters.yaml#/clientKey"
     - $ref: "../../parameters/requestQueueParameters.yaml#/forefront"
 
@@ -207,5 +210,6 @@ postTaskLastRun:
   parameters:
     - $ref: "../../parameters/runAndBuildParameters.yaml#/actorTaskId"
     - $ref: "../../parameters/runAndBuildParameters.yaml#/statusLastRun"
+    - $ref: "../../parameters/runAndBuildParameters.yaml#/originLastRun"
     - $ref: "../../parameters/requestQueueParameters.yaml#/clientKey"
     - $ref: "../../parameters/requestQueueParameters.yaml#/forefront"

--- a/apify-api/openapi/components/objects/request-queues/request-queue-requests.yaml
+++ b/apify-api/openapi/components/objects/request-queues/request-queue-requests.yaml
@@ -93,8 +93,8 @@ listLastRun:
   operationId: act_runs_last_requestQueue_requests_get
   parameters:
     - $ref: "../../parameters/runAndBuildParameters.yaml#/actorId"
-    - $ref: "../../parameters/runAndBuildParameters.yaml#/statusLastRun"
-    - $ref: "../../parameters/runAndBuildParameters.yaml#/originLastRun"
+    - $ref: "../../parameters/lastRunParameters.yaml#/status"
+    - $ref: "../../parameters/lastRunParameters.yaml#/origin"
     - $ref: "../../parameters/requestQueueParameters.yaml#/clientKey"
     - $ref: "../../parameters/requestQueueParameters.yaml#/exclusiveStartId"
     - $ref: "../../parameters/requestQueueParameters.yaml#/listLimit"
@@ -112,8 +112,8 @@ listTaskLastRun:
   operationId: actorTask_runs_last_requestQueue_requests_get
   parameters:
     - $ref: "../../parameters/runAndBuildParameters.yaml#/actorTaskId"
-    - $ref: "../../parameters/runAndBuildParameters.yaml#/statusLastRun"
-    - $ref: "../../parameters/runAndBuildParameters.yaml#/originLastRun"
+    - $ref: "../../parameters/lastRunParameters.yaml#/status"
+    - $ref: "../../parameters/lastRunParameters.yaml#/origin"
     - $ref: "../../parameters/requestQueueParameters.yaml#/clientKey"
     - $ref: "../../parameters/requestQueueParameters.yaml#/exclusiveStartId"
     - $ref: "../../parameters/requestQueueParameters.yaml#/listLimit"
@@ -193,8 +193,8 @@ postLastRun:
   operationId: act_runs_last_requestQueue_requests_post
   parameters:
     - $ref: "../../parameters/runAndBuildParameters.yaml#/actorId"
-    - $ref: "../../parameters/runAndBuildParameters.yaml#/statusLastRun"
-    - $ref: "../../parameters/runAndBuildParameters.yaml#/originLastRun"
+    - $ref: "../../parameters/lastRunParameters.yaml#/status"
+    - $ref: "../../parameters/lastRunParameters.yaml#/origin"
     - $ref: "../../parameters/requestQueueParameters.yaml#/clientKey"
     - $ref: "../../parameters/requestQueueParameters.yaml#/forefront"
 
@@ -209,7 +209,7 @@ postTaskLastRun:
   operationId: actorTask_runs_last_requestQueue_requests_post
   parameters:
     - $ref: "../../parameters/runAndBuildParameters.yaml#/actorTaskId"
-    - $ref: "../../parameters/runAndBuildParameters.yaml#/statusLastRun"
-    - $ref: "../../parameters/runAndBuildParameters.yaml#/originLastRun"
+    - $ref: "../../parameters/lastRunParameters.yaml#/status"
+    - $ref: "../../parameters/lastRunParameters.yaml#/origin"
     - $ref: "../../parameters/requestQueueParameters.yaml#/clientKey"
     - $ref: "../../parameters/requestQueueParameters.yaml#/forefront"

--- a/apify-api/openapi/components/objects/request-queues/request-queue.yaml
+++ b/apify-api/openapi/components/objects/request-queues/request-queue.yaml
@@ -38,16 +38,16 @@ sharedLastRun: &sharedLastRun
     - Last Actor run's default request queue
   parameters:
     - $ref: "../../parameters/runAndBuildParameters.yaml#/actorId"
-    - $ref: "../../parameters/runAndBuildParameters.yaml#/statusLastRun"
-    - $ref: "../../parameters/runAndBuildParameters.yaml#/originLastRun"
+    - $ref: "../../parameters/lastRunParameters.yaml#/status"
+    - $ref: "../../parameters/lastRunParameters.yaml#/origin"
 
 sharedTaskLastRun: &sharedTaskLastRun
   tags:
     - Last Actor task run's default request queue
   parameters:
     - $ref: "../../parameters/runAndBuildParameters.yaml#/actorTaskId"
-    - $ref: "../../parameters/runAndBuildParameters.yaml#/statusLastRun"
-    - $ref: "../../parameters/runAndBuildParameters.yaml#/originLastRun"
+    - $ref: "../../parameters/lastRunParameters.yaml#/status"
+    - $ref: "../../parameters/lastRunParameters.yaml#/origin"
 
 sharedGet: &sharedGet
   responses:

--- a/apify-api/openapi/components/objects/request-queues/request-queue.yaml
+++ b/apify-api/openapi/components/objects/request-queues/request-queue.yaml
@@ -39,6 +39,7 @@ sharedLastRun: &sharedLastRun
   parameters:
     - $ref: "../../parameters/runAndBuildParameters.yaml#/actorId"
     - $ref: "../../parameters/runAndBuildParameters.yaml#/statusLastRun"
+    - $ref: "../../parameters/runAndBuildParameters.yaml#/originLastRun"
 
 sharedTaskLastRun: &sharedTaskLastRun
   tags:
@@ -46,6 +47,7 @@ sharedTaskLastRun: &sharedTaskLastRun
   parameters:
     - $ref: "../../parameters/runAndBuildParameters.yaml#/actorTaskId"
     - $ref: "../../parameters/runAndBuildParameters.yaml#/statusLastRun"
+    - $ref: "../../parameters/runAndBuildParameters.yaml#/originLastRun"
 
 sharedGet: &sharedGet
   responses:

--- a/apify-api/openapi/components/parameters/lastRunParameters.yaml
+++ b/apify-api/openapi/components/parameters/lastRunParameters.yaml
@@ -1,0 +1,18 @@
+status:
+  name: status
+  in: query
+  description: Filter for the run status.
+  style: form
+  explode: true
+  schema:
+    type: string
+    example: SUCCEEDED
+
+origin:
+  name: origin
+  in: query
+  description: Filter for the run origin, i.e. the means by which the run was started.
+  style: form
+  explode: true
+  schema:
+    $ref: ../schemas/actor-runs/RunOrigin.yaml

--- a/apify-api/openapi/components/parameters/runAndBuildParameters.yaml
+++ b/apify-api/openapi/components/parameters/runAndBuildParameters.yaml
@@ -98,6 +98,15 @@ statusLastRun:
     type: string
     example: SUCCEEDED
 
+originLastRun:
+  name: origin
+  in: query
+  description: Filter for the run origin, i.e. the means by which the run was started.
+  style: form
+  explode: true
+  schema:
+    $ref: ../schemas/actor-runs/RunOrigin.yaml
+
 timeout: &timeout
   name: timeout
   in: query

--- a/apify-api/openapi/components/parameters/runAndBuildParameters.yaml
+++ b/apify-api/openapi/components/parameters/runAndBuildParameters.yaml
@@ -88,25 +88,6 @@ gracefully:
     type: boolean
     example: true
 
-statusLastRun:
-  name: status
-  in: query
-  description: Filter for the run status.
-  style: form
-  explode: true
-  schema:
-    type: string
-    example: SUCCEEDED
-
-originLastRun:
-  name: origin
-  in: query
-  description: Filter for the run origin, i.e. the means by which the run was started.
-  style: form
-  explode: true
-  schema:
-    $ref: ../schemas/actor-runs/RunOrigin.yaml
-
 timeout: &timeout
   name: timeout
   in: query

--- a/apify-api/openapi/paths/actor-tasks/actor-tasks@{actorTaskId}@runs@last.yaml
+++ b/apify-api/openapi/paths/actor-tasks/actor-tasks@{actorTaskId}@runs@last.yaml
@@ -9,11 +9,12 @@ get:
 
     The base path represents the last actor task run object is:
 
-    `/v2/actor-tasks/{actorTaskId}/runs/last{?token,status}`
+    `/v2/actor-tasks/{actorTaskId}/runs/last{?token,status,origin}`
 
     Using the `status` query parameter you can ensure to only get a run with a certain status
-    (e.g. `status=SUCCEEDED`). The output of this endpoint and other query parameters
-    are the same as in the [Run object](/api/v2/actor-run-get) endpoint.
+    (e.g. `status=SUCCEEDED`). Similarly, the `origin` query parameter filters runs by the means
+    by which they were started (e.g. `origin=API`). The output of this endpoint and other query
+    parameters are the same as in the [Run object](/api/v2/actor-run-get) endpoint.
 
     ##### Convenience endpoints for last Actor task run
 
@@ -29,6 +30,7 @@ get:
   parameters:
     - $ref: "../../components/parameters/runAndBuildParameters.yaml#/actorTaskId"
     - $ref: "../../components/parameters/runAndBuildParameters.yaml#/statusLastRun"
+    - $ref: "../../components/parameters/runAndBuildParameters.yaml#/originLastRun"
     - $ref: "../../components/parameters/runAndBuildParameters.yaml#/waitForFinishRun"
   responses:
     "200":

--- a/apify-api/openapi/paths/actor-tasks/actor-tasks@{actorTaskId}@runs@last.yaml
+++ b/apify-api/openapi/paths/actor-tasks/actor-tasks@{actorTaskId}@runs@last.yaml
@@ -29,8 +29,8 @@ get:
   operationId: actorTask_runs_last_get
   parameters:
     - $ref: "../../components/parameters/runAndBuildParameters.yaml#/actorTaskId"
-    - $ref: "../../components/parameters/runAndBuildParameters.yaml#/statusLastRun"
-    - $ref: "../../components/parameters/runAndBuildParameters.yaml#/originLastRun"
+    - $ref: "../../components/parameters/lastRunParameters.yaml#/status"
+    - $ref: "../../components/parameters/lastRunParameters.yaml#/origin"
     - $ref: "../../components/parameters/runAndBuildParameters.yaml#/waitForFinishRun"
   responses:
     "200":

--- a/apify-api/openapi/paths/actors/acts@{actorId}@runs@last.yaml
+++ b/apify-api/openapi/paths/actors/acts@{actorId}@runs@last.yaml
@@ -9,11 +9,12 @@ get:
 
     The base path represents the last Actor run object is:
 
-    `/v2/actors/{actorId}/runs/last{?token,status}`
+    `/v2/actors/{actorId}/runs/last{?token,status,origin}`
 
     Using the `status` query parameter you can ensure to only get a run with a certain status
-    (e.g. `status=SUCCEEDED`). The output of this endpoint and other query parameters
-    are the same as in the [Run object](#/reference/actors/run-object) endpoint.
+    (e.g. `status=SUCCEEDED`). Similarly, the `origin` query parameter filters runs by the means
+    by which they were started (e.g. `origin=API`). The output of this endpoint and other query
+    parameters are the same as in the [Run object](#/reference/actors/run-object) endpoint.
 
     ##### Convenience endpoints for last Actor run
 
@@ -29,6 +30,7 @@ get:
   parameters:
     - $ref: "../../components/parameters/runAndBuildParameters.yaml#/actorId"
     - $ref: "../../components/parameters/runAndBuildParameters.yaml#/statusLastRun"
+    - $ref: "../../components/parameters/runAndBuildParameters.yaml#/originLastRun"
     - $ref: "../../components/parameters/runAndBuildParameters.yaml#/waitForFinishRun"
   responses:
     "200":

--- a/apify-api/openapi/paths/actors/acts@{actorId}@runs@last.yaml
+++ b/apify-api/openapi/paths/actors/acts@{actorId}@runs@last.yaml
@@ -29,8 +29,8 @@ get:
   operationId: act_runs_last_get
   parameters:
     - $ref: "../../components/parameters/runAndBuildParameters.yaml#/actorId"
-    - $ref: "../../components/parameters/runAndBuildParameters.yaml#/statusLastRun"
-    - $ref: "../../components/parameters/runAndBuildParameters.yaml#/originLastRun"
+    - $ref: "../../components/parameters/lastRunParameters.yaml#/status"
+    - $ref: "../../components/parameters/lastRunParameters.yaml#/origin"
     - $ref: "../../components/parameters/runAndBuildParameters.yaml#/waitForFinishRun"
   responses:
     "200":


### PR DESCRIPTION
The last run and last task run endpoints accept an `origin` query parameter to filter the last run by how it was started (e.g. `origin=API`), but it was missing from the OpenAPI spec. This adds it to those endpoints and all their convenience variants (default dataset/key-value store/request queue/log, plus abort/metamorph/reboot), reusing the existing `RunOrigin` schema for the enum.

Surfaced by apify/apify-client-js#952; API source: [actors/last_run.ts](https://github.com/apify/apify-core/blob/v0.1508.0/src/api/src/routes/actors/last_run.ts#L21) and [actor_tasks/last_run.ts](https://github.com/apify/apify-core/blob/v0.1508.0/src/api/src/routes/actor_tasks/last_run.ts#L21).
