### PR TITLE
docs(openapi): Autofix OpenAPI spec validation errors

### DIFF
--- a/apify-api/openapi/components/objects/datasets/dataset-items.yaml
+++ b/apify-api/openapi/components/objects/datasets/dataset-items.yaml
@@ -428,6 +428,10 @@ sharedPost: &sharedPost
             anyOf:
               - $ref: ../../schemas/datasets/PutItemResponseError.yaml
               - $ref: ../../schemas/common/ErrorResponse.yaml
+    "413":
+      $ref: ../../responses/PayloadTooLarge.yaml
+    "415":
+      $ref: ../../responses/UnsupportedMediaType.yaml
   deprecated: false
 
 postById:

--- a/apify-api/openapi/components/schemas/actor-builds/BuildStats.yaml
+++ b/apify-api/openapi/components/schemas/actor-builds/BuildStats.yaml
@@ -13,5 +13,5 @@ properties:
     type: number
     examples: [0.0126994444444444]
   imageSizeBytes:
-    type: integer
+    type: [integer, "null"]
     examples: [975770223]

--- a/apify-api/openapi/components/schemas/common/ErrorType.yaml
+++ b/apify-api/openapi/components/schemas/common/ErrorType.yaml
@@ -126,6 +126,7 @@ enum:
   - expired-conference-token
   - failed-to-charge-user
   - final-invoice-negative
+  - full-permission-actor-blocked-for-admin
   - full-permission-actor-not-approved
   - github-branch-empty
   - github-issue-already-exists

--- a/apify-api/openapi/components/schemas/users/Profile.yaml
+++ b/apify-api/openapi/components/schemas/users/Profile.yaml
@@ -2,22 +2,22 @@ title: Profile
 type: object
 properties:
   bio:
-    type: string
+    type: [string, "null"]
     examples: [I started web scraping in 1985 using Altair BASIC.]
   name:
     type: string
     examples: [Jane Doe]
   pictureUrl:
-    type: string
+    type: [string, "null"]
     format: uri
     examples: [https://apify.com/img/anonymous_user_picture.png]
   githubUsername:
-    type: string
+    type: [string, "null"]
     examples: [torvalds.]
   websiteUrl:
-    type: string
+    type: [string, "null"]
     format: uri
     examples: [http://www.example.com]
   twitterUsername:
-    type: string
+    type: [string, "null"]
     examples: ["@BillGates"]

--- a/apify-api/openapi/components/schemas/webhook-dispatches/WebhookDispatch.yaml
+++ b/apify-api/openapi/components/schemas/webhook-dispatches/WebhookDispatch.yaml
@@ -30,7 +30,6 @@ properties:
     type: [object, "null"]
     required:
       - actorId
-      - actorRunId
     properties:
       actorId:
         type: string
@@ -38,6 +37,12 @@ properties:
       actorRunId:
         type: string
         examples: [JgwXN9BdwxGcu9MMF]
+      actorBuildId:
+        type: string
+        examples: [HG7ML7M8z78YcAPEB]
+      actorTaskId:
+        type: [string, "null"]
+        examples: [zRLp8SDOZz2NyLg7K]
   webhook:
     anyOf:
       - $ref: ./WebhookDispatchWebhookSummary.yaml


### PR DESCRIPTION
## Summary
Auto-generated OpenAPI fixes suggestions based on validation errors reported by the OpenAPI validator running in staging apify-api.

**apify-core version:** https://github.com/apify/apify-core/tree/097f5cbed085ef8a99640a1004531b325b5c03f3

## Detailed changes description

### Error fixes

#### Nullable user profile fields
- **Files:** `apify-api/openapi/components/schemas/users/Profile.yaml:4-23`
- **Error:** `Response OpenAPI validation error {"errors":[{"errorCode":"type.openapi.validation","message":"must be string","path":"/response/data/profile/bio"},{"errorCode":"type.openapi.validation","message":"must be string","path":"/response/data/profile/githubUsername"}],"method":"GET","statusCode":200,"url":"/v2/users/{userId}"}` - also raised for `/profile/twitterUsername`, `/profile/websiteUrl` and `/profile/pictureUrl`, on both `GET /v2/users/{userId}` and `GET /v2/users/me` (~340 occurrences, ongoing through the end of the log window).
- **Root cause:** All profile fields are optional and a field cleared by the user is stored as `null`. `getProfileOfUser()` copies the stored `profile` values into the API response unchanged, so the API returns `bio: null`, `githubUsername: null`, etc., while the spec declared these five fields as non-nullable `string`. Changed them to `type: [string, "null"]`.
- **Reference:** https://github.com/apify/apify-core/blob/097f5cbed085ef8a99640a1004531b325b5c03f3/src/packages/users-server/src/profiles.ts#L34-L49

#### Webhook test dispatch `eventData` without `actorRunId`
- **Files:** `apify-api/openapi/components/schemas/webhook-dispatches/WebhookDispatch.yaml:28-46`
- **Error:** `Response OpenAPI validation error {"errors":[{"errorCode":"required.openapi.validation","message":"must have required property 'actorRunId'","path":"/response/data/eventData/actorRunId"}],"method":"POST","statusCode":201,"url":"/v2/webhooks/{webhookId}/test?token=[REDACTED]"}`
- **Root cause:** When a webhook is tested against a build resource, `processActorJobForWebhook()` produces `eventData = { actorId, actorBuildId }` - there is no `actorRunId` for build events. The `eventData` schema required both `actorId` and `actorRunId` and did not declare `actorBuildId` or `actorTaskId` at all (the run case produces `{ actorId, actorTaskId, actorRunId }`). Removed `actorRunId` from `required` (keeping `actorId`, which is present in both cases) and added the missing `actorBuildId` and `actorTaskId` properties.
- **Reference:** https://github.com/apify/apify-core/blob/097f5cbed085ef8a99640a1004531b325b5c03f3/src/packages/actor-server/src/actor_commons.ts#L246-L266

#### Nullable `imageSizeBytes` in build stats
- **Files:** `apify-api/openapi/components/schemas/actor-builds/BuildStats.yaml:15-16`
- **Error:** `Response OpenAPI validation error {"errors":[{"errorCode":"type.openapi.validation","message":"must be integer","path":"/response/data/stats/imageSizeBytes"},{"errorCode":"type.openapi.validation","message":"must be null","path":"/response/data/stats"},{"errorCode":"anyOf.openapi.validation","message":"must match a schema in anyOf","path":"/response/data/stats"}],"method":"POST","statusCode":200,"url":"/v2/actor-builds/{buildId}/abort"}`
- **Root cause:** Verified by live reproduction against production. Build stats have two writers: the finish path persists the worker's payload verbatim with `imageSizeBytes: null` (`finishActJob` / `updateActorJobRecordOnFinish` do `$set: { ...payload, finishedAt }` with no post-processing), and `actor-build-analyzer` overwrites it with the real integer computed from `dockerImageHistory` roughly 45 seconds later. Any read of the build in that window - in the logged case an abort that raced the build's completion within the same second (`finishedAt` `08:57:22.145Z`, abort logged `08:57:22`) and was served the just-finished document by the `if (actorJob.finishedAt) return actorJob` short-circuit - returns `"stats": { ..., "imageSizeBytes": null }`. Against `type: integer` the `null` produces exactly the three logged errors: `must be integer` on the field, plus `must be null` and `must match a schema in anyOf` on the parent `stats` (which validates as `anyOf` [`BuildStats`, `null`], and both branches fail). Reproduced end-to-end: a fresh build served `{"durationMillis": 1000, "runTimeSecs": 1, "computeUnits": 0.0011..., "imageSizeBytes": null}` from build success until the analyzer update replaced `null` with `531356672` at t+47s. Changed `imageSizeBytes` to `type: [integer, "null"]`.
- **Reference:** https://github.com/apify/apify-core/blob/097f5cbed085ef8a99640a1004531b325b5c03f3/src/packages/actor-server/src/actor_commons.ts#L375-L400

#### Missing `full-permission-actor-blocked-for-admin` in `ErrorType` enum
- **Files:** `apify-api/openapi/components/schemas/common/ErrorType.yaml:129`
- **Error:** `Response OpenAPI validation error {"errors":[{"errorCode":"enum.openapi.validation","message":"must be equal to one of the allowed values: 3d-secure-auth-failed, access-right-already-exists, action-not-foun...[truncated]","path":"/response/error/type"}],"method":"POST","statusCode":403,"url":"/v2/actors/{actorId}/runs"}`
- **Root cause:** The returned `error/type` value is not visible because the log line is truncated, so it was identified by exclusion: diffing all error types defined in apify-core (`newMeteorishError` calls in `src/packages/errors`) against the spec enum, the only type with status 403 that is thrown in the public run-start path (`validateUserCanRunActor`) and missing from the enum is `full-permission-actor-blocked-for-admin`, thrown when an admin account starts a full-permission Actor not managed by Apify. Added it to the enum.
- **Reference:** https://github.com/apify/apify-core/blob/097f5cbed085ef8a99640a1004531b325b5c03f3/src/packages/actor-server/src/actor_jobs/actor_jobs.server.ts#L793-L803

#### Missing 413 and 415 responses on dataset items POST endpoints
- **Files:** `apify-api/openapi/components/objects/datasets/dataset-items.yaml:431-434`
- **Error:** `Response OpenAPI validation error {"errors":[{"message":"no schema defined for status code '415' in the openapi spec","path":"/v2/datasets/{datasetId}/items?token=[REDACTED]"}],"method":"POST","statusCode":415,"url":"/v2/datasets/{datasetId}/items?token=[REDACTED]"}`
- **Root cause:** The API returns 415 `unsupported-content-encoding` when the express body-parser rejects the request's `Content-Encoding` (`encoding.unsupported` is transformed in the API error middleware), but the shared POST items definition declared no 415 response. Added `413` and `415` responses (both required for endpoints with `requestBody` by this repo's error-response guidelines) referencing the existing shared `PayloadTooLarge.yaml` and `UnsupportedMediaType.yaml` components. The shared `sharedPost` anchor propagates the fix to all four push-items operations (`dataset_items_post`, default/last-run/task-last-run variants).
- **Reference:** https://github.com/apify/apify-core/blob/097f5cbed085ef8a99640a1004531b325b5c03f3/src/api/src/middleware/error_transformer.ts#L27-L30

## Issues
- https://github.com/apify/apify-docs/issues/2286