### PR TITLE
docs: Fix PPE spelling

### DIFF
--- a/sources/platform/actors/development/programming_interface/actor_standby.md
+++ b/sources/platform/actors/development/programming_interface/actor_standby.md
@@ -177,7 +177,8 @@ When you send a request to an Actor in Standby mode, the total timeout for recei
 
 The URL is exposed as an environment variable `ACTOR_STANDBY_URL`. You can also use `Actor.config`, where the `standbyUrl` option is available.
 
-## Monetization of Actors with the Standby mode?
+## Monetization of Actors in Standby mode
 
-You can monetize Standby Actors just like any other Actor. For best results with Standby workflows, use pay-per-event monetization model.
-When monetizing your Actor in Standby mode using pay per event mode, you are not responsible for covering the platform usage costs of your users' runs. Users will need to cover both the platform usage costs (paid to Apify) and event costs (paid to you).
+You can monetize Standby Actors just like any other Actor.
+
+For best results with Standby workflows, use the [pay-per-event pricing model](/actors/publishing/monetize/pay-per-event). In this model, users cover both the platform usage costs of their runs, as well as the event costs.

--- a/sources/platform/actors/publishing/monetize/index.mdx
+++ b/sources/platform/actors/publishing/monetize/index.mdx
@@ -92,7 +92,7 @@ Agentic payments let AI agents discover, run, and pay for your Actor without an 
 
 To be eligible for agentic payments, your Actor must:
 
-- Use the [pay per event](/actors/publishing/monetize/pay-per-event) pricing model. Rental and pay-per-usage Actors are not supported.
+- Use the [pay-per-event](/actors/publishing/monetize/pay-per-event) pricing model. Rental and pay-per-usage Actors are not supported.
 - Run with [limited permissions](/actors/development/permissions). Actors that request full permissions are excluded.
 - Not use [Standby](/actors/running/standby) mode for now. Standby support is coming later.
 

--- a/sources/platform/actors/publishing/monetize/pay_per_event.mdx
+++ b/sources/platform/actors/publishing/monetize/pay_per_event.mdx
@@ -1,5 +1,5 @@
 ---
-title: Pay per event pricing model
+title: Pay-per-event pricing model
 description: Learn how to monetize your Actor with pay-per-event (PPE) pricing, charging users for specific actions like Actor starts, dataset items, or API calls.
 slug: /actors/publishing/monetize/pay-per-event
 sidebar_position: 1.1
@@ -10,7 +10,7 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
 
-The pay per event (PPE) pricing model offers a flexible monetization option for Actors on Apify Store. The key benefits are:
+The pay-per-event (PPE) pricing model offers a flexible monetization option for Actors on Apify Store. The key benefits are:
 
 - Unlimited revenue scalability
 - AI/MCP compatibility

--- a/sources/platform/actors/publishing/monetize/pricing_and_costs.mdx
+++ b/sources/platform/actors/publishing/monetize/pricing_and_costs.mdx
@@ -42,7 +42,7 @@ If you decide not to offer tiered discounts on your Actor, the unit prices for _
 
 :::note Cost of PPE Actors in Standby mode
 
-When you monetize your Actor in Standby mode using pay per event mode only, you are not responsible for covering platform usage costs of your users' runs.
+When you monetize your Actor in Standby mode using pay-per-event mode only, you are not responsible for covering platform usage costs of your users' runs.
 
 :::
 

--- a/sources/platform/actors/publishing/quality_score.mdx
+++ b/sources/platform/actors/publishing/quality_score.mdx
@@ -71,7 +71,7 @@ Ease of use evaluates how quickly users can understand and successfully run your
 
 ### Pricing transparency
 
-Pricing transparency evaluates how clearly users can understand and predict the costs of running your Actor. Transparent pricing models help users make informed decisions and budget accordingly. The [Pay per event (PPE)](https://docs.apify.com/actors/publishing/monetize/pay-per-event) monetization model provides predictable, event-based pricing that makes costs explicit and easier to estimate.
+Pricing transparency evaluates how clearly users can understand and predict the costs of running your Actor. Transparent pricing models help users make informed decisions and budget accordingly. The [pay-per-event (PPE)](/actors/publishing/monetize/pay-per-event) monetization model provides predictable, event-based pricing that makes costs explicit and easier to estimate.
 
 Consider offering discounts for Bronze, Silver, and Gold subscription tiers. These incentives reward committed platform users and can increase your Actor's adoption among engaged customers.
 

--- a/sources/platform/actors/running/store/index.md
+++ b/sources/platform/actors/running/store/index.md
@@ -31,7 +31,7 @@ After a run finishes, any interactions with the dataset - such as reading or wri
 
 ### Pay per event
 
-With pay per event pricing, you pay for specific events defined by the Actor creator, such as producing a single result, uploading a file, or starting an Actor. These events and their prices are always described on each Actor's page.
+With pay-per-event pricing, you pay for specific events defined by the Actor creator, such as producing a single result, uploading a file, or starting an Actor. These events and their prices are always described on each Actor's page.
 
 [//]: # (TODO: also show the screenshot from Apify Store on Web)
 
@@ -39,7 +39,7 @@ With pay per event pricing, you pay for specific events defined by the Actor cre
 
 :::caution Some Actors charge platform usage separately
 
-Most pay per event Actors include [platform usage](../usage_and_resources.md) in the event price. However, some Actors may require you to pay for platform usage separately. Always check the Actor's pricing section to understand what's included.
+Most pay-per-event Actors include [platform usage](../usage_and_resources.md) in the event price. However, some Actors may require you to pay for platform usage separately. Always check the Actor's pricing section to understand what's included.
 
 :::
 

--- a/sources/platform/actors/running/store/index.md
+++ b/sources/platform/actors/running/store/index.md
@@ -35,7 +35,7 @@ With pay-per-event pricing, you pay for specific events defined by the Actor cre
 
 [//]: # (TODO: also show the screenshot from Apify Store on Web)
 
-![Example pay per event Actor](../images/store/pay_per_event_example_actor.png)
+![Example of a pay-per-event Actor](../images/store/pay_per_event_example_actor.png)
 
 :::caution Some Actors charge platform usage separately
 
@@ -47,13 +47,13 @@ Most pay-per-event Actors include [platform usage](../usage_and_resources.md) in
 
 When starting a run, you can define a maximum charge limit. The Actor terminates gracefully when it reaches that limit - and even if it does not stop immediately, you are never charged for produced events over the defined limit.
 
-![Pay per event Actor - max charge per run](../images/store/pay_per_event_max_charge_per_run.png)
+![Pay-per-event Actor - max charge per run](../images/store/pay_per_event_max_charge_per_run.png)
 
 Your charges appear on your invoices and in the [Historical usage tab](https://console.apify.com/billing/historical-usage) in the Billing section of Apify Console. The cost of each run also appears on the run detail page.
 
-![Pay per event Actor - historical usage tab](../images/store/pay_per_event_historical_usage_tab.png)
+![Pay-per-event Actor - historical usage tab](../images/store/pay_per_event_historical_usage_tab.png)
 
-![Pay per event Actor - run detail](../images/store/pay_per_event_price_on_run_detail.png)
+![Pay-per-event Actor - run detail](../images/store/pay_per_event_price_on_run_detail.png)
 
 If charges seem incorrect, contact the Actor author or the Apify support team. You can also open an issue directly on the Actor's detail page in Apify Console.
 

--- a/sources/platform/integrations/ai/skyfire.md
+++ b/sources/platform/integrations/ai/skyfire.md
@@ -209,7 +209,7 @@ curl -s \
 
 Not all Actors in Apify Store can be run using agentic payments. To be eligible, an Actor must:
 
-- Use the [pay per event](/actors/publishing/monetize/pay-per-event) pricing model. Rental and pay-per-usage Actors are not supported.
+- Use the [pay-per-event](/actors/publishing/monetize/pay-per-event) pricing model. Rental and pay-per-usage Actors are not supported.
 - Run with [limited permissions](/actors/development/permissions). Actors that request full permissions are excluded.
 - Not use [Standby](/actors/running/standby) mode for now. Standby support is coming later.
 

--- a/sources/platform/integrations/ai/x402.md
+++ b/sources/platform/integrations/ai/x402.md
@@ -135,7 +135,7 @@ curl -s \
 
 Not all Actors in Apify Store can be run using agentic payments. To be eligible, an Actor must:
 
-- Use the [pay per event](/actors/publishing/monetize/pay-per-event) pricing model. Rental and pay-per-usage Actors are not supported.
+- Use the [pay-per-event](/actors/publishing/monetize/pay-per-event) pricing model. Rental and pay-per-usage Actors are not supported.
 - Run with [limited permissions](/actors/development/permissions). Actors that request full permissions are excluded.
 - Not use [Standby](/actors/running/standby) mode for now. Standby support is coming later.
 
@@ -149,5 +149,5 @@ Not all Actors in Apify Store can be run using agentic payments. To be eligible,
 ## Next steps
 
 - Browse [Apify Store](https://apify.com/store) for supported Actors to use with x402.
-- Learn more about [Pay Per Event](/actors/publishing/monetize/pay-per-event) pricing for Actors.
+- Learn more about [pay-per-event](/actors/publishing/monetize/pay-per-event) pricing for Actors.
 - Read the [x402 protocol specification](https://www.x402.org/) for technical details on the payment standard.


### PR DESCRIPTION
Adds missing hyphens.