### PR TITLE
fix(openapi): Preserve RequestWithoutId and its required fields when bundling

### DIFF
--- a/apify-api/openapi/components/schemas/request-queues/Request.yaml
+++ b/apify-api/openapi/components/schemas/request-queues/Request.yaml
@@ -4,8 +4,6 @@ allOf:
   - $ref: ./RequestBase.yaml
     required:
       - id
-      - uniqueKey
-      - url
   - properties:
       id:
         $ref: ./SharedProperties.yaml#/RequestId

--- a/apify-api/openapi/components/schemas/request-queues/RequestBase.yaml
+++ b/apify-api/openapi/components/schemas/request-queues/RequestBase.yaml
@@ -1,5 +1,8 @@
 title: RequestBase
 type: object
+required:
+  - uniqueKey
+  - url
 properties:
   uniqueKey:
     $ref: ./SharedProperties.yaml#/UniqueKey

--- a/apify-api/openapi/components/schemas/request-queues/RequestWithoutId.yaml
+++ b/apify-api/openapi/components/schemas/request-queues/RequestWithoutId.yaml
@@ -1,6 +1,4 @@
 title: RequestWithoutId
 description: A request stored in the request queue, including its metadata and processing state, without the assigned ID.
-$ref: ./RequestBase.yaml
-required:
-  - uniqueKey
-  - url
+allOf:
+  - $ref: ./RequestBase.yaml

--- a/apify-api/openapi/components/schemas/request-queues/RequestWithoutId.yaml
+++ b/apify-api/openapi/components/schemas/request-queues/RequestWithoutId.yaml
@@ -1,6 +1,7 @@
 title: RequestWithoutId
 description: A request stored in the request queue, including its metadata and processing state, without the assigned ID.
-$ref: ./RequestBase.yaml
-required:
-  - uniqueKey
-  - url
+# Wrapped in a single-member `allOf` so that bundling keeps this component. A bare `$ref` with sibling keys is a
+# pass-through schema, which the bundler inlines into its target - the component then never reaches the published
+# specification, and clients generated from it have no schema for the request-queue write bodies.
+allOf:
+  - $ref: ./RequestBase.yaml


### PR DESCRIPTION
`RequestWithoutId` was a bare `$ref` with sibling keys, so the bundler inlined it: the published `openapi.json` has no such component, the add-request / batch-add-requests / update-request bodies point straight at `RequestBase`, and `required: [uniqueKey, url]` disappears. Generated clients therefore get no schema for those bodies — `apify-client-python` fell back to a response shape and sent `userData` and friends snake_cased, which the API rejects with HTTP 400 (apify/apify-client-python#1026).

Wrapping `RequestWithoutId` in a single-member `allOf` keeps it a named component through bundling. `required: [uniqueKey, url]` moves to `RequestBase`, and `Request` drops the now-redundant entries — net constraints unchanged.

`redocly lint` passes, and the bundle keeps the component with all 11 properties and the required constraint.

*✍️ Drafted by Claude Code*
