### PR TITLE
fix: only show subnavbar in mobile menu when path matches its regex

### DIFF
--- a/apify-docs-theme/src/theme/Navbar/MobileSidebar/PrimaryMenu/index.jsx
+++ b/apify-docs-theme/src/theme/Navbar/MobileSidebar/PrimaryMenu/index.jsx
@@ -1,4 +1,5 @@
-import { useThemeConfig } from '@docusaurus/theme-common';
+import { useLocation } from '@docusaurus/router';
+import { isRegexpStringMatch, useThemeConfig } from '@docusaurus/theme-common';
 import useBaseUrl from '@docusaurus/useBaseUrl';
 import { usePluginData } from '@docusaurus/useGlobalData';
 import NavbarItem from '@theme/NavbarItem';
@@ -18,9 +19,11 @@ export default function NavbarMobilePrimaryMenu() {
     const {
         options: { subNavbar },
     } = usePluginData('@apify/docs-theme');
+    const location = useLocation();
+    const showSubNavbar = subNavbar && (!subNavbar?.pathRegex || isRegexpStringMatch(subNavbar.pathRegex, location.pathname));
     return (
         <>
-            {subNavbar ? (
+            {showSubNavbar ? (
                 <>
                     <ul
                         className="menu__list"

--- a/apify-docs-theme/src/theme/Navbar/MobileSidebar/PrimaryMenu/index.jsx
+++ b/apify-docs-theme/src/theme/Navbar/MobileSidebar/PrimaryMenu/index.jsx
@@ -20,7 +20,8 @@ export default function NavbarMobilePrimaryMenu() {
         options: { subNavbar },
     } = usePluginData('@apify/docs-theme');
     const location = useLocation();
-    const showSubNavbar = subNavbar && (!subNavbar?.pathRegex || isRegexpStringMatch(subNavbar.pathRegex, location.pathname));
+    const showSubNavbar =
+        subNavbar && (!subNavbar?.pathRegex || isRegexpStringMatch(subNavbar.pathRegex, location.pathname));
     return (
         <>
             {showSubNavbar ? (


### PR DESCRIPTION
Mobile menu ignored subNavbar.pathRegex, unlike desktop, so it showed on every page.

Fixes #2757