### PR TITLE
docs(storage): document CRAWLEE_STORAGE_DIR for local file-backed storage

### DIFF
--- a/sources/platform/storage/dataset.md
+++ b/sources/platform/storage/dataset.md
@@ -192,10 +192,10 @@ Additionally the SDK offers other methods like [`getData()`](/sdk/js/reference/c
 If you have chosen to store your dataset locally, you can find it in the location below.
 
 ```text
-{APIFY_LOCAL_STORAGE_DIR}/datasets/{DATASET_ID}/{INDEX}.json
+{CRAWLEE_STORAGE_DIR}/datasets/{DATASET_ID}/{INDEX}.json
 ```
 
-`DATASET_ID` refers to the dataset's _name_ or _ID_. The default dataset will be stored in the _default_ directory.
+`DATASET_ID` refers to the dataset's _name_ or _ID_. The default dataset will be stored in the _default_ directory. See [Key-value store](/platform/storage/key-value-store#javascript-sdk) for the `CRAWLEE_STORAGE_DIR` environment variable that controls this path when you run the Actor outside `apify run`.
 
 To add data to the default dataset, you can use the example below:
 

--- a/sources/platform/storage/key_value_store.md
+++ b/sources/platform/storage/key_value_store.md
@@ -151,10 +151,20 @@ Every Actor run is linked to a default key-value store that is automatically cre
 You can find _INPUT.json_ and other key-value store files in the location below.
 
 ```text
-{APIFY_LOCAL_STORAGE_DIR}/key_value_stores/{STORE_ID}/{KEY}.{EXT}
+{CRAWLEE_STORAGE_DIR}/key_value_stores/{STORE_ID}/{KEY}.{EXT}
 ```
 
 The default key-value store's ID is _default_. The `{KEY}` is the record's _key_ and `{EXT}` corresponds to the record value's MIME content type.
+
+:::info Local storage directory
+
+When you run an Actor locally through `apify run`, the CLI sets `CRAWLEE_STORAGE_DIR=./storage` in the Actor's process. If you launch your entry point directly (for example, `tsx src/main.ts` or `node dist/main.js`), you need to set the variable yourself — otherwise the SDK falls back to the platform client and fails with `ApifyApiError: Authentication token was not provided` when it tries to reach `api.apify.com`. Setting `APIFY_IS_AT_HOME=0` on its own is not enough; the SDK still needs `CRAWLEE_STORAGE_DIR` to know where the file-backed storage lives.
+
+```bash
+CRAWLEE_STORAGE_DIR=./storage tsx src/main.ts
+```
+
+:::
 
 To manage your key-value stores, you can use the following methods. See the `KeyValueStore` class's [API reference](/sdk/js/reference/class/KeyValueStore) for the full list.
 

--- a/sources/platform/storage/request_queue.md
+++ b/sources/platform/storage/request_queue.md
@@ -159,10 +159,10 @@ Every Actor run is automatically linked with a default request queue, initiated 
 If you are storing your data locally, you can find your request queue at the following location.
 
 ```text
-{APIFY_LOCAL_STORAGE_DIR}/request_queues/{QUEUE_ID}/{ID}.json
+{CRAWLEE_STORAGE_DIR}/request_queues/{QUEUE_ID}/{ID}.json
 ```
 
-The default request queue's ID is _default_. Each request in the queue is stored as a separate JSON file, where `{ID}` is a request ID.
+The default request queue's ID is _default_. Each request in the queue is stored as a separate JSON file, where `{ID}` is a request ID. See [Key-value store](/platform/storage/key-value-store#javascript-sdk) for the `CRAWLEE_STORAGE_DIR` environment variable that controls this path when you run the Actor outside `apify run`.
 
 To open a request queue, use the [`Actor.openRequestQueue()`](/sdk/js/reference/class/Actor#openRequestQueue) method.
 


### PR DESCRIPTION
## Summary

The JavaScript SDK sections of the storage pages refer to `{APIFY_LOCAL_STORAGE_DIR}` as the placeholder for the local storage root. That variable is no longer respected by Apify SDK v3 — it reads `CRAWLEE_STORAGE_DIR` (inherited from Crawlee v3). `apify run` sets it automatically (see `src/commands/run.ts` in `apify-cli`), so users staying on the CLI never see the mismatch. But users who launch their compiled entry point directly (`tsx src/main.ts`, `node dist/main.js`, unit tests, IDE run configurations, ...) get bitten.

## Reproducer

```bash
# Fresh Actor scaffolded from a TypeScript template
apify create my-actor -t js-crawlee-cheerio-ts  # or any v3-based template
cd my-actor

# Run the compiled entry point directly, bypassing `apify run`
APIFY_IS_AT_HOME=0 APIFY_LOCAL_STORAGE_DIR=./storage tsx src/main.ts
```

Expected: the SDK persists the default key-value store / dataset / request queue under `./storage`.

Actual:

```
ApifyApiError: Authentication token was not provided
    path: /v2/key-value-stores
```

The SDK ignores `APIFY_LOCAL_STORAGE_DIR`, treats storage as unconfigured, and falls back to the platform HTTP client — which then fails because no `APIFY_TOKEN` was provided. Setting `APIFY_IS_AT_HOME=0` on its own is not enough. The fix is:

```bash
CRAWLEE_STORAGE_DIR=./storage tsx src/main.ts
```

Nothing in the docs points to `CRAWLEE_STORAGE_DIR`, so the only way to discover it today is to grep `node_modules/@apify/*` or `node_modules/@crawlee/*`.

## Changes

- `sources/platform/storage/key_value_store.md` — JS SDK section: rename the path placeholder to `{CRAWLEE_STORAGE_DIR}` and add an info callout explaining the env var, the failure mode, and a working example.
- `sources/platform/storage/dataset.md` — JS SDK section: rename the path placeholder and cross-link to the callout.
- `sources/platform/storage/request_queue.md` — JS SDK section: same.

The Python SDK sections are left untouched — the Python SDK uses a different storage backend and env var, and this issue is JS-specific.

## Test plan

- [ ] `pnpm build` (or the docs preview) renders the three pages without broken links or admonition errors.
- [ ] Follow the `CRAWLEE_STORAGE_DIR=./storage tsx src/main.ts` example on a fresh v3 template and confirm files land under `./storage/key_value_stores/default/`.

_Surfaced during an evaluation of Apify surfaces for agent-driven Actor development._