### PR TITLE
docs(dockerfile): warn about the npm omit=dev + tsc build trap in TypeScript Actors

### DIFF
--- a/sources/platform/actors/development/actor_definition/docker.md
+++ b/sources/platform/actors/development/actor_definition/docker.md
@@ -204,6 +204,48 @@ You can check out various optimization tips for Dockerfile in the [Performance](
 
 :::
 
+## Build TypeScript Actors
+
+TypeScript Actors compile to JavaScript at build time through a `tsc` build step. Installing only production dependencies (`npm install --omit=dev`, or the older `--only=prod`) strips the `typescript` package, so the build fails with `tsc: not found`. Three fixes:
+
+1. Multi-stage build (smallest runtime image, most complex Dockerfile). Installs dev dependencies in a builder stage, then copies the compiled output into a slim runtime stage.
+
+    ```dockerfile
+    FROM apify/actor-node:24 AS builder
+    COPY --chown=myuser:myuser package*.json ./
+    RUN npm install --include=dev
+    COPY --chown=myuser:myuser . ./
+    RUN npm run build
+
+    FROM apify/actor-node:24
+    COPY --chown=myuser:myuser package*.json ./
+    RUN npm install --omit=dev --omit=optional
+    COPY --from=builder --chown=myuser:myuser /usr/src/app/dist ./dist
+    CMD ["node", "dist/main.js"]
+    ```
+
+1. Drop `--omit=dev` (simplest Dockerfile, largest runtime image). Installs everything, including linters and type declarations, into the single-stage image.
+
+    ```dockerfile
+    FROM apify/actor-node:24
+    COPY --chown=myuser:myuser package*.json ./
+    RUN npm install
+    COPY --chown=myuser:myuser . ./
+    RUN npm run build
+    CMD ["node", "dist/main.js"]
+    ```
+
+1. Move `typescript` to `dependencies`. Keeps the single-stage Dockerfile but bloats the runtime image with the TypeScript compiler and its tooling. The runtime never uses these, so the extra size is wasted.
+
+    ```json
+    {
+        "dependencies": {
+            "apify": "^3.4.0",
+            "typescript": "^5.5.0"
+        }
+    }
+    ```
+
 ## Update older Dockerfiles
 
 All Apify base Docker images now use a non-root user to enhance security. This change requires updates to existing Actor `Dockerfile`s that use the `apify/actor-node`, `apify/actor-python`, `apify/actor-python-playwright`, or `apify/actor-python-selenium` images. This section provides guidance on resolving common issues that may arise during this migration.

--- a/sources/platform/actors/development/actor_definition/source_code.md
+++ b/sources/platform/actors/development/actor_definition/source_code.md
@@ -81,7 +81,11 @@ By copying the `package.json` and `package-lock.json` files and installing depen
 
 :::warning TypeScript Actors
 
-The Dockerfile above uses `--omit=dev`, which strips `typescript`. If your `build` script invokes `tsc`, the image build fails with `sh: tsc: not found` even though the code compiles locally. Use a multi-stage build (see the [`ts-empty` template's Dockerfile](https://github.com/apify/actor-templates/blob/master/templates/ts-empty/Dockerfile)) or drop `--omit=dev` from the single-stage install.
+The Dockerfile above uses `--omit=dev`, which strips `typescript`. If your `build` script invokes `tsc`, the image build fails with `tsc: not found`. Three fixes:
+
+- Use a multi-stage build: install with `--include=dev` in a builder stage, then copy the compiled output into a slim runtime stage.
+- Drop `--omit=dev` from the single-stage install.
+- Move `typescript` (and `tsx`, if used) from `devDependencies` to `dependencies`.
 
 :::
 

--- a/sources/platform/actors/development/actor_definition/source_code.md
+++ b/sources/platform/actors/development/actor_definition/source_code.md
@@ -79,59 +79,6 @@ By copying the `package.json` and `package-lock.json` files and installing depen
 
 :::
 
-:::warning TypeScript Actors
-
-The Dockerfile above uses `--omit=dev`, which strips `typescript`. If your `build` script invokes `tsc`, the image build fails with `tsc: not found`. Three fixes:
-
-- **Multi-stage build** (smallest runtime image)—installs devDeps in a builder stage, copies the compiled output into a slim runtime stage. Most complex Dockerfile.
-  <details><summary>Example</summary>
-
-  ```dockerfile
-  FROM apify/actor-node:24 AS builder
-  COPY --chown=myuser:myuser package*.json ./
-  RUN npm install --include=dev
-  COPY --chown=myuser:myuser . ./
-  RUN npm run build
-
-  FROM apify/actor-node:24
-  COPY --chown=myuser:myuser package*.json ./
-  RUN npm install --omit=dev --omit=optional
-  COPY --from=builder --chown=myuser:myuser /usr/src/app/dist ./dist
-  CMD ["node", "dist/main.js"]
-  ```
-
-  </details>
-
-- **Drop `--omit=dev`** (simplest Dockerfile, largest runtime image)—installs everything, including linters and type declarations, into the single-stage image.
-  <details><summary>Example</summary>
-
-  ```dockerfile
-  FROM apify/actor-node:24
-  COPY --chown=myuser:myuser package*.json ./
-  RUN npm install
-  COPY --chown=myuser:myuser . ./
-  RUN npm run build
-  CMD ["node", "dist/main.js"]
-  ```
-
-  </details>
-
-- **Move `typescript` to `dependencies`**—keeps the single-stage Dockerfile but bloats the runtime image with the TypeScript compiler and its tooling. Runtime never uses these, so the extra size is wasted.
-  <details><summary>Example</summary>
-
-  ```json
-  {
-    "dependencies": {
-      "apify": "^3.4.0",
-      "typescript": "^5.5.0"
-    }
-  }
-  ```
-
-  </details>
-
-:::
-
 ### `package.json`
 
 The `package.json` file defines the `npm start` command:

--- a/sources/platform/actors/development/actor_definition/source_code.md
+++ b/sources/platform/actors/development/actor_definition/source_code.md
@@ -83,7 +83,7 @@ By copying the `package.json` and `package-lock.json` files and installing depen
 
 The Dockerfile above uses `--omit=dev`, which strips `typescript`. If your `build` script invokes `tsc`, the image build fails with `tsc: not found`. Three fixes:
 
-- **Multi-stage build** (smallest runtime image) — installs devDeps in a builder stage, copies the compiled output into a slim runtime stage. Most complex Dockerfile.
+- **Multi-stage build** (smallest runtime image)—installs devDeps in a builder stage, copies the compiled output into a slim runtime stage. Most complex Dockerfile.
   <details><summary>Example</summary>
 
   ```dockerfile
@@ -102,7 +102,7 @@ The Dockerfile above uses `--omit=dev`, which strips `typescript`. If your `buil
 
   </details>
 
-- **Drop `--omit=dev`** (simplest Dockerfile, largest runtime image) — installs everything, including linters and type declarations, into the single-stage image.
+- **Drop `--omit=dev`** (simplest Dockerfile, largest runtime image)—installs everything, including linters and type declarations, into the single-stage image.
   <details><summary>Example</summary>
 
   ```dockerfile
@@ -116,7 +116,7 @@ The Dockerfile above uses `--omit=dev`, which strips `typescript`. If your `buil
 
   </details>
 
-- **Move `typescript` to `dependencies`** — keeps the single-stage Dockerfile but adds ~30 MB to the runtime image (`typescript` ~23 MB + `tsx` + esbuild ~10 MB). Runtime never uses these, so the space is wasted.
+- **Move `typescript` to `dependencies`**—keeps the single-stage Dockerfile but bloats the runtime image with the TypeScript compiler and its tooling. Runtime never uses these, so the extra size is wasted.
   <details><summary>Example</summary>
 
   ```json

--- a/sources/platform/actors/development/actor_definition/source_code.md
+++ b/sources/platform/actors/development/actor_definition/source_code.md
@@ -79,29 +79,9 @@ By copying the `package.json` and `package-lock.json` files and installing depen
 
 :::
 
-:::warning TypeScript Actors and `npm install --omit=dev`
+:::warning TypeScript Actors
 
-If your Actor is written in TypeScript and its `package.json` `build` script invokes `tsc` (the TypeScript compiler), the JavaScript template's Dockerfile above will break the build inside the Docker image. `--omit=dev` drops `devDependencies` — including `typescript` — so `tsc` is not on `PATH` when the build script runs, and the whole image build fails with `sh: tsc: not found`.
-
-For TypeScript projects, either:
-
-1. Run the build **before** the production install (recommended — smaller final image):
-
-    ```dockerfile
-    FROM apify/actor-node:24 AS build
-    COPY --chown=myuser:myuser package*.json ./
-    RUN npm ci --include=dev
-    COPY --chown=myuser:myuser . ./
-    RUN npm run build
-    RUN npm prune --omit=dev
-
-    FROM apify/actor-node:24
-    COPY --from=build --chown=myuser:myuser /home/myuser ./
-    ```
-
-2. Or drop `--omit=dev` from the single-stage install and rely on `npm run build` succeeding because devDependencies are present.
-
-Symptoms of this trap: the remote build fails during the `RUN npm run build` step with `tsc: not found` (or `Cannot find module 'typescript'`) even though the code compiles locally. Every retry burns a build cycle, so it's worth catching in the Dockerfile itself.
+The Dockerfile above uses `--omit=dev`, which strips `typescript`. If your `build` script invokes `tsc`, the image build fails with `sh: tsc: not found` even though the code compiles locally. Use a multi-stage build (see the [`ts-empty` template's Dockerfile](https://github.com/apify/actor-templates/blob/master/templates/ts-empty/Dockerfile)) or drop `--omit=dev` from the single-stage install.
 
 :::
 

--- a/sources/platform/actors/development/actor_definition/source_code.md
+++ b/sources/platform/actors/development/actor_definition/source_code.md
@@ -83,9 +83,52 @@ By copying the `package.json` and `package-lock.json` files and installing depen
 
 The Dockerfile above uses `--omit=dev`, which strips `typescript`. If your `build` script invokes `tsc`, the image build fails with `tsc: not found`. Three fixes:
 
-- Use a multi-stage build: install with `--include=dev` in a builder stage, then copy the compiled output into a slim runtime stage.
-- Drop `--omit=dev` from the single-stage install.
-- Move `typescript` (and `tsx`, if used) from `devDependencies` to `dependencies`.
+- **Multi-stage build** (smallest runtime image) — installs devDeps in a builder stage, copies the compiled output into a slim runtime stage. Most complex Dockerfile.
+  <details><summary>Example</summary>
+
+  ```dockerfile
+  FROM apify/actor-node:24 AS builder
+  COPY --chown=myuser:myuser package*.json ./
+  RUN npm install --include=dev
+  COPY --chown=myuser:myuser . ./
+  RUN npm run build
+
+  FROM apify/actor-node:24
+  COPY --chown=myuser:myuser package*.json ./
+  RUN npm install --omit=dev --omit=optional
+  COPY --from=builder --chown=myuser:myuser /usr/src/app/dist ./dist
+  CMD ["node", "dist/main.js"]
+  ```
+
+  </details>
+
+- **Drop `--omit=dev`** (simplest Dockerfile, largest runtime image) — installs everything, including linters and type declarations, into the single-stage image.
+  <details><summary>Example</summary>
+
+  ```dockerfile
+  FROM apify/actor-node:24
+  COPY --chown=myuser:myuser package*.json ./
+  RUN npm install
+  COPY --chown=myuser:myuser . ./
+  RUN npm run build
+  CMD ["node", "dist/main.js"]
+  ```
+
+  </details>
+
+- **Move `typescript` to `dependencies`** — keeps the single-stage Dockerfile but adds ~30 MB to the runtime image (`typescript` ~23 MB + `tsx` + esbuild ~10 MB). Runtime never uses these, so the space is wasted.
+  <details><summary>Example</summary>
+
+  ```json
+  {
+    "dependencies": {
+      "apify": "^3.4.0",
+      "typescript": "^5.5.0"
+    }
+  }
+  ```
+
+  </details>
 
 :::
 

--- a/sources/platform/actors/development/actor_definition/source_code.md
+++ b/sources/platform/actors/development/actor_definition/source_code.md
@@ -79,6 +79,32 @@ By copying the `package.json` and `package-lock.json` files and installing depen
 
 :::
 
+:::warning TypeScript Actors and `npm install --omit=dev`
+
+If your Actor is written in TypeScript and its `package.json` `build` script invokes `tsc` (the TypeScript compiler), the JavaScript template's Dockerfile above will break the build inside the Docker image. `--omit=dev` drops `devDependencies` — including `typescript` — so `tsc` is not on `PATH` when the build script runs, and the whole image build fails with `sh: tsc: not found`.
+
+For TypeScript projects, either:
+
+1. Run the build **before** the production install (recommended — smaller final image):
+
+    ```dockerfile
+    FROM apify/actor-node:24 AS build
+    COPY --chown=myuser:myuser package*.json ./
+    RUN npm ci --include=dev
+    COPY --chown=myuser:myuser . ./
+    RUN npm run build
+    RUN npm prune --omit=dev
+
+    FROM apify/actor-node:24
+    COPY --from=build --chown=myuser:myuser /home/myuser ./
+    ```
+
+2. Or drop `--omit=dev` from the single-stage install and rely on `npm run build` succeeding because devDependencies are present.
+
+Symptoms of this trap: the remote build fails during the `RUN npm run build` step with `tsc: not found` (or `Cannot find module 'typescript'`) even though the code compiles locally. Every retry burns a build cycle, so it's worth catching in the Dockerfile itself.
+
+:::
+
 ### `package.json`
 
 The `package.json` file defines the `npm start` command:


### PR DESCRIPTION
## Summary

Adds a `:::warning` on `source_code.md` about the `npm install --omit=dev` + `tsc` build trap: `--omit=dev` drops `typescript`, so any TS Actor whose `build` invokes `tsc` fails at image-build time with `sh: tsc: not found`. Callout links to the ts-empty template's Dockerfile as the canonical multi-stage reference.

## Related — coordinated remediation stack

Four defense layers, each covering a different failure mode:

- [`apify/actor-templates`](https://github.com/apify/actor-templates) — ts-* Dockerfiles ship a multi-stage build (already in master via [#592](https://github.com/apify/actor-templates/pull/592), Dec 2025). Users of `apify create -t ts-*` cannot hit the trap.
- [`apify/apify-cli#1252`](https://github.com/apify/apify-cli/pull/1252) — `apify push` preflight warning when a Dockerfile has `--omit=dev` before `npm run build` that invokes `tsc`.
- [`apify/apify-cli#1261`](https://github.com/apify/apify-cli/pull/1261) — `apify create` forces `--include=dev` + `NODE_ENV=development` on the post-scaffold install, so `apify run` works locally.
- **This PR** — docs callout on the Source-code page for the direct-`docker build` / search-fallback case.

---

_Surfaced during an evaluation of Apify surfaces for agent-driven Actor development._