### PR TITLE
docs: clarify agentic payment methods and enhance x402 documentation

### DIFF
--- a/sources/platform/integrations/ai/mcp.md
+++ b/sources/platform/integrations/ai/mcp.md
@@ -356,10 +356,12 @@ Your AI can search Apify Store for relevant Actors using the `search-actors` too
 
 ## Agentic payments
 
-Agentic payments allow AI agents to autonomously pay for Actor runs without requiring an Apify API token. The Apify MCP server supports two payment methods:
+Agentic payments allow AI agents to autonomously pay for Actor runs without requiring an Apify API token:
 
-- [x402 protocol](/integrations/x402) - Direct on-chain payments using USDC on the [Base](https://www.base.org/) blockchain via the open [x402](https://www.x402.org/) standard.
-- [Skyfire](/integrations/skyfire) - Managed payment tokens through the [Skyfire](https://www.skyfire.xyz/) payment platform.
+- [AGI](/integrations/x402) - buy a prepaid Apify API token from [Apify AGI](https://agi.apify.com) with an x402 or MPP payment, then use it against this MCP server or the Apify API directly. Recommended for most agents - works for any Actor, not just Pay Per Event ones.
+- [Skyfire](/integrations/skyfire) - managed payment tokens through the [Skyfire](https://www.skyfire.xyz/) payment platform.
+
+The MCP server also has its own Direct x402 support (per-request, no minted token, Pay Per Event Actors only) via [`mcpc`](https://github.com/apify/mcp-cli) - see the [Apify MCP Server README](https://github.com/apify/apify-mcp-server#-agentic-payments) for setup.
 
 For setup instructions and details, see the individual integration pages.
 

--- a/sources/platform/integrations/ai/x402.md
+++ b/sources/platform/integrations/ai/x402.md
@@ -13,6 +13,12 @@ Agentic payments are experimental and may change as payment protocols evolve.
 
 :::
 
+:::info Powered by Apify AGI
+
+This flow buys a prepaid Apify API token from [Apify AGI](https://agi.apify.com) (Agent General Interface) in exchange for an x402 payment - see its site for current terms (minimum amount, token lifetime, refund policy).
+
+:::
+
 :::tip For AI agents
 
 If you are an AI agent, use the ready-made [Apify x402 skill](https://raw.githubusercontent.com/apify/awesome-skills/refs/heads/main/skills/apify-x402-agentic-wallet/SKILL.md). It walks you through wallet setup, payment, and running Actors end to end. The steps below describe the same flow for manual use.
@@ -71,7 +77,7 @@ Both USDC and ETH must be present. ETH covers the gas for deploying your wallet 
 
 ## Buy a prepaid token
 
-Pay for a prepaid token from the Apify agentic endpoint. The wallet signs the payment and returns a token tied to a prepaid balance:
+Pay for a prepaid token from Apify AGI. The wallet signs the payment and returns a token tied to a prepaid balance:
 
 ```bash
 npx awal x402 pay 'https://agi.apify.com/protocols/x402/prepaid-tokens?amount=1&currency=usd' \


### PR DESCRIPTION
## Why
Follow-up to [apify-web#6391](https://github.com/apify/apify-web/pull/6391) and [apify-mcp-server#1178](https://github.com/apify/apify-mcp-server/pull/1178). Agentic-payment info is scattered and out of sync across repos, tracked in [apify-agi#89](https://github.com/apify/apify-agi/issues/89). `docs.apify.com/integrations/x402` describes Apify AGI's own flow (buys a token from `agi.apify.com` via `awal`) but never says "AGI" anywhere, so a reader has no way to connect it to AGI as described elsewhere. `mcp.md`'s "Agentic payments" section led with "x402" and "Skyfire" with no mention of AGI at all.

## What changed
**Before**: `x402.md` never mentioned AGI; `mcp.md` presented "x402" and "Skyfire" as the MCP server's two payment methods, no AGI.
**Now**: `x402.md` gets an info callout naming Apify AGI and linking to its site for current terms (minimum amount, token lifetime, refund policy). `mcp.md`'s payment list now leads with AGI (recommended, works for any Actor) and separately links out to the MCP server's own native "Direct x402" support in the `apify-mcp-server` README, instead of presenting it as just "x402."

## Notes for reviewers (human-written)
First time touching docs conventions here, so flag anything stylistically off - happy to adjust. Content was fact-checked against the live implementations; wording was drafted with Claude.

Btw.. Not really `adhoc` issue, but I cannot link https://github.com/apify/apify-agi/issues/89