### PR TITLE
docs: rename APIFY_MCP_PROXY_URL to ACTOR_MCP_CONNECTOR_BASE_URL

### DIFF
--- a/sources/platform/actors/development/programming_interface/environment_variables.md
+++ b/sources/platform/actors/development/programming_interface/environment_variables.md
@@ -56,7 +56,7 @@ Variables prefixed with `ACTOR_` are defined by the [Actor specification](https:
 | `ACTOR_WEB_SERVER_PORT` | TCP port for the Actor to start an HTTP server on. This server can be used to receive external messages or expose monitoring and control interfaces. The server also receives messages from the [Actor Standby](/actors/development/programming-interface/standby) mode. |
 | `ACTOR_STANDBY_URL` | URL for accessing web servers of Actor runs in the [Actor Standby](/actors/development/programming-interface/standby) mode. |
 | `ACTOR_EVENTS_WEBSOCKET_URL` | Websocket URL where Actor may listen for [events](/actors/development/programming-interface/system-events) from Actor platform. |
-| `ACTOR_MCP_PROXY_URL` | Base URL of the Apify MCP Proxy. Connect to an [MCP connector](/integrations/mcp-connectors) at `${ACTOR_MCP_PROXY_URL}/<connectorId>` using `APIFY_TOKEN` as the bearer token. |
+| `ACTOR_MCP_CONNECTOR_BASE_URL` | Base URL of the Apify MCP Proxy. Connect to an [MCP connector](/integrations/mcp-connectors) at `${ACTOR_MCP_CONNECTOR_BASE_URL}/<connectorId>` using `APIFY_TOKEN` as the bearer token. |
 
 <!-- vale Microsoft.RangeFormat = NO -->
 

--- a/sources/platform/actors/development/programming_interface/environment_variables.md
+++ b/sources/platform/actors/development/programming_interface/environment_variables.md
@@ -56,6 +56,7 @@ Variables prefixed with `ACTOR_` are defined by the [Actor specification](https:
 | `ACTOR_WEB_SERVER_PORT` | TCP port for the Actor to start an HTTP server on. This server can be used to receive external messages or expose monitoring and control interfaces. The server also receives messages from the [Actor Standby](/actors/development/programming-interface/standby) mode. |
 | `ACTOR_STANDBY_URL` | URL for accessing web servers of Actor runs in the [Actor Standby](/actors/development/programming-interface/standby) mode. |
 | `ACTOR_EVENTS_WEBSOCKET_URL` | Websocket URL where Actor may listen for [events](/actors/development/programming-interface/system-events) from Actor platform. |
+| `ACTOR_MCP_PROXY_URL` | Base URL of the Apify MCP Proxy. Connect to an [MCP connector](/integrations/mcp-connectors) at `${ACTOR_MCP_PROXY_URL}/<connectorId>` using `APIFY_TOKEN` as the bearer token. |
 
 <!-- vale Microsoft.RangeFormat = NO -->
 
@@ -81,7 +82,6 @@ Variables prefixed with `APIFY_` are Apify-platform-specific extensions that go 
 | `APIFY_PROXY_PORT` | TCP port number to be used for connecting to Apify Proxy. |
 | `APIFY_PROXY_STATUS_URL` | URL for retrieving proxy status information. Appending `?format=json` to this URL returns the data in JSON format for programmatic processing. |
 | `APIFY_API_PUBLIC_BASE_URL` | Public URL of the Apify API. May be used to interact with the platform programmatically. Typically set to `api.apify.com`. |
-| `APIFY_MCP_PROXY_URL` | Base URL of the Apify MCP Proxy. Connect to an [MCP connector](/integrations/mcp-connectors) at `${APIFY_MCP_PROXY_URL}/<connectorId>` using `APIFY_TOKEN` as the bearer token. |
 | `APIFY_WORKFLOW_KEY` | Identifier used for grouping related runs and API calls together. |
 | `APIFY_META_ORIGIN` | Specifies how an Actor run was started. Possible values are in [Runs and builds](/actors/running/runs-and-builds#origin) documentation. |
 | `APIFY_INPUT_SECRETS_PRIVATE_KEY_FILE` | Path to the secret key used to decrypt [Secret inputs](/actors/development/actor-definition/input-schema/secret-input). |

--- a/sources/platform/integrations/ai/mcp-connectors/index.md
+++ b/sources/platform/integrations/ai/mcp-connectors/index.md
@@ -16,7 +16,7 @@ MCP connectors are distinct from the [Apify MCP server](/integrations/mcp). The 
 ```mermaid
 flowchart LR
     subgraph actor [Your Actor]
-        client["MCP client<br/><br/>Reads env vars:<br/>ACTOR_MCP_PROXY_URL<br/>APIFY_TOKEN"]
+        client["MCP client<br/><br/>Reads env vars:<br/>ACTOR_MCP_CONNECTOR_BASE_URL<br/>APIFY_TOKEN"]
     end
 
     subgraph platform [Apify platform]
@@ -32,7 +32,7 @@ flowchart LR
 <br/>
 1. The Actor developer declares which connectors the Actor accepts in its input schema (either a specific server, or any MCP-compatible connector).
 1. When you run the Actor, you select an eligible connector in the input form. If you don't have one yet, you can create and authorize a new connector in advance under **Settings > API & Integrations** or inline within the Actor input.
-1. When the Actor sends an MCP request to `ACTOR_MCP_PROXY_URL/<connectorId>`, the Apify MCP Proxy validates the request, injects your credentials, and forwards it to the upstream MCP server the connector is authorized against.
+1. When the Actor sends an MCP request to `ACTOR_MCP_CONNECTOR_BASE_URL/<connectorId>`, the Apify MCP Proxy validates the request, injects your credentials, and forwards it to the upstream MCP server the connector is authorized against.
 
 The Actor code uses a standard MCP client - no Apify-specific SDK is required.
 

--- a/sources/platform/integrations/ai/mcp-connectors/index.md
+++ b/sources/platform/integrations/ai/mcp-connectors/index.md
@@ -16,7 +16,7 @@ MCP connectors are distinct from the [Apify MCP server](/integrations/mcp). The 
 ```mermaid
 flowchart LR
     subgraph actor [Your Actor]
-        client["MCP client<br/><br/>Reads env vars:<br/>APIFY_MCP_PROXY_URL<br/>APIFY_TOKEN"]
+        client["MCP client<br/><br/>Reads env vars:<br/>ACTOR_MCP_PROXY_URL<br/>APIFY_TOKEN"]
     end
 
     subgraph platform [Apify platform]
@@ -32,7 +32,7 @@ flowchart LR
 <br/>
 1. The Actor developer declares which connectors the Actor accepts in its input schema (either a specific server, or any MCP-compatible connector).
 1. When you run the Actor, you select an eligible connector in the input form. If you don't have one yet, you can create and authorize a new connector in advance under **Settings > API & Integrations** or inline within the Actor input.
-1. When the Actor sends an MCP request to `APIFY_MCP_PROXY_URL/<connectorId>`, the Apify MCP Proxy validates the request, injects your credentials, and forwards it to the upstream MCP server the connector is authorized against.
+1. When the Actor sends an MCP request to `ACTOR_MCP_PROXY_URL/<connectorId>`, the Apify MCP Proxy validates the request, injects your credentials, and forwards it to the upstream MCP server the connector is authorized against.
 
 The Actor code uses a standard MCP client - no Apify-specific SDK is required.
 

--- a/sources/platform/integrations/ai/mcp-connectors/using-connectors-in-actors.md
+++ b/sources/platform/integrations/ai/mcp-connectors/using-connectors-in-actors.md
@@ -287,7 +287,7 @@ Every Actor run receives two environment variables for MCP connector access.
 
 | Variable | Description |
 | --- | --- |
-| `APIFY_MCP_PROXY_URL` | Base URL of the Apify MCP Proxy. Connect to a connector at `${APIFY_MCP_PROXY_URL}/<connectorId>`. |
+| `ACTOR_MCP_PROXY_URL` | Base URL of the Apify MCP Proxy. Connect to a connector at `${ACTOR_MCP_PROXY_URL}/<connectorId>`. |
 | `APIFY_TOKEN` | API token of the user who started the Actor. Use it as the bearer token for proxy requests. |
 
 The Actor uses a standard MCP client to connect to the proxy URL with the token as a bearer credential. No Apify-specific MCP SDK is required.
@@ -312,7 +312,7 @@ const input = await Actor.getInputOrThrow<{ slackConnector: string }>();
 const connectorId = input.slackConnector;
 
 const transport = new StreamableHTTPClientTransport(
-    new URL(`${process.env.APIFY_MCP_PROXY_URL}/${connectorId}`),
+    new URL(`${process.env.ACTOR_MCP_PROXY_URL}/${connectorId}`),
     {
         requestInit: {
             headers: {
@@ -360,7 +360,7 @@ async def main():
         input_data = await Actor.get_input()
         connector_id = input_data['slack_connector']
 
-        proxy_url = os.environ['APIFY_MCP_PROXY_URL']
+        proxy_url = os.environ['ACTOR_MCP_PROXY_URL']
         token = os.environ['APIFY_TOKEN']
 
         async with httpx.AsyncClient(
@@ -400,7 +400,7 @@ const connectorIds: string[] = input.mcpConnectors;
 const clients = await Promise.all(
     connectorIds.map(async (connectorId) => {
         const transport = new StreamableHTTPClientTransport(
-            new URL(`${process.env.APIFY_MCP_PROXY_URL}/${connectorId}`),
+            new URL(`${process.env.ACTOR_MCP_PROXY_URL}/${connectorId}`),
             {
                 requestInit: {
                     headers: { Authorization: `Bearer ${process.env.APIFY_TOKEN}` },

--- a/sources/platform/integrations/ai/mcp-connectors/using-connectors-in-actors.md
+++ b/sources/platform/integrations/ai/mcp-connectors/using-connectors-in-actors.md
@@ -287,7 +287,7 @@ Every Actor run receives two environment variables for MCP connector access.
 
 | Variable | Description |
 | --- | --- |
-| `ACTOR_MCP_PROXY_URL` | Base URL of the Apify MCP Proxy. Connect to a connector at `${ACTOR_MCP_PROXY_URL}/<connectorId>`. |
+| `ACTOR_MCP_CONNECTOR_BASE_URL` | Base URL of the Apify MCP Proxy. Connect to a connector at `${ACTOR_MCP_CONNECTOR_BASE_URL}/<connectorId>`. |
 | `APIFY_TOKEN` | API token of the user who started the Actor. Use it as the bearer token for proxy requests. |
 
 The Actor uses a standard MCP client to connect to the proxy URL with the token as a bearer credential. No Apify-specific MCP SDK is required.
@@ -312,7 +312,7 @@ const input = await Actor.getInputOrThrow<{ slackConnector: string }>();
 const connectorId = input.slackConnector;
 
 const transport = new StreamableHTTPClientTransport(
-    new URL(`${process.env.ACTOR_MCP_PROXY_URL}/${connectorId}`),
+    new URL(`${process.env.ACTOR_MCP_CONNECTOR_BASE_URL}/${connectorId}`),
     {
         requestInit: {
             headers: {
@@ -360,7 +360,7 @@ async def main():
         input_data = await Actor.get_input()
         connector_id = input_data['slack_connector']
 
-        proxy_url = os.environ['ACTOR_MCP_PROXY_URL']
+        proxy_url = os.environ['ACTOR_MCP_CONNECTOR_BASE_URL']
         token = os.environ['APIFY_TOKEN']
 
         async with httpx.AsyncClient(
@@ -400,7 +400,7 @@ const connectorIds: string[] = input.mcpConnectors;
 const clients = await Promise.all(
     connectorIds.map(async (connectorId) => {
         const transport = new StreamableHTTPClientTransport(
-            new URL(`${process.env.ACTOR_MCP_PROXY_URL}/${connectorId}`),
+            new URL(`${process.env.ACTOR_MCP_CONNECTOR_BASE_URL}/${connectorId}`),
             {
                 requestInit: {
                     headers: { Authorization: `Bearer ${process.env.APIFY_TOKEN}` },


### PR DESCRIPTION
The MCP connector base URL environment variable is being renamed on the platform, so the docs need to match - otherwise anyone following the MCP connectors guide reads a variable name that no longer resolves.

Since the reference tables in `environment_variables.md` are grouped by name prefix, the variable also moves from the Apify platform (`APIFY_`) table to the standard Actor (`ACTOR_`) table.

TODO: Release this once worker release is out.