### PR TITLE
docs(auth): expand auth reference — add CLI + full MCP + Console interactive sections

### DIFF
--- a/sources/platform/integrations/programming/api.md
+++ b/sources/platform/integrations/programming/api.md
@@ -28,8 +28,86 @@ unless you fully understand the consequences! You can also consider  [limiting t
 
 You can authenticate the Apify API in two ways. You can either pass the token via the `Authorization` HTTP header or the URL `token` query parameter. We always recommend you use the authentication via the HTTP header as this method is more secure.
 
+Example using the HTTP header:
+
+```bash
+curl -H "Authorization: Bearer $APIFY_TOKEN" https://api.apify.com/v2/users/me
+```
+
 Note that some API endpoints, such as [Get list of keys](/api/v2/key-value-store-keys-get),
 do not require an authentication token because they contain a hard-to-guess identifier that effectively serves as an authentication key.
+
+### Apify CLI
+
+The [Apify CLI](/cli) authenticates against the same REST API using the same tokens described above. Running:
+
+```bash
+apify login
+```
+
+opens your browser and completes an OAuth flow with Apify Console. The resulting token is written to a local credentials file (typically `~/.apify/auth.json` on macOS and Linux, or `%USERPROFILE%\.apify\auth.json` on Windows). Subsequent `apify` commands read from this file automatically.
+
+For non-interactive environments (CI, containers, remote servers) pass the token explicitly. This bypasses the browser flow and is safe to script:
+
+```bash
+apify login --token "$APIFY_TOKEN"
+```
+
+The `APIFY_TOKEN` environment variable is also honored by many CLI subcommands and by the [JavaScript](/api/client/js/) and [Python](/api/client/python/) API clients, so exporting it once covers the CLI plus any client library your Actor code uses. If both `~/.apify/auth.json` and `APIFY_TOKEN` are present, the CLI prefers the credentials file for `apify` commands that require a logged-in user, so remember to `apify logout` before switching accounts on a shared machine.
+
+```bash
+export APIFY_TOKEN=apify_api_XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+apify call apify/rag-web-browser -i '{"query":"Apify"}'
+```
+
+### Apify MCP server
+
+The same API token authenticates the [Apify MCP server](/platform/integrations/mcp), which exposes Actors, storages, and platform actions as [Model Context Protocol](https://modelcontextprotocol.io) tools to compatible AI clients.
+
+There are two transports, both authenticated with the same token as the REST API:
+
+- _Hosted (`mcp.apify.com`)_ - streamable HTTP endpoint at `https://mcp.apify.com`. Supports two credential flows: an OAuth handshake that lets the client obtain a token without you pasting it, or an explicit `Authorization: Bearer <APIFY_TOKEN>` header. OAuth is the default and recommended path for interactive clients.
+- _Local stdio (`@apify/actors-mcp-server`)_ - the [npm package](https://www.npmjs.com/package/@apify/actors-mcp-server) runs the server as a child process and reads the token from the `APIFY_TOKEN` environment variable.
+
+Example `mcp.json` snippet compatible with Claude Code, Cursor, VS Code, Codex, and other MCP-aware clients:
+
+```json
+{
+  "mcpServers": {
+    "apify": {
+      "url": "https://mcp.apify.com"
+    }
+  }
+}
+```
+
+Or, for clients that only speak stdio (for example Claude Desktop):
+
+```json
+{
+  "mcpServers": {
+    "apify": {
+      "command": "npx",
+      "args": ["-y", "@apify/actors-mcp-server"],
+      "env": { "APIFY_TOKEN": "YOUR_TOKEN" }
+    }
+  }
+}
+```
+
+A token used with MCP grants the MCP server access to the same set of Apify endpoints it would grant to any other API caller - Actor runs, dataset reads, key-value stores, request queues, schedules, and so on - subject to any [scoped-token](#api-tokens-with-limited-permissions) restrictions you configured. Scoped tokens work transparently with the MCP server, so restricting a token to a single Actor and its output storages is a common pattern when handing a token to an AI agent.
+
+### Apify Console (interactive login)
+
+When you click _Log in_ on [console.apify.com](https://console.apify.com), the browser completes a session-based sign-in against Apify's console backend rather than issuing you an API token. The session is stored client-side in a first-party cookie scoped to the Console origin; it is not usable as an `Authorization: Bearer` value against the public REST API.
+
+To use API tokens after logging in interactively:
+
+1. Open [Settings > API & Integrations](https://console.apify.com/settings/integrations) in Apify Console.
+1. Create a new personal token (or copy an existing one). Give each token a descriptive label so you can later identify what integration it belongs to.
+1. Optionally set an [expiration date](#expiration) or [scope](#api-tokens-with-limited-permissions), then save.
+
+The same page is used to [rotate](#rotation) a token if it is compromised, or to revoke a token you no longer need. Tokens are shown in full only at creation time; treat the copied value like any other secret. For organization contexts, see [Organization accounts](#organization-accounts) for how personal versus organization tokens differ.
 
 ## Expiration
 


### PR DESCRIPTION
## Summary

The current [API integration](https://docs.apify.com/platform/integrations/api) page only describes REST-based authentication (HTTP header vs. `token` query param). Users who arrive via the CLI, the Apify MCP server, or the Console interactive login have no single reference explaining how their credential surface actually works.

This PR adds three subsections under the existing `## Authentication` heading — CLI, MCP, and Console interactive — without touching existing prose.

Draft finding: F13 (auth reference gap) from an internal docs sweep. Related upstream conversations: apify-cli #1246 (APIFY_TOKEN interaction with `~/.apify/auth.json`).

## What changes

Single file: `sources/platform/integrations/programming/api.md`.

- Adds a short `curl` example after the existing Authentication paragraph so the HTTP header form is concrete.
- Adds `### Apify CLI` — `apify login` OAuth flow, `~/.apify/auth.json` credentials file (macOS/Linux and Windows paths), non-interactive `apify login --token`, `APIFY_TOKEN` env var precedence.
- Adds `### Apify MCP server` — hosted `mcp.apify.com` (streamable HTTP + OAuth or bearer header), local stdio via `@apify/actors-mcp-server`, drop-in `mcp.json` snippets for Claude Code / Cursor / VS Code / Codex and for stdio-only clients (Claude Desktop), plus a note that scoped tokens transparently constrain MCP access.
- Adds `### Apify Console (interactive login)` — clarifies that browser sign-in yields a Console session cookie, not an API token, and walks through generating / scoping / rotating tokens on the Integrations settings page.

The new subsections cross-link to the existing `#expiration`, `#rotation`, `#organization-accounts`, and `#api-tokens-with-limited-permissions` sections so lifecycle information isn't duplicated.

## Test plan

- [ ] `markdownlint --config .markdownlint.json sources/platform/integrations/programming/api.md` passes (verified locally, exit 0).
- [ ] `pnpm start` renders the page and the three new anchors show up in the TOC.
- [ ] All fragment links in the new content resolve to existing headings on the same page.
- [ ] Preview build has no console warnings about broken internal links.
