### PR TITLE
ci: bump apify/actions/pnpm-install to v1.3.1

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -23,7 +23,7 @@ jobs:
                 with:
                     node-version: 24
 
-            -   uses: apify/actions/pnpm-install@v1.1.2
+            -   uses: apify/actions/pnpm-install@v1.3.1
 
             -   name: Build docs
                 run: |

--- a/.github/workflows/lychee.yml
+++ b/.github/workflows/lychee.yml
@@ -16,7 +16,7 @@ jobs:
                 with:
                     node-version: 24
 
-            -   uses: apify/actions/pnpm-install@v1.1.2
+            -   uses: apify/actions/pnpm-install@v1.3.1
 
             -   name: Build docs
                 run: |

--- a/.github/workflows/openapi-ci.yaml
+++ b/.github/workflows/openapi-ci.yaml
@@ -27,7 +27,7 @@ jobs:
               with:
                   node-version: 24
 
-            - uses: apify/actions/pnpm-install@v1.1.2
+            - uses: apify/actions/pnpm-install@v1.3.1
 
             - name: Lint with Redocly
               run: pnpm openapi:lint:redocly --format=github-actions
@@ -48,7 +48,7 @@ jobs:
               with:
                   node-version: 24
 
-            - uses: apify/actions/pnpm-install@v1.1.2
+            - uses: apify/actions/pnpm-install@v1.3.1
 
             - name: Build bundles
               run: pnpm openapi:build
@@ -75,7 +75,7 @@ jobs:
               with:
                   node-version: 24
 
-            - uses: apify/actions/pnpm-install@v1.1.2
+            - uses: apify/actions/pnpm-install@v1.3.1
 
             - name: Download bundles
               uses: actions/download-artifact@v8

--- a/.github/workflows/publish-to-npm.yaml
+++ b/.github/workflows/publish-to-npm.yaml
@@ -53,7 +53,7 @@ jobs:
                     node-version: 24
                     registry-url: 'https://registry.npmjs.org'
 
-            -   uses: apify/actions/pnpm-install@v1.1.2
+            -   uses: apify/actions/pnpm-install@v1.3.1
 
             -   name: Setup git user and npm
                 run: |

--- a/.github/workflows/test-academy.yml
+++ b/.github/workflows/test-academy.yml
@@ -21,7 +21,7 @@ jobs:
             -   name: Setup Python
                 uses: astral-sh/setup-uv@v8.1.0
 
-            -   uses: apify/actions/pnpm-install@v1.1.2
+            -   uses: apify/actions/pnpm-install@v1.3.1
 
             -   name: Test
                 run: pnpm test:academy

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -18,7 +18,7 @@ jobs:
                 with:
                     node-version: 24
 
-            -   uses: apify/actions/pnpm-install@v1.1.2
+            -   uses: apify/actions/pnpm-install@v1.3.1
 
             -   run: pnpm build
                 env:
@@ -250,7 +250,7 @@ jobs:
                 with:
                     node-version: 24
 
-            -   uses: apify/actions/pnpm-install@v1.1.2
+            -   uses: apify/actions/pnpm-install@v1.3.1
 
             -   name: List and Lint Changed Markdown Files
                 env:
@@ -274,7 +274,7 @@ jobs:
                 with:
                     node-version: 24
 
-            -   uses: apify/actions/pnpm-install@v1.1.2
+            -   uses: apify/actions/pnpm-install@v1.3.1
 
             -   run: pnpm lint:code
 


### PR DESCRIPTION
Bumps the pinned `apify/actions/pnpm-install` composite action to `v1.3.1`.

That release updates `actions/cache` to `v6.1.0`, so the action runs on the Node.js 24 runtime. It clears the "Node.js 20 is deprecated" warning that shows up on every CI run. For details, see apify/actions#29.
