### PR TITLE
docs(openapi): Autofix OpenAPI spec validation errors

### DIFF
--- a/apify-api/openapi/components/objects/actor-runs/resurrect.yaml
+++ b/apify-api/openapi/components/objects/actor-runs/resurrect.yaml
@@ -12,6 +12,8 @@ sharedResurrect: &sharedResurrect
       $ref: ../../responses/BadRequest.yaml
     "401":
       $ref: ../../responses/Unauthorized.yaml
+    "402":
+      $ref: ../../responses/PaymentRequired.yaml
     "403":
       $ref: ../../responses/Forbidden.yaml
     "404":

--- a/apify-api/openapi/components/schemas/actor-builds/BuildStats.yaml
+++ b/apify-api/openapi/components/schemas/actor-builds/BuildStats.yaml
@@ -1,6 +1,4 @@
 title: BuildStats
-required:
-  - computeUnits
 type: object
 properties:
   durationMillis:

--- a/apify-api/openapi/components/schemas/actor-runs/RunStats.yaml
+++ b/apify-api/openapi/components/schemas/actor-runs/RunStats.yaml
@@ -1,8 +1,4 @@
 title: RunStats
-required:
-  - restartCount
-  - resurrectCount
-  - computeUnits
 type: object
 properties:
   inputBodyLen:

--- a/apify-api/openapi/components/schemas/key-value-stores/KeyValueStoreStats.yaml
+++ b/apify-api/openapi/components/schemas/key-value-stores/KeyValueStoreStats.yaml
@@ -1,7 +1,4 @@
 title: KeyValueStoreStats
-required:
-  - readCount
-  - writeCount
 type: object
 properties:
   readCount:

--- a/apify-api/openapi/components/schemas/webhooks/WebhookStats.yaml
+++ b/apify-api/openapi/components/schemas/webhooks/WebhookStats.yaml
@@ -1,6 +1,4 @@
 title: WebhookStats
-required:
-  - totalDispatches
 type: object
 properties:
   totalDispatches:

--- a/apify-api/openapi/paths/actor-tasks/actor-tasks@{actorTaskId}@run-sync-get-dataset-items.yaml
+++ b/apify-api/openapi/paths/actor-tasks/actor-tasks@{actorTaskId}@run-sync-get-dataset-items.yaml
@@ -185,6 +185,8 @@ post:
       $ref: ../../components/responses/NotFound.yaml
     "405":
       $ref: ../../components/responses/MethodNotAllowed.yaml
+    "408":
+      $ref: ../../components/responses/Timeout.yaml
     "413":
       $ref: ../../components/responses/PayloadTooLarge.yaml
     "415":

--- a/apify-api/openapi/paths/actors/acts@{actorId}@run-sync-get-dataset-items.yaml
+++ b/apify-api/openapi/paths/actors/acts@{actorId}@run-sync-get-dataset-items.yaml
@@ -177,6 +177,8 @@ get:
       $ref: ../../components/responses/BadRequest.yaml
     "401":
       $ref: ../../components/responses/Unauthorized.yaml
+    "402":
+      $ref: ../../components/responses/PaymentRequired.yaml
     "403":
       $ref: ../../components/responses/Forbidden.yaml
     "404":


### PR DESCRIPTION
## Summary
Autogenerated OpenAPI fixes suggestions based on validation errors generated from running API integration tests with OpenAPI validator turned on.

**apify-core version:** https://github.com/apify/apify-core/tree/a300e63c18aaa9ae0b8cbaa334adf8a1fb8ad163

## Detailed changes description
### Error fixes

#### `402` on actor `run-sync-get-dataset-items` (GET)
- **Files:** `apify-api/openapi/paths/actors/acts@{actorId}@run-sync-get-dataset-items.yaml` (GET responses)
- **Error:** `no schema defined for status code '402' in the openapi spec` - `GET /v2/actors/{actorId}/run-sync-get-dataset-items`
- **Root cause:** Starting a run (memory or concurrency limit exceeded, or not enough remaining usage to run a paid Actor) throws a payment-required error defined with HTTP status `402` before the run can start. The spec did not declare `402` for this endpoint.
- **Reference:** https://github.com/apify/apify-core/tree/a300e63c18aaa9ae0b8cbaa334adf8a1fb8ad163/src/packages/errors/src/errors/actor.ts#L33

#### `402` on run `resurrect` (POST)
- **Files:** `apify-api/openapi/components/objects/actor-runs/resurrect.yaml`
- **Error:** `no schema defined for status code '402' in the openapi spec` - `POST /v2/actor-runs/{runId}/resurrect`
- **Root cause:** Resurrecting a run re-runs the same quota and payment checks as starting a run and can therefore return the same `402` payment-required error.
- **Reference:** https://github.com/apify/apify-core/tree/a300e63c18aaa9ae0b8cbaa334adf8a1fb8ad163/src/api/src/routes/actor_runs/run_resurrect.ts

#### `408` on actor-task `run-sync-get-dataset-items` (POST)
- **Files:** `apify-api/openapi/paths/actor-tasks/actor-tasks@{actorTaskId}@run-sync-get-dataset-items.yaml` (POST responses)
- **Error:** `no schema defined for status code '408' in the openapi spec` - `POST /v2/actor-tasks/{actorTaskId}/run-sync-get-dataset-items`
- **Root cause:** A synchronous run that does not reach a terminal status within the endpoint wait limit throws `runTimeoutExceeded`, which is defined with HTTP status `408`. The spec did not declare `408` for this endpoint.
- **Reference:** https://github.com/apify/apify-core/tree/a300e63c18aaa9ae0b8cbaa334adf8a1fb8ad163/src/api/src/routes/actor_tasks/run_sync_dataset.ts#L53

#### Missing `readCount` on key-value store stats (POST, 200)
- **Files:** `apify-api/openapi/components/schemas/key-value-stores/KeyValueStoreStats.yaml`
- **Error:** `must have required property 'readCount'` - `POST /v2/key-value-stores` (`/response/data/stats/readCount`)
- **Root cause:** All store stats fields are optional in apify-core and the API serializes only fields that already exist; a freshly created store has no `readCount` yet, so it is absent from the response. The spec incorrectly marked `readCount` (and the other counters) required, matching neither the DB schema nor the sibling `DatasetStats`/`RequestQueueStats` schemas which mark nothing required.
- **Reference:** https://github.com/apify/apify-core/tree/a300e63c18aaa9ae0b8cbaa334adf8a1fb8ad163/src/api/src/lib/key_value_stores.ts#L680

### Refactoring
Generalized the key-value store stats fix to the other stats schemas whose counters are optional and lazily populated in apify-core, so the same `must have required property` validation error cannot occur for run, build and webhook stats:

- `apify-api/openapi/components/schemas/actor-runs/RunStats.yaml` - drop `required: [restartCount, resurrectCount, computeUnits]`
- `apify-api/openapi/components/schemas/actor-builds/BuildStats.yaml` - drop `required: [computeUnits]`
- `apify-api/openapi/components/schemas/webhooks/WebhookStats.yaml` - drop `required: [totalDispatches]`

Root cause is identical to the key-value store case - these counters are declared optional in the apify-core stats sub-documents, so requiring them in the spec makes valid responses fail response validation. Reference: https://github.com/apify/apify-core/tree/a300e63c18aaa9ae0b8cbaa334adf8a1fb8ad163/src/packages/schemas/src/key_value_stores.ts#L90

## Issues
Partially implements: https://github.com/apify/apify-docs/issues/2286