### PR TITLE
docs: add agi.apify.com link to llms.txt

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -281,7 +281,7 @@ module.exports = {
             /** @type {import('@signalwire/docusaurus-plugin-llms-txt').PluginOptions} */
             ({
                 siteDescription:
-                    'Apify is the largest marketplace of tools for AI. Thousands of ready-made Actors to automate your business. Get real-time web data, track competitors, generate leads, analyze sentiment, and orchestrate your apps. Actors are created by a global community of builders earning over $1M every month. Apify takes care of infrastructure, billing, and distribution.\n\nThe entire content of Apify documentation is available in a single Markdown file at https://docs.apify.com/llms-full.txt\n\nFor pricing details, see https://apify.com/pricing.md\n\nAI agents can buy prepaid, spend-capped API tokens through the Apify Agent General Interface (AGI) at https://agi.apify.com',
+                    'Apify is the largest marketplace of tools for AI. Thousands of ready-made Actors to automate your business. Get real-time web data, track competitors, generate leads, analyze sentiment, and orchestrate your apps. Actors are created by a global community of builders earning over $1M every month. Apify takes care of infrastructure, billing, and distribution.\n\nThe entire content of Apify documentation is available in a single Markdown file at https://docs.apify.com/llms-full.txt\n\nFor pricing details, see https://apify.com/pricing.md',
                 content: {
                     includeVersionedDocs: false,
                     enableLlmsFullTxt: true,

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -281,7 +281,7 @@ module.exports = {
             /** @type {import('@signalwire/docusaurus-plugin-llms-txt').PluginOptions} */
             ({
                 siteDescription:
-                    'Apify is the largest marketplace of tools for AI. Thousands of ready-made Actors to automate your business. Get real-time web data, track competitors, generate leads, analyze sentiment, and orchestrate your apps. Actors are created by a global community of builders earning over $1M every month. Apify takes care of infrastructure, billing, and distribution.\n\nThe entire content of Apify documentation is available in a single Markdown file at https://docs.apify.com/llms-full.txt\n\nFor pricing details, see https://apify.com/pricing.md',
+                    'Apify is the largest marketplace of tools for AI. Thousands of ready-made Actors to automate your business. Get real-time web data, track competitors, generate leads, analyze sentiment, and orchestrate your apps. Actors are created by a global community of builders earning over $1M every month. Apify takes care of infrastructure, billing, and distribution.\n\nThe entire content of Apify documentation is available in a single Markdown file at https://docs.apify.com/llms-full.txt\n\nFor pricing details, see https://apify.com/pricing.md\n\nFor autonomous AI agents, the Apify Agent General Interface (AGI) at https://agi.apify.com is the entry point to use and pay for the Apify platform and Actors through agentic payment protocols like x402 or MPP, without account setup or ongoing billing.',
                 content: {
                     includeVersionedDocs: false,
                     enableLlmsFullTxt: true,

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -281,7 +281,7 @@ module.exports = {
             /** @type {import('@signalwire/docusaurus-plugin-llms-txt').PluginOptions} */
             ({
                 siteDescription:
-                    'Apify is the largest marketplace of tools for AI. Thousands of ready-made Actors to automate your business. Get real-time web data, track competitors, generate leads, analyze sentiment, and orchestrate your apps. Actors are created by a global community of builders earning over $1M every month. Apify takes care of infrastructure, billing, and distribution.\n\nThe entire content of Apify documentation is available in a single Markdown file at https://docs.apify.com/llms-full.txt\n\nFor pricing details, see https://apify.com/pricing.md',
+                    'Apify is the largest marketplace of tools for AI. Thousands of ready-made Actors to automate your business. Get real-time web data, track competitors, generate leads, analyze sentiment, and orchestrate your apps. Actors are created by a global community of builders earning over $1M every month. Apify takes care of infrastructure, billing, and distribution.\n\nThe entire content of Apify documentation is available in a single Markdown file at https://docs.apify.com/llms-full.txt\n\nFor pricing details, see https://apify.com/pricing.md\n\nAI agents can buy prepaid, spend-capped API tokens through the Apify Agent General Interface (AGI) at https://agi.apify.com',
                 content: {
                     includeVersionedDocs: false,
                     enableLlmsFullTxt: true,

--- a/scripts/joinLlmsFiles.mjs
+++ b/scripts/joinLlmsFiles.mjs
@@ -80,6 +80,27 @@ const SITE_URL = process.env.APIFY_DOCS_ABSOLUTE_URL || 'https://docs.apify.com'
 
 const isExcludedRoute = createMatcher(LLMS_INDEX_EXCLUDE_PATTERNS);
 
+// Top-level links injected into the llms.txt header (before the first `##`
+// section). Used for resources that live outside the generated docs routes.
+const HEADER_LINKS = [
+    '- [Apify Agent General Interface (AGI)](https://agi.apify.com): Entry point to Apify for autonomous AI agents, enabling them to use and pay for the Apify platform and Actors through agentic payment protocols like x402 or MPP, without account setup or ongoing billing.',
+];
+
+/**
+ * Insert HEADER_LINKS into the llms.txt header, just before the first `##`
+ * section heading so they sit alongside the intro resource links.
+ */
+function insertHeaderLinks(content) {
+    if (!HEADER_LINKS.length) return content;
+
+    const firstSection = content.search(/^## /m);
+    const block = `${HEADER_LINKS.join('\n')}\n\n`;
+    if (firstSection === -1) {
+        return `${content.replace(/\n*$/, '\n\n')}${block}`;
+    }
+    return `${content.slice(0, firstSection)}${block}${content.slice(firstSection)}`;
+}
+
 const EXTERNAL_FETCH_URLS = [
     'https://docs.apify.com/api/client/js/llms-full.txt',
     'https://docs.apify.com/api/client/python/llms-full.txt',
@@ -219,7 +240,7 @@ async function joinFiles() {
     // llms.txt: filter out routes we don't want indexed (their .md files are
     // still served), append curated static content, then reorder all sections
     const generated = await fs.readFile(llmsPath, 'utf8');
-    await fs.writeFile(llmsPath, filterLlmsIndex(generated), 'utf8');
+    await fs.writeFile(llmsPath, insertHeaderLinks(filterLlmsIndex(generated)), 'utf8');
 
     const curatedContent = await fs.readFile(CURATED_FILE, 'utf8');
     await fs.appendFile(llmsPath, curatedContent, 'utf8');

--- a/scripts/joinLlmsFiles.mjs
+++ b/scripts/joinLlmsFiles.mjs
@@ -80,27 +80,6 @@ const SITE_URL = process.env.APIFY_DOCS_ABSOLUTE_URL || 'https://docs.apify.com'
 
 const isExcludedRoute = createMatcher(LLMS_INDEX_EXCLUDE_PATTERNS);
 
-// Top-level links injected into the llms.txt header (before the first `##`
-// section). Used for resources that live outside the generated docs routes.
-const HEADER_LINKS = [
-    '- [Apify Agent General Interface (AGI)](https://agi.apify.com): Entry point to Apify for autonomous AI agents, enabling them to use and pay for the Apify platform and Actors through agentic payment protocols like x402 or MPP, without account setup or ongoing billing.',
-];
-
-/**
- * Insert HEADER_LINKS into the llms.txt header, just before the first `##`
- * section heading so they sit alongside the intro resource links.
- */
-function insertHeaderLinks(content) {
-    if (!HEADER_LINKS.length) return content;
-
-    const firstSection = content.search(/^## /m);
-    const block = `${HEADER_LINKS.join('\n')}\n\n`;
-    if (firstSection === -1) {
-        return `${content.replace(/\n*$/, '\n\n')}${block}`;
-    }
-    return `${content.slice(0, firstSection)}${block}${content.slice(firstSection)}`;
-}
-
 const EXTERNAL_FETCH_URLS = [
     'https://docs.apify.com/api/client/js/llms-full.txt',
     'https://docs.apify.com/api/client/python/llms-full.txt',
@@ -240,7 +219,7 @@ async function joinFiles() {
     // llms.txt: filter out routes we don't want indexed (their .md files are
     // still served), append curated static content, then reorder all sections
     const generated = await fs.readFile(llmsPath, 'utf8');
-    await fs.writeFile(llmsPath, insertHeaderLinks(filterLlmsIndex(generated)), 'utf8');
+    await fs.writeFile(llmsPath, filterLlmsIndex(generated), 'utf8');
 
     const curatedContent = await fs.readFile(CURATED_FILE, 'utf8');
     await fs.appendFile(llmsPath, curatedContent, 'utf8');


### PR DESCRIPTION
Adds a line to the `llms.txt` header pointing autonomous AI agents to the Apify Agent General Interface (https://agi.apify.com), alongside the existing llms-full.txt and pricing links. Done via the plugin's `siteDescription` so it renders as plain intro text matching the surrounding links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FyFuxe3woQWyU2xXhPhv5z