### PR TITLE
docs: Update the aborting event description

### DIFF
--- a/sources/platform/actors/development/builds_and_runs/index.md
+++ b/sources/platform/actors/development/builds_and_runs/index.md
@@ -66,13 +66,13 @@ flowchart LR
 
 ---
 
-| Status     | Type         | Description                                 |
-|------------|--------------|---------------------------------------------|
-| READY      | initial      | Started but not allocated to any worker yet |
-| RUNNING    | transitional | Executing on a worker machine               |
-| SUCCEEDED  | terminal     | Finished successfully                       |
-| FAILED     | terminal     | Run failed                                  |
-| TIMING-OUT | transitional | Timing out now                              |
-| TIMED-OUT  | terminal     | Timed out                                   |
-| ABORTING   | transitional | Being aborted by user                       |
-| ABORTED    | terminal     | Aborted by user                             |
+| Status | Type | Description |
+| --- | --- | --- |
+| READY | initial | Started but not allocated to any worker yet |
+| RUNNING | transitional | Executing on a worker machine |
+| SUCCEEDED | terminal | Finished successfully |
+| FAILED | terminal | Run failed |
+| TIMING-OUT | transitional | Timing out now |
+| TIMED-OUT | terminal | Timed out |
+| ABORTING | transitional | Run is being aborted |
+| ABORTED | terminal | Run aborted |

--- a/sources/platform/actors/development/programming_interface/system_events.md
+++ b/sources/platform/actors/development/programming_interface/system_events.md
@@ -9,28 +9,25 @@ sidebar_label: System events
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
----
-
-## Understand system events
 
 Apify's system notifies Actors about various events, such as:
 
-- Migration to another server
-- Abort operations triggered by another Actor
-- CPU overload
+- Migration to another server.
+- Abort operations triggered by another Actor.
+- CPU overload.
 
 These events help you manage your Actor's behavior and resources effectively.
 
 ## System events
 
-The following table outlines the system events available:
+The following system events are available:
 
 
 | Event name | Payload | Description |
 | --- | --- | --- |
 | `cpuInfo` | `{ isCpuOverloaded: Boolean }` | Emitted approximately every second, indicating whether the Actor is using maximum available CPU resources. |
 | `migrating` | `{ timeRemainingSecs: Float }` | Signals that the Actor will soon migrate to another worker server on the Apify platform. |
-| `aborting` | N/A | Triggered when a user initiates a graceful abort of an Actor run, allowing time for cleanup. |
+| `aborting` | N/A | Signals a graceful abort of the run, granting time for cleanup. Emitted in the following cases: <ul><li>User initiates a graceful abort.</li><li>Run reaches its maximum cost limit.</li><li>In [Standby mode](/actors/development/programming-interface/standby), a run times out due to inactivity or its worker is shut down.</li></ul> |
 | `persistState` | `{ isMigrating: Boolean }` | Emitted at regular intervals  (default: _60 seconds_) to notify Apify SDK components to persist their state. |
 
 ## How system events work

--- a/sources/platform/actors/running/runs_and_builds.md
+++ b/sources/platform/actors/running/runs_and_builds.md
@@ -100,27 +100,27 @@ flowchart LR
 
 ---
 
-| Status     | Type         | Description                                 |
-|:-----------|:-------------|:--------------------------------------------|
-| READY      | initial      | Started but not allocated to any worker yet |
-| RUNNING    | transitional | Executing on a worker machine               |
-| SUCCEEDED  | terminal     | Finished successfully                       |
-| FAILED     | terminal     | Run failed                                  |
-| TIMING-OUT | transitional | Timing out now                              |
-| TIMED-OUT  | terminal     | Timed out                                   |
-| ABORTING   | transitional | Being aborted by the user                   |
-| ABORTED    | terminal     | Aborted by the user                         |
+| Status | Type | Description |
+| --- | --- | --- |
+| READY | initial | Started but not allocated to any worker yet |
+| RUNNING | transitional | Executing on a worker machine |
+| SUCCEEDED | terminal | Finished successfully |
+| FAILED | terminal | Run failed |
+| TIMING-OUT | transitional | Timing out now |
+| TIMED-OUT | terminal | Timed out |
+| ABORTING | transitional | Run is being aborted |
+| ABORTED | terminal | Run aborted |
 
-### Aborting runs
+### Abort a run
 
 You can abort runs with the statuses **READY**, **RUNNING**, or **TIMING-OUT** in two ways:
 
-- _Immediately_ - this is the default option. The Actor process is killed immediately with no grace period.
-- _Gracefully_ - the Actor run receives a signal about aborting via the `aborting` event and is granted a 30-second window to finish in-progress tasks before getting aborted. This is helpful in cases where you plan to resurrect the run later because it gives the Actor a chance to persist its state. When resurrected, the Actor can restart where it left off.
+- Immediately (default). The Actor process is killed with no grace period.
+- Gracefully. The Actor run receives a signal about aborting with the `aborting` event and is granted a 30-second window to finish in-progress tasks before getting terminated. If you plan to resurrect the run later, a graceful abort gives the Actor a chance to persist its state. When resurrected, the Actor can restart where it left off.
 
-You can abort a run in Apify Console using the **Abort** button or via API using the [Abort run](/api/v2/actor-run-abort-post) endpoint.
+To abort a run, use the **Abort** button in Apify Console or the [Abort run](/api/v2/actor-run-abort-post) API endpoint.
 
-### Resurrection of finished run
+### Resurrect a finished run
 
 Any Actor run in a terminal state, i.e., run with status **FINISHED**, **FAILED**, **ABORTED**, and **TIMED-OUT**, might be resurrected back to a **RUNNING** state. This is helpful in many cases, for example, when the timeout for an Actor run was too low or in case of an unexpected error.
 


### PR DESCRIPTION
The `aborting` event can be triggered in more cases than just by a user.

Closes #2799.