### PR TITLE
fix: Remove unnecessary whitespace on mobile

### DIFF
--- a/apify-docs-theme/src/theme/Navbar/Content/index.jsx
+++ b/apify-docs-theme/src/theme/Navbar/Content/index.jsx
@@ -23,9 +23,9 @@ function NavbarItems({ items }) {
     );
 }
 
-function NavbarContentLayout({ left, center, right }) {
+function NavbarContentLayout({ left, center, right, className }) {
     return (
-        <div className="navbar__inner">
+        <div className={`navbar__inner ${className ?? ''}`}>
             <div className="navbar__container">
                 <div className="navbar__items">{left}</div>
                 <div className="navbar__items navbar__items--center">{center}</div>
@@ -115,6 +115,7 @@ export default function NavbarContent() {
                 }
             />
             <NavbarContentLayout
+                className="navbar__inner--mobile"
                 left={
                     <>
                         <NavbarItems items={leftItems} />

--- a/apify-docs-theme/src/theme/Navbar/Content/index.jsx
+++ b/apify-docs-theme/src/theme/Navbar/Content/index.jsx
@@ -115,7 +115,7 @@ export default function NavbarContent() {
                 }
             />
             <NavbarContentLayout
-                className="navbar__inner--mobile"
+                className="navbar__inner--subnavbar"
                 left={
                     <>
                         <NavbarItems items={leftItems} />

--- a/apify-docs-theme/src/theme/custom.css
+++ b/apify-docs-theme/src/theme/custom.css
@@ -391,7 +391,7 @@ footer .col {
 
 @media (max-width: 996px) {
     /* Nav links move into a dropdown on mobile. */
-    .navbar__inner--mobile {
+    .navbar__inner--subnavbar {
         display: none;
     }
 }

--- a/apify-docs-theme/src/theme/custom.css
+++ b/apify-docs-theme/src/theme/custom.css
@@ -389,6 +389,13 @@ footer .col {
     background: var(--color-Neutral_Background);
 }
 
+@media (max-width: 996px) {
+    /* Nav links move into a dropdown on mobile. */
+    .navbar__inner--mobile {
+        display: none;
+    }
+}
+
 .navbar__sub {
     padding: 0.8rem var(--ifm-spacing-horizontal);
     height: 58px;


### PR DESCRIPTION
On mobile, the second navbar still shows up. It's empty, because all links moved into the dropdown. That creates unnecessary whitespace.

Before:
<img width="416" height="875" alt="Screenshot 2026-07-17 at 13 40 04" src="https://github.com/user-attachments/assets/34fbe510-22cd-47ac-86b2-e905d4aa737c" />

After:
<img width="410" height="874" alt="Screenshot 2026-07-17 at 13 40 11" src="https://github.com/user-attachments/assets/f595f798-ca30-4603-8786-279b3c822d4a" />
