### PR TITLE
docs(openapi): Indicate not to override the run memory limit

### DIFF
--- a/apify-api/openapi/components/parameters/runAndBuildParameters.yaml
+++ b/apify-api/openapi/components/parameters/runAndBuildParameters.yaml
@@ -110,8 +110,9 @@ memory: &memory
   name: memory
   in: query
   description: |
-    Memory limit for the run, in megabytes. The amount of memory can be set to a power of 2 with a minimum of 128.
-    By default, the run uses the memory limit from its configuration.
+    Memory limit for the run, in megabytes. You can set the amount of memory to a power of 2 with a minimum of 128.
+    By default, the run uses the memory limit from its configuration. Don't change this value unless the Actor's
+    documentation recommends it.
   style: form
   explode: true
   schema:

--- a/apify-api/openapi/components/parameters/runAndBuildParameters.yaml
+++ b/apify-api/openapi/components/parameters/runAndBuildParameters.yaml
@@ -112,7 +112,7 @@ memory: &memory
   description: |
     Memory limit for the run, in megabytes. You can set the amount of memory to a power of 2 with a minimum of 128.
     By default, the run uses the memory limit from its configuration. Don't change this value unless the Actor's
-    documentation recommends it.
+    documentation recommends it or you're aware of the consequences.
   style: form
   explode: true
   schema:


### PR DESCRIPTION
Closes #2768.