### PR TITLE
fix: Content on mobile rendered too narrow

### DIFF
--- a/src/theme/DocItem/Layout/styles.module.css
+++ b/src/theme/DocItem/Layout/styles.module.css
@@ -2,11 +2,6 @@
     margin-bottom: 50px;
 }
 
-.docItemContainer > article {
-    margin-left: 16px;
-    margin-right: 16px;
-}
-
 .docItemContainer header + *,
 .docItemContainer article > *:first-child {
     margin-top: 0;
@@ -15,5 +10,9 @@
 @media (min-width: 997px) {
     .docItemCol {
         max-width: 75% !important;
+    }
+    .docItemContainer > article {
+        margin-left: 16px;
+        margin-right: 16px;
     }
 }


### PR DESCRIPTION
Content from apify-docs was rendered with extra padding compared to other repos. Extra margins now apply to desktop only.

Before:
<img width="406" height="557" alt="Screenshot 2026-07-17 at 14 50 18" src="https://github.com/user-attachments/assets/1aa57ad8-3fb8-4466-b9aa-d78b6a12b07b" />

After:
<img width="403" height="507" alt="Screenshot 2026-07-17 at 14 50 14" src="https://github.com/user-attachments/assets/2b9e75ab-4a66-44b1-9003-52e4649f1105" />
