### PR TITLE
docs(playwright): warn against playwright install-deps without root

### DIFF
--- a/sources/platform/actors/development/actor_definition/docker.md
+++ b/sources/platform/actors/development/actor_definition/docker.md
@@ -35,6 +35,19 @@ These images come with Node.js (versions `20`, `22`, or `24`) the [Apify SDK for
 
 See the [Docker image guide](/sdk/js/docs/guides/docker-images) for more details.
 
+:::note Testing Playwright Actors locally
+
+The `actor-node-playwright-*` base images already include all the system libraries Playwright needs (`libnss3`, `libatk1.0-0`, and so on). When developing locally, do **not** run `npx playwright install-deps` &mdash; it requires `sudo` and will fail with an error like `su: must be suid to work properly` in unprivileged environments (containers, restricted shells, CI runners without root).
+
+To iterate on a Playwright Actor without a local `sudo`-capable shell, either:
+
+- Rely on the browsers and libraries pre-installed in the base image and run your Actor inside Docker (`apify run` builds and executes it in the image), or
+- Push your Actor to Apify with `apify push` and run it remotely &mdash; the platform build already has the required system dependencies.
+
+Only `npx playwright install` (which downloads browser binaries into your user directory) is safe to run without root.
+
+:::
+
 ### Python base images
 
 These images come with Python (version `3.9`, `3.10`, `3.11`, `3.12`, or `3.13`) and the [Apify SDK for Python](/sdk/python) preinstalled. The `latest` tag corresponds to the latest Python 3 version supported by the Apify SDK.


### PR DESCRIPTION
## Summary

Add a note in the Dockerfile reference explaining that users developing a Playwright Actor locally should **not** run `npx playwright install-deps`. That command requires `sudo`, and in unprivileged environments (agent sandboxes, restricted shells, some CI runners) it fails with a cryptic error and blocks the user from making progress.

The `apify/actor-node-playwright-*` base images already include every system library Playwright needs, so the workaround is just: rely on the base image via `apify run`, or push to Apify and run remotely.

## Rationale

When a user new to Playwright follows the Playwright docs verbatim and runs the recommended local setup command:

```
$ npx playwright install-deps
BEWARE: your OS is not officially supported by Playwright; installing dependencies for Ubuntu Jammy (22.04) LTS as a fallback.
Switching to root user to install dependencies...
su: must be suid to work properly
Failed to install browser dependencies
```

...they hit a dead end. Nothing in the current [Dockerfile docs](https://docs.apify.com/platform/actors/development/actor-definition/dockerfile) tells them that this step is redundant when using an Apify base image. Adding one small note under the "Node.js base images" section prevents the whole class of "Playwright won't install locally" support questions.

## Change

`sources/platform/actors/development/actor_definition/docker.md` &mdash; add a `:::note` admonition immediately below the Node.js base images table, covering:

- Base images already ship `libnss3`, `libatk1.0-0`, etc.
- `playwright install-deps` requires root and will fail as shown above in unprivileged environments.
- Preferred paths: `apify run` (uses the base image) or `apify push` + run remotely.
- `npx playwright install` (browser binaries only, user-owned dir) is still fine.

## Test plan

- [ ] Docs page renders the new admonition below the Node.js base images table.
- [ ] Links (`apify run`, `apify push`) resolve to the CLI reference.
- [ ] No typos flagged by `typos.toml`.

_Surfaced during an evaluation of Apify surfaces for agent-driven Actor development._