### PR TITLE
docs: Update best practices for PPE Actors and mention negative profit

### DIFF
--- a/sources/platform/actors/publishing/monetize/pay_per_event.mdx
+++ b/sources/platform/actors/publishing/monetize/pay_per_event.mdx
@@ -129,6 +129,14 @@ The Apify platform enforces this limit. Once it's reached, `Actor.charge()` and 
 
 To protect your profits, finish the Actor run once charges reach the user's limit.
 
+:::tip Set a minimum for the user limit
+
+To prevent users from setting the maximum cost for the run too low, set the minimum value during the [monetization setup](/actors/publishing/monetize#set-up-monetization). For example, you can use it to cover the price of starting the Actor and producing one result.
+
+The minimum value is stored by the `minimalMaxTotalChargeUsd` property.
+
+:::
+
 For both custom and synthetic events, Apify SDKs return a `ChargeResult` from every `Actor.charge()` and `Actor.pushData()` call. The user spending limit is available in your Actor code as the `ACTOR_MAX_TOTAL_CHARGE_USD` [environment variable](/actors/development/programming-interface/environment-variables), and `ChargeResult` already accounts for it. Inspect its properties to decide when to stop the run:
 
 | Property | Description |
@@ -139,14 +147,14 @@ For both custom and synthetic events, Apify SDKs return a `ChargeResult` from ev
 
 :::caution The limit is per run, not per user
 
-`ACTOR_MAX_TOTAL_CHARGE_USD` and the `ChargeResult` limit apply to a single run. If a user starts many runs at once, your aggregate platform costs can grow beyond what a single run's limit suggests. To protect your profit, [set memory limits](#memory-limits) and keep per-event platform costs low.
+`ACTOR_MAX_TOTAL_CHARGE_USD` and the `ChargeResult` limit apply to a single run, not to a user's total spending. If a user starts many runs at once, your combined platform costs across all runs can grow beyond what a single run's limit suggests. To protect your profit, [set memory limits](#memory-limits) and keep per-event platform costs low.
 
 :::
 
 Make sure to:
 
-- Charge for work as soon as it's done, not in a large batch at the end. If the run is stops early, unbilled work is lost.
-- Prefer charging one unit at a time over batching with `count`, so a partial charge can't leave produced results unpaid.
+- Charge for work as soon as it's done, not in a large batch at the end. If the run stops early, produced results don't get charged.
+- Charge for results after they're saved and available for users. Don't bill users for what they can't access, for example if a run gets aborted.
 - Finish the run once `eventChargeLimitReached` is `true`.
 
 :::tip Consider using `ChargingManager`
@@ -289,7 +297,7 @@ Apify recommends using the synthetic `apify-actor-start` event in all Actors. It
 
 The `apify-actor-start` synthetic event works as follows:
 
-- It's enabled by default for all new PPE Actors. For existing Actors, you can enable it in Apify Console.
+- It's available by default for all new PPE Actors. For existing Actors, you can enable it in Apify Console.
 - Apify automatically charges the event. Don't manually charge the event in your Actor code, as it will fail.
 - The default price of the event is $0.00005, which equals to $0.05 per 1,000 starts. To keep your Actor competitive, Apify recommends keeping the default price.
 - The number of events charged depends on the amount of memory allocated to the run. Up to and including 1 GB of RAM, the event is charged once. Then, it's charged once for each extra GB of memory. For example:

--- a/sources/platform/actors/publishing/monetize/pay_per_event.mdx
+++ b/sources/platform/actors/publishing/monetize/pay_per_event.mdx
@@ -125,7 +125,7 @@ You can also call the [Charge events in run](/api/v2/post-charge-run) API endpoi
 
 Your Actor users can set the maximum cost for the run in Apify Console or with the API. It helps users control their spending, as they won't be billed beyond the limit.
 
-The Apify platform enforces this limit. Once it's reached, `Actor.charge()` and `Actor.pushData()` stop charging and pushing data, but your Actor keeps running, consuming platform resources, and producing results that are no longer billed.
+The Apify platform enforces this limit. Once it's reached, `Actor.charge()` stop charging and `Actor.pushData()` stops pushing data over the limit. The platform then aborts the run automatically. However, the run keeps consuming platform resources for a short time before it stops. For details, see [Handle graceful shutdown](#handle-graceful-shutdown).
 
 To protect your profits, finish the Actor run once charges reach the user's limit.
 
@@ -137,7 +137,12 @@ The minimum value is stored by the `minimalMaxTotalChargeUsd` property.
 
 :::
 
-For both custom and synthetic events, Apify SDKs return a `ChargeResult` from every `Actor.charge()` and `Actor.pushData()` call. The user spending limit is available in your Actor code as the `ACTOR_MAX_TOTAL_CHARGE_USD` [environment variable](/actors/development/programming-interface/environment-variables), and `ChargeResult` already accounts for it. Inspect its properties to decide when to stop the run:
+The user spending limit is available in your Actor code as the `ACTOR_MAX_TOTAL_CHARGE_USD` [environment variable](/actors/development/programming-interface/environment-variables), and `ChargeResult` already accounts for it. Returning a `ChargeResult` depends on the event type:
+
+- For custom events, `Actor.charge()` and `Actor.pushData()` called with an event name always return a `ChargeResult`.
+- For synthetic events, pushing datasets items is charged automatically. In the Python SDK, `Actor.pushData()` returns a `ChargeResult`. In the JavaScript SDK, `Actor.pushData()` called without an event name returns `void`.
+
+Inspect the `ChargeResult` properties to decide when to stop the run:
 
 | Property | Description |
 | --- | --- |
@@ -226,7 +231,7 @@ When using [Crawlee](https://crawlee.dev/), use `crawler.autoscaledPool.abort()`
 
 ### Handle graceful shutdown
 
-When a user gracefully aborts a run, the platform sends the `aborting` event and force-stops the run 30 seconds later. Use this window to bill for work already done, so an abort doesn't cost you the revenue.
+When a platform or user gracefully aborts a run, the platform sends the `aborting` event and force-stops the run 30 seconds later. Use this window to bill for work already done, so an abort doesn't cost you the revenue.
 
 Apify SDKs already handle the graceful shutdown for you. They listen for `aborting` and call `Actor.exit()` automatically. Register your own `aborting` handler to:
 

--- a/sources/platform/actors/publishing/monetize/pay_per_event.mdx
+++ b/sources/platform/actors/publishing/monetize/pay_per_event.mdx
@@ -38,7 +38,7 @@ You define the events and can set different pricing for each of them.
 
 ### Synthetic events
 
-Sythetic events cover the most common billing patterns. They're predefined by Apify and charged automatically:
+Synthetic events cover the most common billing patterns. They're predefined by Apify and charged automatically:
 
 - [`apify-actor-start`](#synthetic-start-event) covers the costs spent during the first 5 seconds of starting the Actor.
 - [`apify-default-dataset-item`](#synthetic-default-dataset-item-event) charges for each item written to the run's default dataset.
@@ -71,6 +71,7 @@ Only revenue and cost for Apify customers on paid plans are taken into considera
 To make your Actor profitable, price your events so that the revenue covers the platform costs. For details, see [Compute costs for PPE Actors](/actors/publishing/monetize/pricing-and-costs#compute-costs).
 
 If your Actor produces negative profit, make sure to:
+
 - [Set memory limits](#memory-limits).
 - [Respect user spending limits](#respect-user-spending-limits).
 - Enable the [`apify-actor-start` synthetic event](#synthetic-start-event).
@@ -131,7 +132,7 @@ To protect your profits, finish the Actor run once charges reach the user's limi
 For both custom and synthetic events, Apify SDKs return a `ChargeResult` from every `Actor.charge()` and `Actor.pushData()` call. The user spending limit is available in your Actor code as the `ACTOR_MAX_TOTAL_CHARGE_USD` [environment variable](/actors/development/programming-interface/environment-variables), and `ChargeResult` already accounts for it. Inspect its properties to decide when to stop the run:
 
 | Property | Description |
-|----------|-------------|
+| --- | --- |
 | `eventChargeLimitReached` | Checks if the user's limit allows for another charge of the event. |
 | `chargeableWithinLimit` | Indicates how many more of each event you can still charge within the remaining budget. Use it if you have multiple events. |
 | `chargedCount` | Indicates how many events were billed by the call. For batch charges (`count`), it can be lower than you requested. Charges above `chargedCount` are not billed. |

--- a/sources/platform/actors/publishing/monetize/pay_per_event.mdx
+++ b/sources/platform/actors/publishing/monetize/pay_per_event.mdx
@@ -1,31 +1,24 @@
 ---
-title: Pay per event
+title: Pay per event pricing model
 description: Learn how to monetize your Actor with pay-per-event (PPE) pricing, charging users for specific actions like Actor starts, dataset items, or API calls.
 slug: /actors/publishing/monetize/pay-per-event
 sidebar_position: 1.1
+sidebar_label: Pay per event
 ---
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-The pay per event (PPE) pricing model offers a flexible monetization option for Actors on Apify Store:
 
-- You can charge users based on specific events triggered programmatically by your Actor's code. Common events include starting an Actor, creating a dataset item, or calling an external API.
-- You can define different pricing for individual events.
-- You can charge for specific events directly from your Actor using the [JS](/sdk/js/reference/class/Actor#charge) or [Python](/sdk/python/reference/class/Actor#charge) SDK, or by calling the [PPE charging API](/api/v2/post-charge-run) directly.
+The pay per event (PPE) pricing model offers a flexible monetization option for Actors on Apify Store. The key benefits are:
 
-See the key benefits of the PPE pricing model:
-
-| Category | Pay per event (PPE) |
-| --- | --- |
-| Revenue scalability | Unlimited, scales with usage |
-| AI/MCP compatibility | ✅ Fully compatible |
-| User cost predictability | Predictable |
-| Store discounts | ✅ Store discounts available |
-| Marketing boost | Priority store placement |
-| Commission opportunities | Standard 20% |
-| Custom event billing | ✅ Charge for any event |
-| Per-result billing | Optional (via event; automatic via `apify-default-dataset-item`) |
+- Unlimited revenue scalability
+- AI/MCP compatibility
+- Predictable user costs
+- Store discounts
+- Standard 20% commission
+- Custom event billing
+- Per-result billing (optional)
 
 :::tip Additional benefits
 
@@ -33,29 +26,67 @@ Actors that implement PPE pricing receive additional benefits, including increas
 
 :::
 
-## How is profit computed
+## About events
 
-Your profit is calculated from the mentioned formula:
+An event is a specific, measurable action that your Actor triggers programmatically and charges the user for. The most common events include:
+
+- Starting an Actor.
+- Creating a dataset item.
+- Calling an external API.
+
+You define the events and can set different pricing for each of them.
+
+### Synthetic events
+
+Sythetic events cover the most common billing patterns. They're predefined by Apify and charged automatically:
+
+- [`apify-actor-start`](#synthetic-start-event) covers the costs spent during the first 5 seconds of starting the Actor.
+- [`apify-default-dataset-item`](#synthetic-default-dataset-item-event) charges for each item written to the run's default dataset.
+
+You can adjust or remove synthetic events in Apify Console.
+
+### Custom events
+
+To charge users for the unique value that your Actor delivers, define custom events. You name each event, describe it, set its price, and charge it from your Actor's code.
+
+### Get event names
+
+To retrieve the list of all chargeable event names for your Actor, use the [Get Actor](/api/v2/act-get) API endpoint.
+
+## Calculate your profit
+
+Your profit is calculated from the following formula:
 
 `profit = (0.8 * revenue) - platform costs`
 
 where:
 
-- _Revenue_: The amount charged for events via the PPE charging API or through JS/Python SDK. You receive 80% of this revenue.
-- _Platform costs_: The underlying platform usage costs for running the Actor. For more details, visit the [Computing your costs for PPE Actors](/actors/publishing/monetize/pricing-and-costs#computing-your-costs-for-ppe-actors) section.
+- `revenue` is the amount charged for events through the PPE charging API or JS/Python SDK. You receive 80% of this revenue.
+- `platform costs` are the underlying platform usage costs for running the Actor. For details, see [Compute costs for PPE Actors](/actors/publishing/monetize/pricing-and-costs#compute-costs).
 
-Only revenue and cost for Apify customers on paid plans are taken into consideration when computing your profit. Users on free plans are not reflected there.
+Only revenue and cost for Apify customers on paid plans are taken into consideration when computing your profit. Users on free plans aren't reflected there.
+
+### Avoid negative profit
+
+To make your Actor profitable, price your events so that the revenue covers the platform costs. For details, see [Compute costs for PPE Actors](/actors/publishing/monetize/pricing-and-costs#compute-costs).
+
+If your Actor produces negative profit, make sure to:
+- [Set memory limits](#memory-limits).
+- [Respect user spending limits](#respect-user-spending-limits).
+- Enable the [`apify-actor-start` synthetic event](#synthetic-start-event).
+
+When testing your Actor pricing, you can also temporarily [pass platform usage costs on to users](#platform-usage-costs).
 
 :::note Negative profit isolation
 
-An Actor's negative net profit does not affect the positive profit of another Actor. For aggregation purposes, any Actor with a negative net profit is considered to have a profit of $0.
+An Actor's negative net profit doesn't affect the positive profit of another Actor. For aggregation purposes, an Actor with a negative net profit is considered to have a profit of $0.
 
-- _Previously:_ `Total Profit = (-$90) + $100 = $10`
-- _Now:_ `Total Profit = $0 + $100 = $100`
+- Before: `Total profit = (-$90) + $100 = $10`
+- Now: `Total profit = $0 + $100 = $100`
 
 :::
 
-## How to set pricing for PPE Actors
+## Set pricing for PPE Actors
 
 1. _Understand your costs_: Analyze resource usage (e.g CPU, memory, proxies, external APIs) and identify cost drivers
 1. _Define clear events_: break your Actor's functionality into measurable, chargeable events.
@@ -81,16 +112,45 @@ To pass platform usage costs on to users, in the **Actor pricing** step of the [
 
 Turning this option on takes 14 days to take effect. However, you can turn it off immediately, as it is a positive change for users.
 
-## Respect user spending limits
+## Best practices
 
-Finish the Actor run once charging reaches user-configured maximum cost per run. Apify SDKs (JS and Python) return `ChargeResult` that helps determine when to finish.
+To simplify PPE implementation into you Actor, use the [Apify SDKs](/sdk). They help you handle pricing, usage tracking, idempotency keys, API errors, and event charging through an API. Without the SDKs, you must handle API integration and possible edge cases manually.
 
-The `eventChargeLimitReached` property checks if the user's limit allows for another charge of this event. If you have multiple events, analyze the `chargeableWithinLimit` property to see if other events can still be charged before stopping the Actor.
+To implement event charging with the Apify CLI, use the [`apify actor charge`](/cli/docs/reference#apify-actor-charge) command.
 
-:::info ACTOR_MAX_TOTAL_CHARGE_USD environment variable
+You can also call the [Charge events in run](/api/v2/post-charge-run) API endpoint directly.
 
-All pricing models support a spending limit set through the Apify Console or API. This limit is available in your Actor code as the `ACTOR_MAX_TOTAL_CHARGE_USD` [environment variable](/actors/development/programming-interface/environment-variables), which contains the user's maximum total cost for the run.
-The Apify SDK's `ChargeResult` respects the user set limit already.
+### Respect user spending limits
+
+Your Actor users can set the maximum cost for the run in Apify Console or with the API. It helps users control their spending, as they won't be billed beyond the limit.
+
+The Apify platform enforces this limit. Once it's reached, `Actor.charge()` and `Actor.pushData()` stop charging and pushing data, but your Actor keeps running, consuming platform resources, and producing results that are no longer billed.
+
+To protect your profits, finish the Actor run once charges reach the user's limit.
+
+For both custom and synthetic events, Apify SDKs return a `ChargeResult` from every `Actor.charge()` and `Actor.pushData()` call. The user spending limit is available in your Actor code as the `ACTOR_MAX_TOTAL_CHARGE_USD` [environment variable](/actors/development/programming-interface/environment-variables), and `ChargeResult` already accounts for it. Inspect its properties to decide when to stop the run:
+
+| Property | Description |
+|----------|-------------|
+| `eventChargeLimitReached` | Checks if the user's limit allows for another charge of the event. |
+| `chargeableWithinLimit` | Indicates how many more of each event you can still charge within the remaining budget. Use it if you have multiple events. |
+| `chargedCount` | Indicates how many events were billed by the call. For batch charges (`count`), it can be lower than you requested. Charges above `chargedCount` are not billed. |
+
+:::caution The limit is per run, not per user
+
+`ACTOR_MAX_TOTAL_CHARGE_USD` and the `ChargeResult` limit apply to a single run. If a user starts many runs at once, your aggregate platform costs can grow beyond what a single run's limit suggests. To protect your profit, [set memory limits](#memory-limits) and keep per-event platform costs low.
+
+:::
+
+Make sure to:
+
+- Charge for work as soon as it's done, not in a large batch at the end. If the run is stops early, unbilled work is lost.
+- Prefer charging one unit at a time over batching with `count`, so a partial charge can't leave produced results unpaid.
+- Finish the run once `eventChargeLimitReached` is `true`.
+
+:::tip Consider using `ChargingManager`
+
+If charging happens in multiple places across your code, or when you use a crawler where you don't directly control the main loop, you can use the `ChargingManager` to check the remaining budget periodically instead of inspecting every `ChargeResult`.
 
 :::
 
@@ -151,42 +211,92 @@ async def main():
 
 :::note Crawlee integration and spending limits
 
-When using [Crawlee](https://crawlee.dev/), use `crawler.autoscaledPool.abort()` instead of `Actor.exit()` to gracefully finish the crawler and allow the rest of your code to process normally.
+When using [Crawlee](https://crawlee.dev/), use `crawler.autoscaledPool.abort()` instead of `Actor.exit()` to gracefully finish the crawler and let the rest of your code run normally.
 
 :::
 
-## Best practices for PPE Actors
+### Handle graceful shutdown
 
-Use the [Apify SDKs](/sdk) (JS or Python) or the [`apify actor charge`](/cli/docs/next/reference#apify-actor-charge-eventname) when using the Apify CLI to simplify PPE implementation into your Actor. SDKs help you handle pricing, usage tracking, idempotency keys, API errors, and, event charging via an API. You can also choose not to use it, but then you must handle API integration and possible edge cases manually.
+When a user gracefully aborts a run, the platform sends the `aborting` event and force-stops the run 30 seconds later. Use this window to bill for work already done, so an abort doesn't cost you the revenue.
 
-### Use synthetic start event `apify-actor-start` {#synthetic-start-event}
+Apify SDKs already handle the graceful shutdown for you. They listen for `aborting` and call `Actor.exit()` automatically. Register your own `aborting` handler to:
+
+- Charge for completed but unbilled work with `Actor.charge()`.
+- Push buffered results with `Actor.pushData()`.
+- Persist state so a resurrected run can resume instead of redoing paid work.
+- Close open resources, such as browsers, database connections, or files.
+
+Your handler runs alongside the SDK's, and `Actor.exit()` waits for all event listeners to finish before terminating, so your cleanup completes within the 30-second window.
+
+<Tabs groupId="main">
+<TabItem value="JavaScript" label="JavaScript">
+
+```js
+import { Actor } from 'apify';
+
+await Actor.init();
+
+Actor.on('aborting', async () => {
+  // Charge for completed but unbilled work
+});
+
+// Rest of the Actor logic
+
+await Actor.exit();
+```
+
+</TabItem>
+<TabItem value="Python" label="Python">
+
+```py
+from apify import Actor, Event
+
+
+async def main():
+    await Actor.init()
+
+    async def on_aborting(_event_data=None):
+        # Charge for completed but unbilled work
+        ...
+
+    Actor.on(Event.ABORTING, on_aborting)
+
+    # Rest of the Actor logic
+
+    await Actor.exit()
+```
+
+</TabItem>
+</Tabs>
+
+
+:::caution Non-graceful aborts are default behavior
+
+A non-graceful abort stops the run immediately, without emitting `aborting`, so your handler never runs. Don't rely on it and charge for work as soon as it's done. For details, see [Respect user spending limits](#respect-user-spending-limits).
+
+:::
+
+### Use `apify-actor-start` {#synthetic-start-event}
+
+The `apify-actor-start` synthetic event reduces your startup costs and makes your Actor pricing more competitive. When enabled, Apify covers the compute cost of the first 5 seconds of every run.
 
 :::info Synthetic Actor start event recommended
 
-Apify recommends using the synthetic Actor start event in all Actors. It benefits both you and your users.
+Apify recommends using the synthetic `apify-actor-start` event in all Actors. It benefits both you and your users.
 
 :::
 
-Starting an Actor takes time, and creates additional cost for the Actor creator, because the profit equals revenue minus platform costs.
+The `apify-actor-start` synthetic event works as follows:
 
-One of the options to charge for the time spent on starting the Actor is to charge an “Actor start” event. Unfortunately, this makes your Actor comparably expensive with other tools on the market (outside of [Apify Store](/console/store)) that do not incur this startup cost.
-
-We want to make it easier for Actor creators to stay competitive, but also help them to be profitable. Therefore, we have the Apify Actor synthetic start event `apify-actor-start`. This event is enabled by default for all new PPE Actors, and when you use it Apify will cover the compute unit cost of the first 5 seconds of every Actor run.
-
-The default price of the event is set intentionally low. This pricing means that the free 5 seconds of compute we provide costs us more than the revenue generated from the event. We've made this investment to _support the creator community_ by reducing your startup costs while keeping your Actors competitively priced for users.
-
-#### How the synthetic start event works
-
-- The Apify Actor start event is _automatically enabled_ for all new PPE Actors. For existing Actors, you can enable it in Apify Console.
-- Apify _automatically charges_ the event.
-  - You must _not_ manually charge for the synthetic start event (`apify-actor-start`) in your Actor code. If you attempt to charge this event yourself, the operation will fail.
-- The default price of the event is _$0.00005_, which equals _$0.05 per 1,000 starts_. We recommend keeping the default price to keep your Actors competitive.
-- The number of events charged _depends on the memory_ of the Actor run. Up to and including 1 GB of RAM, the event is charged once. Then it's charged once for each extra GB of memory. For example:
+- It's enabled by default for all new PPE Actors. For existing Actors, you can enable it in Apify Console.
+- Apify automatically charges the event. Don't manually charge the event in your Actor code, as it will fail.
+- The default price of the event is $0.00005, which equals to $0.05 per 1,000 starts. To keep your Actor competitive, Apify recommends keeping the default price.
+- The number of events charged depends on the amount of memory allocated to the run. Up to and including 1 GB of RAM, the event is charged once. Then, it's charged once for each extra GB of memory. For example:
   - 128 MB RAM: 1 event, $0.00005
   - 1 GB RAM: 1 event, $0.00005
   - 4 GB RAM: 4 events, $0.0002
-- You can increase the price of the event if you wish, but you _won't get more free compute_.
-- You can delete the event if you wish, but if you do, you will _lose the free 5 seconds_ of compute.
+- You can increase the price of the event, but you won't get more free compute.
+- You can delete the event, but then you will lose the free 5 seconds of compute.
 
 #### Synthetic start event for new and existing Actors
 
@@ -198,33 +308,32 @@ For existing Actors, you can add this event manually:
 1. In the **Actor pricing** step, under **Event name**, add `apify-actor-start`.
 1. Complete the remaining event details: title, description, and price.
 
-#### Synthetic start event for Actors with start event
+#### Actors with a custom start event
 
-Your Actor might already have a start event defined, such as `actor-start` or another variant of the event name. In this case, you can choose whether to use the synthetic start event or keep the existing start event.
+Your Actor can't use both the synthetic and custom start events.
 
-If you want to use the synthetic start event, remove the existing start event from your Actor and add the synthetic start event in Apify Console in the **Publication** tab.
+To use the synthetic event, remove the existing custom event from your Actor in Apify Console.
 
-### Use synthetic default dataset item event `apify-default-dataset-item` {#synthetic-default-dataset-item-event}
+### Use `apify-default-dataset-item` {#synthetic-default-dataset-item-event}
 
-The `apify-default-dataset-item` synthetic event charges users for each item written to the run's default dataset. It lets you align PPE pricing with per-result use cases without adding charging code to your Actor.
+The `apify-default-dataset-item` synthetic event lets you align PPE pricing with per-result use cases:
 
-This event charges users automatically for each default dataset item, requiring no code changes.
+- It automatically charges users for each item that your Actor writes to the default dataset. For example, when using `Actor.pushData()`.
+- It applies only to the default dataset of the run.
+- It's enabled by default, you don't need to add extra charging code to your Actor.
 
-#### How the synthetic default dataset item event works
+To stop charging for default dataset items automatically, remove this event from your Actor in Apify Console.
 
-- Apify automatically charges this event whenever your Actor writes an item to the default dataset (for example, when using `Actor.pushData`).
-- No code changes are required to charge this event.
-- You can remove the event in Apify Console if you don't want automatic charging for default dataset items. If you remove it, default dataset writes will no longer be charged automatically.
-- The event applies only to the default dataset of the run. Writes to other (non-default) datasets are not charged by this synthetic event.
+### Set memory limits {#memory-limits}
 
-### Set memory limits
+Memory allocation is the user's choice. By setting an upper limit, you prevent users from selecting more memory than your Actor needs and avoid higher platform costs.
 
-Set memory limits using `minMemoryMbytes` and `maxMemoryMbytes` in your [`actor.json`](https://docs.apify.com/actors/development/actor-definition/actor-json) file to control platform usage costs.
+To set memory limits, use the `minMemoryMbytes` and `maxMemoryMbytes` properties in your [`actor.json`](https://docs.apify.com/actors/development/actor-definition/actor-json) file:
 
 ```json
 {
     "actorSpecification": 1,
-    "name": "name-of-my-scraper",
+    "name": "name-of-my-actor",
     "version": "0.0",
     "minMemoryMbytes": 512,
     "maxMemoryMbytes": 1024,
@@ -239,9 +348,11 @@ When using browser automation tools like Puppeteer or Playwright for web scrapin
 
 ### Charge for invalid input
 
-Charge for things like URLs that appear valid but lead to errors (like 404s) since you had to open the page to discover the error. Return error items with proper error codes and messages instead of failing the entire Actor run.
+Charge for inputs that seem valid but lead to errors, such as URLs that return a 404. Even though such action doesn't produce usable data, you still spend platform resources opening the page to discover the problem.
 
-The snippet below shows how you can charge for invalid inputs using `Actor.pushData` when a dataset item is created and the `scraped-result` event is charged.
+Instead of failing the entire run because of the bad input, return error items with clear error codes and messages. The run continues for the valid inputs and gives users a transparent record of what they were charged for.
+
+The following example shows how to charge for invalid inputs using `Actor.pushData()` when a dataset item is created and the `scraped-result` event is charged:
 
 <Tabs groupId="main">
 <TabItem value="JavaScript" label="JavaScript">
@@ -319,32 +430,30 @@ async def main():
 </TabItem>
 </Tabs>
 
-### Keep pricing simple with fewer events
+### Keep pricing simple
 
-Try to limit the number of events. Fewer events make it easier for users to understand your pricing and predict their costs.
+Limit the number of events. Fewer events make it easier for users to understand your pricing and predict the costs.
+
+Avoid cases where producing a single result triggers too many events. It makes your Actor more expensive.
 
 ### Make events produce visible results {#actor-events}
 
-For Actors that produce data, events should map to something concrete in the user's dataset or storage.
+Don't charge users for actions they don't see. For Actors that produce data, events should map to concrete results in the user's dataset or storage.
 
-However, we acknowledge that some events don't produce tangible results (such as running AI workflows or processing external API calls). This flexibility gives you the freedom to charge for special operations, complex workflows, and unique value propositions.
+You can still implement events that don't produce tangible results, such as running AI workflows or processing external API calls. In such cases, inform users about actions performed by your Actor by displaying a status message or pushing a record to the dataset. It helps users understand what actions they were charged for.
 
-Examples:
+The following examples show clear mapping of events to results:
 
-- _`post` event_: Each charge adds one social media post to the dataset
-- _`profile` event_: Each charge adds one user profile to the dataset
-- _`processed-image` event_: Each charge adds one processed image to the dataset
-- _`ai-analysis` event_: Each charge processes one document through an AI workflow (no tangible output, but valuable processing)
+- `post` event: Each charge adds one social media post to the dataset.
+- `profile` event: Each charge adds one user profile to the dataset.
+- `processed-image` event: Each charge adds one processed image to the dataset.
+- `ai-analysis` event: Each charge processes one document through an AI workflow. It doesn't produce an output, but processing is still valuable.
 
-:::note Additional context
+### Use idempotency keys
 
-You can display a status message or push a record to the dataset to inform users about non-data actions performed by your Actor. This helps users understand what actions were charged for, even if those actions do not produce tangible output.
+Apify SDKs handle idempotency for you.
 
-:::
-
-### Use idempotency keys to prevent double charges
-
-If you're not using the Apify SDKs (JS/Python), you need to handle idempotency (ensuring the same operation produces the same result when called multiple times) manually to prevent charging the same event multiple times.
+If you're not using the Apify SDKs, implement idempotency to prevent charging for the same event multiple times.
 
 ## Example of a PPE pricing
 
@@ -433,10 +542,6 @@ The platform usage costs are just examples, but you can see the actual costs in 
 - _Revenue (paid users only)_: $20 + $11 = _\$31_
 - _Platform cost (paid users only)_: $2.50 + $1.50 = _\$4_
 - _Profit_: 0.8 × $31 − $4 = _\$20.80_
-
-## Event names
-
-If you need to know your event names, you can retrieve the list of available pricing event names using the [Get Actor](https://apify.com/docs/api/v2/act-get) API endpoint.
 
 ## Next steps
 

--- a/sources/platform/actors/publishing/monetize/pay_per_event.mdx
+++ b/sources/platform/actors/publishing/monetize/pay_per_event.mdx
@@ -15,10 +15,10 @@ The pay per event (PPE) pricing model offers a flexible monetization option for 
 - Unlimited revenue scalability
 - AI/MCP compatibility
 - Predictable user costs
-- Store discounts
+- Store discounts available
 - Standard 20% commission
 - Custom event billing
-- Per-result billing (optional)
+- Two automatically charged events available
 
 :::tip Additional benefits
 
@@ -30,20 +30,20 @@ Actors that implement PPE pricing receive additional benefits, including increas
 
 An event is a specific, measurable action that your Actor triggers programmatically and charges the user for. The most common events include:
 
-- Starting an Actor.
-- Creating a dataset item.
+- Creating a result.
+- Processing an item.
 - Calling an external API.
 
-You define the events and can set different pricing for each of them.
+You define the events and can set different pricing for each event type and [discount tier](/actors/publishing/monetize/pricing-and-costs#discount-tiers).
 
 ### Synthetic events
 
-Synthetic events cover the most common billing patterns. They're predefined by Apify and charged automatically:
+Synthetic events are predefined by Apify and charged automatically:
 
-- [`apify-actor-start`](#synthetic-start-event) covers the costs spent during the first 5 seconds of starting the Actor.
-- [`apify-default-dataset-item`](#synthetic-default-dataset-item-event) charges for each item written to the run's default dataset.
+- [`apify-actor-start`](#synthetic-start-event) reduces the costs of starting the Actor.
+- [`apify-default-dataset-item`](#synthetic-default-dataset-item-event) charges for each item written to the default dataset of the run.
 
-You can adjust or remove synthetic events in Apify Console.
+You can remove synthetic events or change their price in Apify Console.
 
 ### Custom events
 
@@ -82,8 +82,8 @@ When testing your Actor pricing, you can also temporarily [pass platform usage c
 
 An Actor's negative net profit doesn't affect the positive profit of another Actor. For aggregation purposes, an Actor with a negative net profit is considered to have a profit of $0.
 
-- Before: `Total profit = (-$90) + $100 = $10`
-- Now: `Total profit = $0 + $100 = $100`
+- Without isolation: `Total profit = (-$90) + $100 = $10`
+- With isolation: `Total profit = $0 + $100 = $100`
 
 :::
 
@@ -151,7 +151,7 @@ Make sure to:
 
 :::tip Consider using `ChargingManager`
 
-If charging happens in multiple places across your code, or when you use a crawler where you don't directly control the main loop, you can use the `ChargingManager` to check the remaining budget periodically instead of inspecting every `ChargeResult`.
+If charging happens in multiple places across your code, or when you use an Actor where you don't directly control the main loop, you can use the `ChargingManager` to check the remaining budget periodically instead of inspecting every `ChargeResult`.
 
 :::
 
@@ -311,7 +311,7 @@ For existing Actors, you can add this event manually:
 
 #### Actors with a custom start event
 
-Your Actor can't use both the synthetic and custom start events.
+Don't use both the synthetic and custom start events.
 
 To use the synthetic event, remove the existing custom event from your Actor in Apify Console.
 
@@ -450,7 +450,7 @@ The following examples show clear mapping of events to results:
 - `post` event: Each charge adds one social media post to the dataset.
 - `profile` event: Each charge adds one user profile to the dataset.
 - `processed-image` event: Each charge adds one processed image to the dataset.
-- `ai-analysis` event: Each charge processes one document through an AI workflow. It doesn't produce an output, but processing is still valuable.
+- `ai-analysis` event: Each charge processes one document through an AI workflow.
 
 ### Use idempotency keys
 

--- a/sources/platform/actors/publishing/monetize/pay_per_event.mdx
+++ b/sources/platform/actors/publishing/monetize/pay_per_event.mdx
@@ -351,6 +351,8 @@ When using browser automation tools like Puppeteer or Playwright for web scrapin
 
 Charge for inputs that seem valid but lead to errors, such as URLs that return a 404. Even though such action doesn't produce usable data, you still spend platform resources opening the page to discover the problem.
 
+Note that charging for invalid input might not cover the entire cost of platform resources spent on handling errors. Test your Actor with invalid input and adjust the validation logic, if necessary.
+
 Instead of failing the entire run because of the bad input, return error items with clear error codes and messages. The run continues for the valid inputs and gives users a transparent record of what they were charged for.
 
 The following example shows how to charge for invalid inputs using `Actor.pushData()` when a dataset item is created and the `scraped-result` event is charged:

--- a/sources/platform/actors/publishing/monetize/pay_per_event.mdx
+++ b/sources/platform/actors/publishing/monetize/pay_per_event.mdx
@@ -16,15 +16,8 @@ The pay per event (PPE) pricing model offers a flexible monetization option for 
 - AI/MCP compatibility
 - Predictable user costs
 - Store discounts available
-- Standard 20% commission
 - Custom event billing
 - Two automatically charged events available
-
-:::tip Additional benefits
-
-Actors that implement PPE pricing receive additional benefits, including increased visibility in Apify Store and enhanced discoverability.
-
-:::
 
 ## About events
 
@@ -89,7 +82,7 @@ An Actor's negative net profit doesn't affect the positive profit of another Act
 
 ## Set pricing for PPE Actors
 
-1. _Understand your costs_: Analyze resource usage (e.g CPU, memory, proxies, external APIs) and identify cost drivers
+1. _Understand your costs_: Analyze resource usage (e.g CPU, memory, proxies, external APIs) and identify cost drivers.
 1. _Define clear events_: break your Actor's functionality into measurable, chargeable events.
 1. _Choose a primary event_: Pick the event that best represents the main value of your Actor. This primary event is highlighted on the Actor detail page, so users quickly understand what they are mainly paying for.
 1. _Common use cases_:

--- a/sources/platform/actors/publishing/monetize/pricing_and_costs.mdx
+++ b/sources/platform/actors/publishing/monetize/pricing_and_costs.mdx
@@ -5,7 +5,7 @@ slug: /actors/publishing/monetize/pricing-and-costs
 sidebar_position: 4
 ---
 
-## Computing your costs for PPE Actors
+## Compute costs for PPE Actors {#compute-costs}
 
 Profit is computed using the formula `(0.8 * revenue) - costs`. In this section, we'll explain how the `costs` component is calculated.
 

--- a/sources/platform/actors/publishing/monetize/pricing_and_costs.mdx
+++ b/sources/platform/actors/publishing/monetize/pricing_and_costs.mdx
@@ -46,7 +46,7 @@ When you monetize your Actor in Standby mode using pay per event mode only, you 
 
 :::
 
-## Discount tiers and pricing strategy
+## Discount tiers and pricing strategy {#discount-tiers}
 
 Each user running your PPE Actor belongs to a discount tier:
 


### PR DESCRIPTION
- Adds a section on events
- Adds a section on graceful abort
- Adds a section on avoiding negative profit
- Extends the section on respecting user limits 
- Removes fluff and repeated info 

Preview: https://pr-2770.preview.docs.apify.com/actors/publishing/monetize/pay-per-event

Closes #2634.