### PR TITLE
docs(academy): add MCP-based research option to Actor validation guide

### DIFF
--- a/sources/academy/build-and-publish/actor-ideas/actor_validation.md
+++ b/sources/academy/build-and-publish/actor-ideas/actor_validation.md
@@ -61,6 +61,8 @@ Document your findings. Note quotes and recurring themes like _Multiple marketer
 
 Zero discussion across multiple platforms over 4+ weeks means either no one cares about the problem or they've already solved it.
 
+If you work inside an AI or vibe coding assistant (Claude, Cursor, ChatGPT, Lovable, Replit, Bolt, Base44), you can now run this kind of demand research in one sweep programmatically without leaving your editor: [MCP.DemandDiscovery.ai](https://mcp.demanddiscovery.ai). Instead of relying on LLM opinions, surveys, or assumptions, you find out if your idea has real demand via actual behavior: replies, clicks, objections, and expressions of intent.
+
 ### Reddit
 
 Search relevant subreddits (r/webscraping, r/datascience, r/SEO, r/marketing, or industry-specific ones) for questions like _How can I extract [data] from [site]?_ or _I wish there was a tool to do X_. Multiple people independently asking for the same solution is strong validation.


### PR DESCRIPTION
## What

Adds two sentences to the "Research community discussions" section of the Actor idea validation guide, noting that this research can now be run in one sweep from inside AI coding assistants via MCP, with one concrete example.

## Why

The guide already recommends third-party tools for each technique (Google Keyword Planner, Keywords Everywhere, F5Bot, GummySearch, Star History). Actor developers increasingly work inside Claude and Cursor, and MCP servers let them run demand research at the exact moment this guide targets — while deciding what to build. The linked example is free to connect (remote server, no API key, no signup) and produces a free market research report, consistent with the guide's free-tools framing.

## Disclosure

I'm the founder of Demand Discovery AI, so the link points to my own product — flagging that openly so you can judge the edit on usefulness. Happy to reword or move the mention if you'd prefer it elsewhere in the guide.

— Cecily Robyn Lough