### PR TITLE
docs(openapi): Autofix OpenAPI spec validation errors

### DIFF
--- a/apify-api/openapi/components/schemas/actors/TaggedBuildInfo.yaml
+++ b/apify-api/openapi/components/schemas/actors/TaggedBuildInfo.yaml
@@ -7,9 +7,9 @@ properties:
     description: The ID of the build associated with this tag.
     examples: [z2EryhbfhgSyqj6Hn]
   buildNumber:
-    type: string
+    type: [string, "null"]
     pattern: ^([0-9]|[1-9][0-9])\.([0-9]|[1-9][0-9])(\.[1-9][0-9]{0,4})$
-    description: The build number/version string.
+    description: The build number/version string. Can be `null` for legacy builds that lack a valid build number.
     examples: [0.0.2]
   buildNumberInt:
     type: integer

--- a/apify-api/openapi/components/schemas/common/ErrorType.yaml
+++ b/apify-api/openapi/components/schemas/common/ErrorType.yaml
@@ -65,6 +65,7 @@ enum:
   - cannot-metamorph-to-pay-per-result-actor
   - cannot-modify-actor-pricing-too-frequently
   - cannot-modify-actor-pricing-with-immediate-effect
+  - cannot-monetize-without-payout-billing-info
   - cannot-override-paid-actor-trial
   - cannot-permanently-delete-subscription
   - cannot-publish-actor

--- a/apify-api/openapi/paths/actor-tasks/actor-tasks.yaml
+++ b/apify-api/openapi/paths/actor-tasks/actor-tasks.yaml
@@ -139,6 +139,8 @@ post:
       $ref: ../../components/responses/Unauthorized.yaml
     "403":
       $ref: ../../components/responses/Forbidden.yaml
+    "404":
+      $ref: ../../components/responses/NotFound.yaml
     "405":
       $ref: ../../components/responses/MethodNotAllowed.yaml
     "409":

--- a/apify-api/openapi/paths/actor-tasks/actor-tasks@{actorTaskId}.yaml
+++ b/apify-api/openapi/paths/actor-tasks/actor-tasks@{actorTaskId}.yaml
@@ -101,6 +101,8 @@ put:
       $ref: ../../components/responses/NotFound.yaml
     "405":
       $ref: ../../components/responses/MethodNotAllowed.yaml
+    "409":
+      $ref: ../../components/responses/Conflict.yaml
     "413":
       $ref: ../../components/responses/PayloadTooLarge.yaml
     "415":

--- a/apify-api/openapi/paths/actors/acts@{actorId}@builds.yaml
+++ b/apify-api/openapi/paths/actors/acts@{actorId}@builds.yaml
@@ -120,6 +120,8 @@ post:
       $ref: ../../components/responses/BadRequest.yaml
     "401":
       $ref: ../../components/responses/Unauthorized.yaml
+    "402":
+      $ref: ../../components/responses/PaymentRequired.yaml
     "403":
       $ref: ../../components/responses/Forbidden.yaml
     "404":


### PR DESCRIPTION
## Summary
Autogenerated OpenAPI fixes suggestions based on validation errors generated from running API integration tests with OpenAPI validator turned on.

**Error log:** User-provided production `api.log` excerpt (SOFT_FAIL response validation errors, Jul 18–20, 2026). The log is not available at a public URL, so the normalized log lines are included below:

```text
Jul 18 00:34:05 apify-api SOFT_FAIL {"errors":[{"message":"no schema defined for status code '402' in the openapi spec","path":"/v2/actors/{actorId}/builds?version=1.0&useCache=false&waitForFinish=180"}],"method":"POST","msg":"Response OpenAPI validation error","statusCode":402.0,"url":"/v2/actors/{actorId}/builds?version=1.0&useCache=false&waitForFinish=180"}
Jul 18 02:50:38 apify-api SOFT_FAIL {"errors":[{"message":"no schema defined for status code '404' in the openapi spec","path":"/v2/actor-tasks"}],"method":"POST","msg":"Response OpenAPI validation error","statusCode":404.0,"url":"/v2/actor-tasks"}
Jul 20 08:15:38 apify-api SOFT_FAIL {"errors":[{"errorCode":"type.openapi.validation","message":"must be string","path":"/response/data/taggedBuilds/{tag}/buildNumber"},{"errorCode":"type.openapi.validation","message":"must be null","path":"/response/data/taggedBuilds/{tag}"},{"errorCode":"anyOf.openapi.validation","message":"must match a schema in anyOf","path":"/response/data/taggedBuilds/{tag}"},{"errorCode":"type.openapi.validation","message":"must be null","path":"/response/data/taggedBuilds"},{"errorCode":"anyOf.openapi.validation","message":"must match a schema in anyOf","path":"/response/data/taggedBuilds"}],"method":"GET","msg":"Response OpenAPI validation error","statusCode":200.0,"url":"/v2/actors/{actorId}"}
Jul 20 08:47:37 apify-api SOFT_FAIL {"errors":[{"message":"no schema defined for status code '409' in the openapi spec","path":"/v2/actor-tasks/{actorTaskId}"}],"method":"PUT","msg":"Response OpenAPI validation error","statusCode":409.0,"url":"/v2/actor-tasks/{actorTaskId}"}
```

A follow-up regression run of the integration tests with the fixed spec ([validator run results](https://apify-pr-test-env-logs.s3.us-east-1.amazonaws.com/apify/apify-core/27741/results-e7d29056accf1b0316bced404af8210670291e9f.html)) surfaced one additional response validation error, fixed as the fifth fix below.

**apify-core version:** https://github.com/apify/apify-core/commit/48a50ff1c30b82ade5283e5465ef63a7ec09095b

**Stop reason:** All 4 unique errors from the provided log are fixed, plus 1 new response validation error found in the regression run. The original 4 errors cannot be reproduced in the PR test environment (they come from production traffic and legacy data), so they were verified against apify-core source instead. The regression run with the fixed spec passed (status SUCCESS) and its api.log contains no response validation errors caused by these changes; the remaining request validation errors in that log are deliberate malformed-request tests or pre-existing issues unrelated to this diff (see Unfixed errors).

## Detailed changes description
### Error fixes
#### Add 402 (Payment Required) response to Build Actor endpoint
- **Files:** `apify-api/openapi/paths/actors/acts@{actorId}@builds.yaml:123`
- **Error:** `{"errors":[{"message":"no schema defined for status code '402' in the openapi spec","path":"/v2/actors/{actorId}/builds?version=1.0&useCache=false&waitForFinish=180"}],"method":"POST","msg":"Response OpenAPI validation error","statusCode":402}`
- **Root cause:** `POST /v2/actors/{actorId}/builds` enforces the account memory and concurrent-runs limits before creating the build and throws `memory-limit-exceeded`/`concurrent-runs-limit-exceeded` errors with HTTP 402, but the spec did not document a 402 response. Reused the `PaymentRequired` response component, consistent with the run Actor endpoints that document 402 for the same limit checks.
- **Reference:** https://github.com/apify/apify-core/tree/48a50ff1c30b82ade5283e5465ef63a7ec09095b/src/packages/actor-server/src/actor_jobs/actor_jobs.server.ts#L1269

#### Add 404 (Not Found) response to Create task endpoint
- **Files:** `apify-api/openapi/paths/actor-tasks/actor-tasks.yaml:142`
- **Error:** `{"errors":[{"message":"no schema defined for status code '404' in the openapi spec","path":"/v2/actor-tasks"}],"method":"POST","msg":"Response OpenAPI validation error","statusCode":404}`
- **Root cause:** `POST /v2/actor-tasks` looks up the Actor referenced by `actId` in the request payload and throws `record-not-found` with HTTP 404 when that Actor does not exist or is removed, but the spec did not document a 404 response. Reused the `NotFound` response component.
- **Reference:** https://github.com/apify/apify-core/tree/48a50ff1c30b82ade5283e5465ef63a7ec09095b/src/api/src/routes/actor_tasks/actor_task_list.ts#L190

#### Allow null buildNumber in tagged builds of the Actor object
- **Files:** `apify-api/openapi/components/schemas/actors/TaggedBuildInfo.yaml:10`
- **Error:** `{"errors":[{"errorCode":"type.openapi.validation","message":"must be string","path":"/response/data/taggedBuilds/{tag}/buildNumber"},{"errorCode":"anyOf.openapi.validation","message":"must match a schema in anyOf","path":"/response/data/taggedBuilds/{tag}"}],"method":"GET","msg":"Response OpenAPI validation error","statusCode":200,"url":"/v2/actors/{actorId}"}`
- **Root cause:** `GET /v2/actors/{actorId}` builds the `taggedBuilds` map via `transformActor()`, which computes `buildNumber` as `buildOrVersionNumberIntToStr(buildNumberInt)` with return type `string | null`; for legacy builds without a valid `buildNumberInt` the value is `null`, while the spec allowed only a string. Allowed `null` for `buildNumber` (the `pattern` keyword only applies to string values, so it keeps validating real build numbers).
- **Reference:** https://github.com/apify/apify-core/tree/48a50ff1c30b82ade5283e5465ef63a7ec09095b/src/packages/actor/src/actors/actors.both.ts#L113

#### Add 409 (Conflict) response to Update task endpoint
- **Files:** `apify-api/openapi/paths/actor-tasks/actor-tasks@{actorTaskId}.yaml:104`
- **Error:** `{"errors":[{"message":"no schema defined for status code '409' in the openapi spec","path":"/v2/actor-tasks/{actorTaskId}"}],"method":"PUT","msg":"Response OpenAPI validation error","statusCode":409}`
- **Root cause:** `PUT /v2/actor-tasks/{actorTaskId}` throws `actor-task-name-not-unique` with HTTP 409 when renaming a task to a name already used by another task of the same user (Mongo duplicate key on `userId`+`nameLowerCase`), but the spec did not document a 409 response. Reused the `Conflict` response component, matching `POST /v2/actor-tasks` which already documents 409 for the same uniqueness constraint.
- **Reference:** https://github.com/apify/apify-core/tree/48a50ff1c30b82ade5283e5465ef63a7ec09095b/src/api/src/routes/actor_tasks/actor_task.ts#L151

#### Add cannot-monetize-without-payout-billing-info to ErrorType enum
- **Files:** `apify-api/openapi/components/schemas/common/ErrorType.yaml:68`
- **Error:** `{"url":"/v2/actors/{actorId}","method":"PUT","statusCode":400,"errors":[{"message":"must be equal to one of the allowed values: 3d-secure-auth-failed, access-right-already-exists, ...","errorCode":"enum.openapi.validation","path":"/response/error/type"}]}` (from the regression run log)
- **Root cause:** `PUT /v2/actors/{actorId}` with a paid pricing model rejects the update with HTTP 400 and error type `cannot-monetize-without-payout-billing-info` when the Actor owner has no payout billing info set (thrown by `checkAndSanitizePricingInfosModifier`), but this error type was missing from the `ErrorType` enum shared by all error responses.
- **Reference:** https://github.com/apify/apify-core/tree/48a50ff1c30b82ade5283e5465ef63a7ec09095b/src/api/src/lib/paid_actors_helpers.ts#L364

### Refactoring
None - only the minimum necessary response/schema additions were made.

## Unfixed errors
### Out of scope errors
#### Unknown query parameter standbyDeployment on run Actor endpoint
- **Error:** `{"url":"/v2/actors/{actorId}/runs?standbyDeployment=SINGLE_TENANT&memory=1024&build=latest","method":"POST","errors":[{"message":"Unknown query parameter 'standbyDeployment'","path":"/query/standbyDeployment"}]}` (request validation, regression run log)
- **Root cause:** ApifyClient 2.23.4 sends a real `standbyDeployment` query parameter that is not yet documented on `POST /v2/actors/{actorId}/runs`. Documenting it requires product input on the parameter's contract, which is beyond this autofix PR.

#### Undocumented endpoint GET /v2/actors/{actorId}/oauth-connections
- **Error:** `{"url":"/v2/actors/{actorId}/oauth-connections","method":"GET","errors":[{"message":"not found","path":"/actors/{actorId}/oauth-connections"}]}` (request validation, regression run log)
- **Root cause:** The endpoint exists in apify-core (`src/api/src/routes/actors/oauth_connection_list.ts`) but has no path in the OpenAPI spec. Adding a whole new documented endpoint is beyond this autofix PR.

#### Deliberate malformed-request tests and internal-only paths
- **Error:** Remaining request validation errors in the regression run log: invalid `input`/`options`/`generalAccess`/`eventTypes`/`filter`/`handledAt` values, unsupported media types, invalid HTTP methods, missing required parameters, and probes of internal paths (`/v2/meta/_telemetry-test`, `/v2/openapi.json`, `/v2/browser-info?method=...`).
- **Root cause:** Integration tests intentionally send malformed requests to verify error handling, and some internal/telemetry paths are deliberately absent from the public spec. Per the workflow rules, specs must not be changed to accommodate intentionally invalid requests.

## Issues
Partially implements: https://github.com/apify/apify-docs/issues/2286