### PR TITLE
docs: Delete duplicated content on payouts

### DIFF
--- a/sources/platform/actors/publishing/monetize/index.mdx
+++ b/sources/platform/actors/publishing/monetize/index.mdx
@@ -75,25 +75,6 @@ To be eligible for agentic payments, your Actor must:
 
 Actors that meet these criteria become available to agentic users automatically - there is no separate opt-in.
 
-## Monthly payouts and analytics
-
-Payout invoices are automatically generated on the 11th of each month, summarizing the profits from all your Actors for the previous month.
-In accordance with the [Terms & Conditions](/legal/store-publishing-terms-and-conditions), only funds from legitimate users who have already paid are included in the payout invoice.
-
-:::note How negative profits are handled
-
-If your PPE Actor's price doesn't cover its monthly platform usage costs, it will have a negative profit. When this occurs, we automatically set that Actor's profit to $0 for the month. This ensures a single Actor's loss never reduces your total payout.
-
-:::
-
-You have 3 days to review your payout invoice in the **Development >Insights > Payout** section. During this period, you can either approve the invoice or request a revision, which we will process promptly.
-If no action is taken, the payout will be automatically approved on the 14th, with funds disbursed shortly after. Payouts require meeting minimum thresholds of either:
-
-- $20 for PayPal
-- $100 for other payout methods
-
-If the monthly profit does not meet these thresholds, as per the [Terms & Conditions](/legal/store-publishing-terms-and-conditions), the funds will roll over to the next month until the threshold is reached.
-
 ## Handle free users
 
 When monetizing your Actor, you might want to limit features or usage for users on the Apify free plan. If you choose to do this, you _must_ handle it transparently:


### PR DESCRIPTION
[This PR](https://github.com/apify/apify-docs/pull/2622/changes) reintroduced a section that had been deleted and moved to `Manage payouts`.

Deleting the section once again.