### PR TITLE
docs: add missing title and description properties to DatasetSchema object definition #2691

### DIFF
--- a/sources/platform/actors/development/actor_definition/dataset_schema/index.md
+++ b/sources/platform/actors/development/actor_definition/dataset_schema/index.md
@@ -418,6 +418,8 @@ Alternatively, flatten nested structures in your Actor code before calling `Acto
 | Property | Type | Required | Description |
 | --- | --- | --- | --- |
 | `actorSpecification` | integer | true | Version of the dataset schema structure. Only version 1 is available. |
+| `title` | string | false | Human-readable title for the dataset. Displayed in the Output tab UI and API responses. |
+| `description` | string | false | Description of the dataset. Provides additional context in the Output tab UI and API responses. |
 | `fields` | JSONSchema object | false | Schema of one dataset object using JSON Schema Draft 2020-12 or compatible format. |
 | `views` | Object | true | An object containing view definitions. Each key is a view ID, each value is a DatasetView object. |
 

--- a/sources/platform/actors/development/actor_definition/dataset_schema/index.md
+++ b/sources/platform/actors/development/actor_definition/dataset_schema/index.md
@@ -418,8 +418,8 @@ Alternatively, flatten nested structures in your Actor code before calling `Acto
 | Property | Type | Required | Description |
 | --- | --- | --- | --- |
 | `actorSpecification` | integer | true | Version of the dataset schema structure. Only version 1 is available. |
-| `title` | string | false | Human-readable title for the dataset. Displayed in the Output tab UI and API responses. |
-| `description` | string | false | Description of the dataset. Provides additional context in the Output tab UI and API responses. |
+| `title` | string | false | Human-readable title for the dataset. |
+| `description` | string | false | Description of the dataset. |
 | `fields` | JSONSchema object | false | Schema of one dataset object using JSON Schema Draft 2020-12 or compatible format. |
 | `views` | Object | true | An object containing view definitions. Each key is a view ID, each value is a DatasetView object. |
 


### PR DESCRIPTION
## Summary

Fixes #2691

Adds the missing `title` and `description` properties to the DatasetSchema object definition table.

## Changes

- Added `title` (string, optional): Human-readable title for the dataset
- Added `description` (string, optional): Description providing additional context

These properties were being used in examples (e.g., Academy tutorial with Zappos Scraper) but were not documented in the reference table.

## Testing
Tested with a live Actor deployment to verify both properties are:
- ✅ Actor works without them
- ✅ Actor works with them