### PR TITLE
fix: Prevent navbar "Get started" tab from wrapping on smaller screens

### DIFF
--- a/apify-docs-theme/src/theme/custom.css
+++ b/apify-docs-theme/src/theme/custom.css
@@ -519,6 +519,13 @@ aside .icon svg[class*='iconExternalLink'] {
     transition: all ease-in 0.12s;
 }
 
+/* Keep multi-word navbar labels (e.g. "Get started") on a single line so they
+   don't wrap and overflow the fixed-height navbar row. Scoped to navbar links
+   only - the docs sidebar uses .menu__link and must stay free to wrap. */
+.navbar__link {
+    white-space: nowrap;
+}
+
 .menu__link:hover {
     background: var(--color-Neutral_Hover);
     color: unset;


### PR DESCRIPTION
The .navbar__link labels have no wrapping constraint, so the two-word "Get started" nav tab broke onto a second line and overflowed the fixed 68px navbar row at narrower widths. Add white-space: nowrap scoped to navbar links only - the docs sidebar uses .menu__link and must stay free to wrap. Closes #2780.