### PR TITLE
docs: Update procedure on passing platform usage costs on to users

### DIFF
--- a/sources/platform/actors/publishing/monetize/pay_per_event.mdx
+++ b/sources/platform/actors/publishing/monetize/pay_per_event.mdx
@@ -77,7 +77,10 @@ Charging platform usage separately is less transparent for users and may discour
 
 :::
 
-To pass platform usage costs on to users, in the **Actor pricing** step of the [monetization setup](/actors/publishing/monetize#set-up-monetization), switch on the **Pay per event + usage** toggle.
+To pass platform usage costs on to users:
+
+1. Go to the **Actor pricing** step of the [monetization setup](/actors/publishing/monetize#set-up-monetization).
+1. In **Additional options**, switch on the **Pay per event + usage** toggle.
 
 Turning this option on takes 14 days to take effect. However, you can turn it off immediately, as it is a positive change for users.
 


### PR DESCRIPTION
We are moving PPE+U under **Additional options**.