### PR TITLE
fix(openapi): add MCP to RunOrigin enum

### DIFF
--- a/apify-api/openapi/components/schemas/actor-runs/RunOrigin.yaml
+++ b/apify-api/openapi/components/schemas/actor-runs/RunOrigin.yaml
@@ -11,3 +11,4 @@ enum:
   - CLI
   - CI
   - STANDBY
+  - MCP


### PR DESCRIPTION
## What

Add `MCP` to the `RunOrigin` enum in the OpenAPI spec.

The Apify MCP server starts Actor runs with `meta.origin: "MCP"`, but the spec's `RunOrigin` enum doesn't list that value. As a result, generated typed clients reject any such run during validation. `apify-shared-js` already includes `MCP`, so the spec is the last place still missing it.

## Why

This is the root cause of apify/apify-sdk-python#1032. Every Python Actor invoked via the Apify MCP server crashes at startup, before user code runs, because the generated `apify-client` model validates `meta.origin` against a strict enum that has no `MCP` member.

Fixing the enum here propagates down the chain:

- `apify-client-python` regenerates its models from this spec (`docs.apify.com/api/openapi.json`), so `RunOrigin` picks up `MCP`.
- The Python SDK then accepts MCP-triggered runs once it uses the regenerated client.

Follows the same pattern as #2559, which added `CI` to the same enum.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
