### PR TITLE
docs(x402): drop allowsAgenticUsers store filter

### DIFF
--- a/sources/platform/integrations/ai/x402.md
+++ b/sources/platform/integrations/ai/x402.md
@@ -98,11 +98,11 @@ When using the API, replace the `/` in the Actor name with `~` (for example, `ap
 :::
 
 ```bash
-# Discover Actors approved for agentic payments
-curl -s "https://api.apify.com/v2/store?allowsAgenticUsers=true"
+# Discover Actors in the store
+curl -s "https://api.apify.com/v2/store"
 
 # Narrow the results with a search term
-curl -s "https://api.apify.com/v2/store?allowsAgenticUsers=true&search=instagram&limit=5"
+curl -s "https://api.apify.com/v2/store?search=instagram&limit=5"
 
 # Run an Actor and get its dataset items in one call
 curl -s -X POST \
@@ -138,12 +138,6 @@ Not all Actors in Apify Store can be run using agentic payments. To be eligible,
 - Use the [pay per event](/platform/actors/publishing/monetize/pay-per-event) pricing model. Rental and pay-per-usage Actors are not supported.
 - Run with [limited permissions](/platform/actors/development/permissions). Actors that request full permissions are excluded.
 - Not use [Standby](/platform/actors/running/standby) mode for now. Standby support is coming later.
-
-Apify maintains a curated list of Actors approved for agentic payments. To check if an Actor supports agentic payments, use the `allowsAgenticUsers=true` query parameter when [searching the store via API](https://docs.apify.com/api/v2#/reference/store/store-actors-collection/get-list-of-actors-in-store).
-
-```text
-https://api.apify.com/v2/store?allowsAgenticUsers=true
-```
 
 ## Token pricing and limits
 


### PR DESCRIPTION
## What
Remove all mentions of the `?allowsAgenticUsers=true` store query parameter from the x402 integration page. Store discovery examples now use plain store queries, and the paragraph describing the curated agentic-Actor filter is dropped.

## Why
We switched to the `agi.apify.com` approach for agentic payments. Filtering the store to only agent-approved Actors is no longer needed, so the query parameter is obsolete. The Actor eligibility requirements (pay-per-event, limited permissions, no Standby) remain documented.

## Testing
Docs-only change. Verified no `allowsAgenticUsers` references remain in the page via grep.