### PR TITLE
docs: align image format guidance with WebP CI enforcement

### DIFF
--- a/standards/content-standards.md
+++ b/standards/content-standards.md
@@ -186,7 +186,7 @@ FROM apify/actor-node-playwright:22
 All images must include meaningful alt text describing the content:
 
 ```markdown
-![Apify Console showing the Actor creation dialog](./images/create-actor.png)
+![Apify Console showing the Actor creation dialog](./images/create-actor.webp)
 ```
 
 ### Theme
@@ -205,9 +205,10 @@ Use red boxes or arrows to highlight important UI elements:
 
 ### Image format
 
-- **PNG** for screenshots and diagrams
-- **JPG** for photos
+- **WebP** for screenshots and diagrams
 - **SVG** for logos and icons (when available)
+
+New raster images must be WebP. The `lint_images` CI check fails on PNG, JPG, and other raster formats. Convert and optimize an image - or a whole directory - with `pnpm opt:images <path>`, then update your Markdown to reference the resulting `.webp` file.
 
 ### File organization
 
@@ -218,7 +219,7 @@ platform/
 ├── actors/
 │   ├── running.md
 │   └── images/
-│       └── run-button.png
+│       └── run-button.webp
 ```
 
 ## Lists

--- a/standards/content-standards.md
+++ b/standards/content-standards.md
@@ -206,7 +206,7 @@ Use red boxes or arrows to highlight important UI elements:
 ### Image format
 
 - **WebP** for screenshots and diagrams
-- **SVG** for logos and icons (when available)
+- **SVG** for logos, icons, and product images (when available)
 
 New raster images must be WebP. The `lint_images` CI check fails on PNG, JPG, and other raster formats. Convert and optimize an image - or a whole directory - with `pnpm opt:images <path>`, then update your Markdown to reference the resulting `.webp` file.
 

--- a/standards/quality-standards.md
+++ b/standards/quality-standards.md
@@ -82,7 +82,7 @@ Before submitting documentation, verify:
 - [ ] Screenshots use light theme
 - [ ] Red indicators used to highlight UI elements
 - [ ] Images stored in `images/` subdirectory
-- [ ] Image format is appropriate (PNG for screenshots, SVG for logos)
+- [ ] Image format is appropriate (WebP for screenshots, SVG for logos)
 
 ### File organization
 

--- a/standards/quality-standards.md
+++ b/standards/quality-standards.md
@@ -82,7 +82,7 @@ Before submitting documentation, verify:
 - [ ] Screenshots use light theme
 - [ ] Red indicators used to highlight UI elements
 - [ ] Images stored in `images/` subdirectory
-- [ ] Image format is appropriate (WebP for screenshots, SVG for logos)
+- [ ] Image format is appropriate (WebP for screenshots, SVG for logos, icons, and product images)
 
 ### File organization
 


### PR DESCRIPTION
The `lint_images` CI check requires WebP and rejects PNG, JPG, and other raster formats, but the style guide still told writers to use PNG for screenshots - so following the docs failed the build. This updates `content-standards.md` and `quality-standards.md` to say WebP and points to `pnpm opt:images`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)