### PR TITLE
ci: skip rebuild and duplicate CloudFront invalidation on nginx.conf-only pushes

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -4,6 +4,9 @@ on:
     push:
         branches:
             - master
+        # nginx.conf is deployed and invalidated by deploy-nginx.yml; avoid a duplicate here.
+        paths-ignore:
+            - nginx.conf
     workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
A push touching only `nginx.conf` triggered both `docs.yaml` (fires on every master push → invalidates CloudFront) and `deploy-nginx.yml` (fires on the `nginx.conf` path → deploys nginx and invalidates), so the same distribution (`E35XFW5797FGPU`) was invalidated twice and the docs content was rebuilt for no reason. `paths-ignore: nginx.conf` here so `nginx.conf`-only commits are handled solely by the nginx deploy path, which invalidates after the rollout. A commit touching both still runs both paths by design; each invalidation is then correctly ordered against its own deploy.

Pairs with apify/apify-docs-private#79 (nginx pods now roll on config change, so the post-rollout invalidation actually picks up the new config).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
