### PR TITLE
fix(docs): Duplicated routes in Academy

### DIFF
--- a/sources/academy/webscraping/scraping_basics_javascript/13_platform.md
+++ b/sources/academy/webscraping/scraping_basics_javascript/13_platform.md
@@ -2,7 +2,7 @@
 title: Using a scraping platform with Node.js
 sidebar_label: Using a platform
 description: Lesson about building a Node.js application for watching prices. Using the Apify platform to deploy a scraper.
-slug: /scraping-basics-javascript/
+slug: /scraping-basics-javascript/platform
 ---
 
 import LegacyJsCourseAdmonition from '@site/src/components/LegacyJsCourseAdmonition';

--- a/sources/academy/webscraping/scraping_basics_python/13_platform.md
+++ b/sources/academy/webscraping/scraping_basics_python/13_platform.md
@@ -2,7 +2,7 @@
 title: Using a scraping platform with Python
 sidebar_label: Using a platform
 description: Lesson about building a Python application for watching prices. Using the Apify platform to deploy a scraper.
-slug: /scraping-basics-python/
+slug: /scraping-basics-python/platform
 ---
 
 **In this lesson, we'll deploy our application to a scraping platform that automatically runs it daily. We'll also use the platform's API to retrieve and work with the results.**


### PR DESCRIPTION
Due to the recent navigation changes, slugs got duplicated and some content disappeared from Academy.