### PR TITLE
docs(dataset-schema): distinguish top-level `fields` from `views.*.transformation.fields`

### DIFF
--- a/sources/platform/actors/development/actor_definition/dataset_schema/index.md
+++ b/sources/platform/actors/development/actor_definition/dataset_schema/index.md
@@ -35,6 +35,17 @@ A dataset schema has two components:
 }
 ```
 
+### The two `fields` keys
+
+The schema uses two different keys named `fields`. They live in different places and do different jobs — populate both.
+
+| Location | Type | Purpose |
+| --- | --- | --- |
+| Top-level `fields` | [JSON Schema](https://json-schema.org/) object keyed by field name (under `properties`) | Describes each item's structure. Drives server-side validation, MCP schema discovery for AI agents, and the documented API contract. |
+| `views.<viewId>.transformation.fields` | Flat array of field name strings | Selects which columns appear in the Console Output tab and their order. Display-only. |
+
+A common mistake is to populate only `views.overview.transformation.fields` and leave the top-level `fields` empty. Console still renders the selected columns, but validation and the MCP / API schema have nothing to work from. The example under [Schema components](#schema-components) above shows both keys populated together; see [Fields](#fields) below for the full field-metadata example.
+
 ## File structure
 
 Place the dataset schema in the `.actor` folder in your Actor's root directory. You can organize it in two ways:


### PR DESCRIPTION
## Summary

The [Dataset schema specification](https://docs.apify.com/platform/actors/development/actor-definition/dataset-schema) page defines two different keys named `fields`, but does not contrast them explicitly:

- Top-level `fields` — a [JSON Schema](https://json-schema.org/) object keyed by field name (under `properties`). Drives server-side validation, MCP schema discovery for AI agents, and the documented API contract.
- `views.<viewId>.transformation.fields` — a flat array of field name strings. Selects which columns appear in the Console Output tab and their order. Display-only.

Because the two keys share a name and the page introduces them in separate sections, it is easy to populate only the view-level array. Console then still renders the selected columns, so the mistake looks harmless — but validation, the MCP schema, and the API metadata have no schema to work from.

## What this PR changes

Adds a short `### The two \`fields\` keys` subsection under `## Schema components`. The subsection:

- Names both locations and tables their type and purpose side by side.
- Calls out the common mistake (populating only the view-level array).
- Links back to the top-of-page example (which already populates both) and forward to the fuller `## Fields` example.

No content is removed; the existing structure is unchanged.

## Reproducer for the confusion

Following the page in order, a reader hits the `views.*.transformation.fields` array before reaching the top-level `fields` section, and often writes only the view-level array. For example:

```json title=".actor/dataset_schema.json"
{
    "actorSpecification": 1,
    "views": {
        "overview": {
            "title": "Overview",
            "transformation": { "fields": ["title", "price"] },
            "display": { "component": "table" }
        }
    }
}
```

This validates and renders in Console, but the Actor exposes no field-level schema for validation, the MCP server, or the API contract that downstream agents rely on. The intended shape has both keys populated (as in the page's own top-of-file example), and the new subsection makes that requirement explicit up front.

## Test plan

- [ ] Read the updated page top to bottom — the distinction between the two `fields` locations is clear after one pass.
- [ ] The top-of-page example under `## Schema components` still shows both keys populated (unchanged), and the new subsection references it.
- [ ] `pnpm start` renders the new subsection with the table formatted correctly and the two intra-page links resolving.

_Surfaced during an evaluation of Apify surfaces for agent-driven Actor development._