### PR TITLE
docs(openapi): Autofix OpenAPI spec validation errors

### DIFF
--- a/apify-api/openapi/components/objects/datasets/dataset-items.yaml
+++ b/apify-api/openapi/components/objects/datasets/dataset-items.yaml
@@ -93,6 +93,8 @@ sharedGet: &sharedGet
           example: <items><item><foo>bar</foo></item><item><foo2>bar2</foo2></item></items>
     "400":
       $ref: ../../responses/BadRequest.yaml
+    "402":
+      $ref: ../../responses/PaymentRequired.yaml
   deprecated: false
 
 listById:

--- a/apify-api/openapi/components/objects/datasets/dataset-statistics.yaml
+++ b/apify-api/openapi/components/objects/datasets/dataset-statistics.yaml
@@ -10,6 +10,8 @@ sharedGet: &sharedGet
       $ref: ../../responses/BadRequest.yaml
     "401":
       $ref: ../../responses/Unauthorized.yaml
+    "402":
+      $ref: ../../responses/PaymentRequired.yaml
     "403":
       $ref: ../../responses/Forbidden.yaml
     "404":

--- a/apify-api/openapi/components/objects/datasets/dataset.yaml
+++ b/apify-api/openapi/components/objects/datasets/dataset.yaml
@@ -52,6 +52,8 @@ sharedTaskLastRun: &sharedTaskLastRun
 sharedGet: &sharedGet
   responses:
     <<: [*common200, *commonErrors]
+    "402":
+      $ref: ../../responses/PaymentRequired.yaml
   deprecated: false
 
 getById:

--- a/apify-api/openapi/components/objects/key-value-stores/key-value-store-keys.yaml
+++ b/apify-api/openapi/components/objects/key-value-stores/key-value-store-keys.yaml
@@ -31,6 +31,8 @@ sharedTagTaskLastRun: &sharedTagTaskLastRun
 sharedGet: &sharedGet
   responses:
     <<: *commonErrors
+    "402":
+      $ref: ../../responses/PaymentRequired.yaml
     "200":
       description: ""
       headers: {}

--- a/apify-api/openapi/components/objects/key-value-stores/key-value-store-record.yaml
+++ b/apify-api/openapi/components/objects/key-value-stores/key-value-store-record.yaml
@@ -31,6 +31,8 @@ sharedTagTaskLastRun: &sharedTagTaskLastRun
 sharedGet: &sharedGet
   responses:
     <<: *commonErrors
+    "402":
+      $ref: ../../responses/PaymentRequired.yaml
     "200":
       description: ""
       headers: {}

--- a/apify-api/openapi/components/objects/key-value-stores/key-value-store.yaml
+++ b/apify-api/openapi/components/objects/key-value-stores/key-value-store.yaml
@@ -52,6 +52,8 @@ sharedTaskLastRun: &sharedTaskLastRun
 sharedGet: &sharedGet
   responses:
     <<: [*common200, *commonErrors]
+    "402":
+      $ref: ../../responses/PaymentRequired.yaml
   deprecated: false
 
 getById:

--- a/apify-api/openapi/components/objects/request-queues/request-queue-head.yaml
+++ b/apify-api/openapi/components/objects/request-queues/request-queue-head.yaml
@@ -37,6 +37,8 @@ sharedGet: &sharedGet
         application/json:
           schema:
             $ref: ../../schemas/request-queues/HeadResponse.yaml
+    "402":
+      $ref: ../../responses/PaymentRequired.yaml
     <<: *commonErrors
   deprecated: false
 

--- a/apify-api/openapi/components/objects/request-queues/request-queue-request.yaml
+++ b/apify-api/openapi/components/objects/request-queues/request-queue-request.yaml
@@ -37,6 +37,8 @@ sharedGet: &sharedGet
         application/json:
           schema:
             $ref: ../../schemas/request-queues/RequestResponse.yaml
+    "402":
+      $ref: ../../responses/PaymentRequired.yaml
     <<: *commonErrors
   deprecated: false
 

--- a/apify-api/openapi/components/objects/request-queues/request-queue-requests.yaml
+++ b/apify-api/openapi/components/objects/request-queues/request-queue-requests.yaml
@@ -37,6 +37,8 @@ sharedGet: &sharedGet
         application/json:
           schema:
             $ref: ../../schemas/request-queues/ListOfRequestsResponse.yaml
+    "402":
+      $ref: ../../responses/PaymentRequired.yaml
     <<: *commonErrors
   deprecated: false
 

--- a/apify-api/openapi/components/objects/request-queues/request-queue.yaml
+++ b/apify-api/openapi/components/objects/request-queues/request-queue.yaml
@@ -52,6 +52,8 @@ sharedTaskLastRun: &sharedTaskLastRun
 sharedGet: &sharedGet
   responses:
     <<: [*common200, *commonErrors]
+    "402":
+      $ref: ../../responses/PaymentRequired.yaml
   deprecated: false
 
 getById:

--- a/apify-api/openapi/components/schemas/actor-runs/RunOptions.yaml
+++ b/apify-api/openapi/components/schemas/actor-runs/RunOptions.yaml
@@ -24,9 +24,9 @@ properties:
     examples: [2048]
   maxItems:
     type: [integer, "null"]
-    minimum: 1
+    minimum: 0
     examples: [1000]
   maxTotalChargeUsd:
-    type: number
+    type: [number, "null"]
     minimum: 0
     examples: [5]

--- a/apify-api/openapi/components/schemas/actors/Actor.yaml
+++ b/apify-api/openapi/components/schemas/actors/Actor.yaml
@@ -94,7 +94,7 @@ properties:
     type: [string, "null"]
     examples: ["https://my-actor.apify.actor"]
   notice:
-    type: string
+    type: [string, "null"]
     examples: [NONE]
   categories:
     type: array

--- a/apify-api/openapi/components/schemas/key-value-stores/KeyValueStoreStats.yaml
+++ b/apify-api/openapi/components/schemas/key-value-stores/KeyValueStoreStats.yaml
@@ -2,8 +2,6 @@ title: KeyValueStoreStats
 required:
   - readCount
   - writeCount
-  - deleteCount
-  - listCount
 type: object
 properties:
   readCount:

--- a/apify-api/openapi/components/schemas/store/StoreListActor.yaml
+++ b/apify-api/openapi/components/schemas/store/StoreListActor.yaml
@@ -5,7 +5,6 @@ required:
   - name
   - username
   - stats
-  - currentPricingInfo
 type: object
 properties:
   id:
@@ -34,7 +33,7 @@ properties:
       - MARKETING
       - LEAD_GENERATION
   notice:
-    type: string
+    type: [string, "null"]
   pictureUrl:
     type: [string, "null"]
     format: uri

--- a/apify-api/openapi/components/schemas/users/UserPrivateInfo.yaml
+++ b/apify-api/openapi/components/schemas/users/UserPrivateInfo.yaml
@@ -1,7 +1,6 @@
 title: UserPrivateInfo
 required:
   - username
-  - proxy
   - plan
   - effectivePlatformFeatures
   - isPaying

--- a/apify-api/openapi/components/schemas/webhooks/Webhook.yaml
+++ b/apify-api/openapi/components/schemas/webhooks/Webhook.yaml
@@ -45,7 +45,7 @@ properties:
     type: [boolean, "null"]
     examples: [false]
   requestUrl:
-    type: string
+    type: [string, "null"]
     format: uri
     examples: ["http://example.com/"]
   payloadTemplate:

--- a/apify-api/openapi/paths/actor-tasks/actor-tasks@{actorTaskId}@run-sync-get-dataset-items.yaml
+++ b/apify-api/openapi/paths/actor-tasks/actor-tasks@{actorTaskId}@run-sync-get-dataset-items.yaml
@@ -67,6 +67,8 @@ get:
       $ref: ../../components/responses/BadRequest.yaml
     "401":
       $ref: ../../components/responses/Unauthorized.yaml
+    "402":
+      $ref: ../../components/responses/PaymentRequired.yaml
     "403":
       $ref: ../../components/responses/Forbidden.yaml
     "404":
@@ -175,6 +177,8 @@ post:
       $ref: ../../components/responses/BadRequest.yaml
     "401":
       $ref: ../../components/responses/Unauthorized.yaml
+    "402":
+      $ref: ../../components/responses/PaymentRequired.yaml
     "403":
       $ref: ../../components/responses/Forbidden.yaml
     "404":

--- a/apify-api/openapi/paths/actor-tasks/actor-tasks@{actorTaskId}@runs.yaml
+++ b/apify-api/openapi/paths/actor-tasks/actor-tasks@{actorTaskId}@runs.yaml
@@ -133,6 +133,8 @@ post:
       $ref: ../../components/responses/BadRequest.yaml
     "401":
       $ref: ../../components/responses/Unauthorized.yaml
+    "402":
+      $ref: ../../components/responses/PaymentRequired.yaml
     "403":
       $ref: ../../components/responses/Forbidden.yaml
     "404":

--- a/apify-api/openapi/paths/actors/acts@{actorId}@builds@default.yaml
+++ b/apify-api/openapi/paths/actors/acts@{actorId}@builds@default.yaml
@@ -25,6 +25,9 @@ get:
             $ref: ../../components/schemas/actor-builds/BuildResponse.yaml
     "400":
       $ref: ../../components/responses/BadRequest.yaml
+    "401":
+      # Although the endpoint does not require a token, the API still validates any token that is supplied and returns 401 for an invalid one.
+      $ref: ../../components/responses/Unauthorized.yaml
     "403":
       # It should be 404, but is 403 for backwards compatibility. https://github.com/apify/apify-core/pull/17414
       $ref: ../../components/responses/Forbidden.yaml

--- a/apify-api/openapi/paths/actors/acts@{actorId}@run-sync-get-dataset-items.yaml
+++ b/apify-api/openapi/paths/actors/acts@{actorId}@run-sync-get-dataset-items.yaml
@@ -87,6 +87,8 @@ post:
               myOtherValue: some other value
     "400":
       $ref: ../../components/responses/BadRequest.yaml
+    "401":
+      $ref: ../../components/responses/Unauthorized.yaml
     "402":
       $ref: ../../components/responses/PaymentRequired.yaml
     "403":

--- a/apify-api/openapi/paths/store/store.yaml
+++ b/apify-api/openapi/paths/store/store.yaml
@@ -115,6 +115,8 @@ get:
             $ref: ../../components/schemas/store/ListOfActorsInStoreResponse.yaml
     "400":
       $ref: ../../components/responses/BadRequest.yaml
+    "401":
+      $ref: ../../components/responses/Unauthorized.yaml
     "405":
       $ref: ../../components/responses/MethodNotAllowed.yaml
     "429":


### PR DESCRIPTION
## Summary
Autogenerated OpenAPI fixes suggestions based on validation errors generated from running API integration tests with OpenAPI validator turned on.

**Error log:** Production OpenAPI response-validation errors from `apify-api` (Jul 8, 2026)

**apify-core version:** https://github.com/apify/apify-core/commit/abeddcb4b7b3dee66ea2169435153144dae91c19


## Detailed changes description
### Error fixes

#### Missing 402 on Actor task run endpoints
**Files:** `apify-api/openapi/paths/actor-tasks/actor-tasks@{actorTaskId}@runs.yaml` (`post.responses`), `apify-api/openapi/paths/actor-tasks/actor-tasks@{actorTaskId}@run-sync-get-dataset-items.yaml` (`get.responses`, `post.responses`)
**Error:** `no schema defined for status code '402' in the openapi spec` (POST `/v2/actor-tasks/{actorTaskId}/runs`, GET `/v2/actor-tasks/{actorTaskId}/run-sync-get-dataset-items`)
**Root cause:** Task run creation goes through run-limit checks that throw `notEnoughUsageToRunPaidActor` / memory / concurrency errors with HTTP 402. Both run-sync variants launch a run and hit the same checks.
**Reference:** https://github.com/apify/apify-core/tree/abeddcb4b7b3dee66ea2169435153144dae91c19/src/packages/actor-server/src/actor_jobs/run_limits_helper.ts#L194

#### Missing 402 on storage read endpoints (x402 payment reuse)
**Files:** `apify-api/openapi/components/objects/datasets/dataset.yaml`, `.../datasets/dataset-statistics.yaml`, `.../datasets/dataset-items.yaml`, `.../key-value-stores/key-value-store.yaml`, `.../key-value-stores/key-value-store-keys.yaml`, `.../key-value-stores/key-value-store-record.yaml`, `.../request-queues/request-queue.yaml`, `.../request-queues/request-queue-head.yaml`, `.../request-queues/request-queue-requests.yaml`, `.../request-queues/request-queue-request.yaml` (all in the shared GET response blocks)
**Error:** `no schema defined for status code '402' in the openapi spec` (observed on GET `/v2/datasets/{datasetId}/items`; applies to storage reads generally)
**Root cause:** The agentic-payment middleware runs on every request, but only emits 402 when the caller participates in x402 payment. A *new* x402 payment must be initiated on an Actor execution route; *reusing* an already-initiated payment to read a run's results is permitted on any route, and the reuse check returns 402 on a non-execution (storage) route. Consequently any storage GET (read) can return 402. 402 was added to the shared GET blocks of datasets, key-value stores, and request queues - read operations only, not writes - which also covers the default and last-run storage variants (e.g. `/v2/actor-runs/{runId}/dataset/items`).
**Reference:** https://github.com/apify/apify-core/tree/abeddcb4b7b3dee66ea2169435153144dae91c19/src/packages/agentic-payments/src/x402/x402_client.ts#L873

#### Missing 401 on `POST /v2/actors/{actorId}/run-sync-get-dataset-items`
**Files:** `apify-api/openapi/paths/actors/acts@{actorId}@run-sync-get-dataset-items.yaml` (`post.responses`)
**Error:** `no schema defined for status code '401' in the openapi spec` (POST `/v2/actors/{actorId}/run-sync-get-dataset-items`)
**Root cause:** The operation inherits global bearer/api-key security; an invalid token is rejected with 401 by the auth middleware. The GET sibling already documented 401, the POST did not.
**Reference:** https://github.com/apify/apify-core/tree/abeddcb4b7b3dee66ea2169435153144dae91c19/src/api/src/routes/routes_config.ts#L648

#### Missing 401 on `GET /v2/store`
**Files:** `apify-api/openapi/paths/store/store.yaml` (`get.responses`)
**Error:** `no schema defined for status code '401' in the openapi spec` (GET `/v2/store`)
**Root cause:** The global auth middleware validates any supplied token before the route runs, so passing an invalid token to store search returns 401.
**Reference:** https://github.com/apify/apify-core/tree/abeddcb4b7b3dee66ea2169435153144dae91c19/src/api/src/middleware/authentication.ts#L91

#### Missing 401 on `GET /v2/actors/{actorId}/builds/default`
**Files:** `apify-api/openapi/paths/actors/acts@{actorId}@builds@default.yaml` (`get.responses`)
**Error:** `no schema defined for status code '401' in the openapi spec` (GET `/v2/actors/{actorId}/builds/default`)
**Root cause:** Although the endpoint does not require a token (`security: []`), the auth middleware still validates any token that is supplied and returns 401 for an invalid one - the same reason the file already documents 403. `security: []` is left unchanged; only the response is documented.
**Reference:** https://github.com/apify/apify-core/tree/abeddcb4b7b3dee66ea2169435153144dae91c19/src/api/src/routes/routes_config.ts#L521

#### `options.maxTotalChargeUsd` must be nullable
**Files:** `apify-api/openapi/components/schemas/actor-runs/RunOptions.yaml`
**Error:** `type.openapi.validation: must be number` at `/response/data/options/maxTotalChargeUsd` (POST `/v2/actor-runs/{runId}/abort`)
**Root cause:** `maxTotalChargeUsd` is an optional run option that is only stored when truthy, so runs created without it surface `null`. Changed to `type: [number, "null"]` to match the sibling `maxItems` field.
**Reference:** https://github.com/apify/apify-core/tree/abeddcb4b7b3dee66ea2169435153144dae91c19/src/packages/schemas/src/actors.ts#L97

#### `options.maxItems` minimum lowered to 0
**Files:** `apify-api/openapi/components/schemas/actor-runs/RunOptions.yaml`
**Error:** `minimum.openapi.validation: must be >= 1` at `/response/data/options/maxItems` (POST `/v2/actor-runs/{runId}/resurrect`)
**Root cause:** The API defines `maxItems` with min 0 and treats `0` as a valid sentinel; the spec's `minimum: 1` was stricter than the API. Lowered to `0`.
**Reference:** https://github.com/apify/apify-core/tree/abeddcb4b7b3dee66ea2169435153144dae91c19/src/packages/schemas/src/actors.ts#L94

#### `stats.deleteCount` / `stats.listCount` no longer required
**Files:** `apify-api/openapi/components/schemas/key-value-stores/KeyValueStoreStats.yaml`
**Error:** `required.openapi.validation: must have required property 'deleteCount'` / `'listCount'` at `/response/data/stats` (POST `/v2/key-value-stores`)
**Root cause:** The stats serializer picks only present fields and the DB marks every counter optional, so a pre-existing (get-or-create) store can omit `deleteCount`/`listCount`. Removed them from `required`.
**Reference:** https://github.com/apify/apify-core/tree/abeddcb4b7b3dee66ea2169435153144dae91c19/src/api/src/lib/key_value_stores.ts#L682

#### `proxy` no longer required on `GET /v2/users/me`
**Files:** `apify-api/openapi/components/schemas/users/UserPrivateInfo.yaml`
**Error:** `required.openapi.validation: must have required property 'proxy'` at `/response/data/proxy` (GET `/v2/users/me`)
**Root cause:** `proxy` is only attached when the user has proxy `USE` permission; otherwise the key is omitted. Removed from `required`.
**Reference:** https://github.com/apify/apify-core/tree/abeddcb4b7b3dee66ea2169435153144dae91c19/src/api/src/routes/users/user.ts#L84

#### `requestUrl` must be nullable
**Files:** `apify-api/openapi/components/schemas/webhooks/Webhook.yaml`
**Error:** `type.openapi.validation: must be string` at `/response/data/requestUrl` (GET `/v2/webhooks/{webhookId}`, POST `/v2/webhooks`)
**Root cause:** `requestUrl` is modeled as nullish and is only meaningful for HTTP-request webhooks; other action types (Slack, email, etc.) return `null`. Changed to `type: [string, "null"]`.
**Reference:** https://github.com/apify/apify-core/tree/abeddcb4b7b3dee66ea2169435153144dae91c19/src/packages/zod-types/src/common/webhooks.ts#L57

#### `currentPricingInfo` no longer required on store items
**Files:** `apify-api/openapi/components/schemas/store/StoreListActor.yaml`
**Error:** `required.openapi.validation: must have required property 'currentPricingInfo'` at `/response/data/items/{i}/currentPricingInfo` (GET `/v2/store`)
**Root cause:** The Recombee-backed store search maps items without a `currentPricingInfo` field, so it is not guaranteed. Removed from `required`.
**Reference:** https://github.com/apify/apify-core/tree/abeddcb4b7b3dee66ea2169435153144dae91c19/src/packages/actor-server/src/recombee/recombee_store_search.ts#L183

#### `notice` must be nullable (store items and actor)
**Files:** `apify-api/openapi/components/schemas/store/StoreListActor.yaml`, `apify-api/openapi/components/schemas/actors/Actor.yaml`
**Error:** `type.openapi.validation: must be string` at `/response/data/items/{i}/notice` (GET `/v2/store`) and `/response/data/notice` (GET `/v2/actors/{actorId}`)
**Root cause:** `notice` is modeled as `string | null` in the data layer and coalesced to `null` when absent. Made nullable in both (independent) schemas.
**Reference:** https://github.com/apify/apify-core/tree/abeddcb4b7b3dee66ea2169435153144dae91c19/src/packages/types/src/recombee.ts#L34

## Issues
Partially implements: https://github.com/apify/apify-docs/issues/2286
