### PR TITLE
docs: add missing `TEST`, `CI`, and `MCP` run origins to origin table

### DIFF
--- a/sources/platform/actors/running/runs_and_builds.md
+++ b/sources/platform/actors/running/runs_and_builds.md
@@ -65,9 +65,12 @@ Both **Actor runs** and **builds** have the **Origin** field indicating how the 
 |`API`|From [Apify API](https://docs.apify.com/api)|
 |`CLI`|From [Apify CLI](https://docs.apify.com/cli/)|
 |`SCHEDULER`|Using a schedule|
+|`TEST`|From the Actor's test page in Apify Console|
 |`WEBHOOK`|Using a webhook|
 |`ACTOR`|From another Actor run|
 |`STANDBY`|From [Actor Standby](./standby)|
+|`CI`|From a CI/CD pipeline (for example, GitHub Actions)|
+|`MCP`|From the [Apify MCP Server](https://docs.apify.com/integrations/mcp)|
 
 ## Lifecycle
 


### PR DESCRIPTION
Updates the origin table with the new origin types (see [apify-shared-js](https://github.com/apify/apify-shared-js/blob/84114f76085c30ae780798f23cd9c8f9e3e6a8f2/packages/consts/src/consts.ts#L67) for source).

[Discussed on Slack](https://apify.slack.com/archives/CGZSN9DQC/p1783938506578589)