### PR TITLE
fix(academy): avoid the Christmas tree

### DIFF
--- a/sources/academy/webscraping/scraping_basics_javascript/03_devtools_extracting_data.md
+++ b/sources/academy/webscraping/scraping_basics_javascript/03_devtools_extracting_data.md
@@ -81,20 +81,20 @@ In the next lesson, we'll start with our Node.js project. First we'll be figurin
 
 ### Extract the price of IKEA's most expensive artificial plant
 
-At IKEA's [Artificial plants & flowers listing](https://www.ikea.com/se/en/cat/artificial-plants-flowers-20492/), use CSS selectors and HTML elements manipulation in the **Console** to extract the price of the most expensive artificial plant (sold in Sweden, as you'll be browsing their Swedish offer). Before opening DevTools, use your judgment to adjust the page to make the task as straightforward as possible. Finally, use the [`parseInt()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/parseInt) function to convert the price text into a number. You might also need [`replace()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace) to handle spaces.
+At IKEA's [Artificial desk plants listing](https://www.ikea.com/se/en/cat/artificial-desk-plants-700521/), use CSS selectors and HTML elements manipulation in the **Console** to extract the price of the most expensive artificial plant (sold in Sweden, as you'll be browsing their Swedish offer). Before opening DevTools, use your judgment to adjust the page to make the task as straightforward as possible. Finally, use the [`parseInt()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/parseInt) function to convert the price text into a number.
 
 <details>
   <summary>Solution</summary>
 
-  1. Open the [Artificial plants & flowers listing](https://www.ikea.com/se/en/cat/artificial-plants-flowers-20492/).
+  1. Open the [Artificial desk plants listing](https://www.ikea.com/se/en/cat/artificial-desk-plants-700521/).
   1. Sort the products by price, from high to low, so the most expensive plant appears first in the listing.
   1. Activate the element selection tool in your DevTools.
   1. Click on the price of the first and most expensive plant.
   1. Notice that the price is structured into two elements, with the integer separated from the currency, under a class named `plp-price__integer`. This structure is convenient for extracting the value.
   1. In the **Console**, execute `document.querySelector('.plp-price__integer')`. This returns the element representing the first price in the listing. Since `document.querySelector()` returns the first matching element, it directly selects the most expensive plant's price.
   1. Save the element in a variable by executing `price = document.querySelector('.plp-price__integer')`.
-  1. Convert the price text into a number by executing `parseInt(price.textContent.replace(' ', ''))`. The price text contains spaces as thousand separators, so `.replace(' ', '')` strips them before parsing. You'll explore this technique further in the [Extracting data](./07_extracting_data.md#removing-dollar-sign-and-commas) lesson.
-  1. At the time of writing, this returns `1299`, meaning [1 299 SEK](https://www.google.com/search?q=1299%20sek).
+  1. Convert the price text into a number by executing `parseInt(price.textContent)`.
+  1. At the time of writing, this returns `699`, meaning [699 SEK](https://www.google.com/search?q=699%20sek).
 
 </details>
 

--- a/sources/academy/webscraping/scraping_basics_python/03_devtools_extracting_data.md
+++ b/sources/academy/webscraping/scraping_basics_python/03_devtools_extracting_data.md
@@ -78,20 +78,20 @@ In the next lesson, we'll start with our Python project. First we'll be figuring
 
 ### Extract the price of IKEA's most expensive artificial plant
 
-At IKEA's [Artificial plants & flowers listing](https://www.ikea.com/se/en/cat/artificial-plants-flowers-20492/), use CSS selectors and HTML elements manipulation in the **Console** to extract the price of the most expensive artificial plant (sold in Sweden, as you'll be browsing their Swedish offer). Before opening DevTools, use your judgment to adjust the page to make the task as straightforward as possible. Finally, use JavaScript's [`parseInt()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/parseInt) function to convert the price text into a number. You might also need [`replace()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace) to handle spaces.
+At IKEA's [Artificial desk plants listing](https://www.ikea.com/se/en/cat/artificial-desk-plants-700521/), use CSS selectors and HTML elements manipulation in the **Console** to extract the price of the most expensive artificial plant (sold in Sweden, as you'll be browsing their Swedish offer). Before opening DevTools, use your judgment to adjust the page to make the task as straightforward as possible. Finally, use JavaScript's [`parseInt()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/parseInt) function to convert the price text into a number.
 
 <details>
   <summary>Solution</summary>
 
-  1. Open the [Artificial plants & flowers listing](https://www.ikea.com/se/en/cat/artificial-plants-flowers-20492/).
+  1. Open the [Artificial desk plants listing](https://www.ikea.com/se/en/cat/artificial-desk-plants-700521/).
   1. Sort the products by price, from high to low, so the most expensive plant appears first in the listing.
   1. Activate the element selection tool in your DevTools.
   1. Click on the price of the first and most expensive plant.
   1. Notice that the price is structured into two elements, with the integer separated from the currency, under a class named `plp-price__integer`. This structure is convenient for extracting the value.
   1. In the **Console**, execute `document.querySelector('.plp-price__integer')`. This returns the element representing the first price in the listing. Since `document.querySelector()` returns the first matching element, it directly selects the most expensive plant's price.
   1. Save the element in a variable by executing `price = document.querySelector('.plp-price__integer')`.
-  1. Convert the price text into a number by executing `parseInt(price.textContent.replace(' ', ''))`. The price text contains spaces as thousand separators, so `.replace(' ', '')` strips them before parsing. You'll explore this technique further in the [Extracting data](./07_extracting_data.md#removing-dollar-sign-and-commas) lesson.
-  1. At the time of writing, this returns `1299`, meaning [1 299 SEK](https://www.google.com/search?q=1299%20sek).
+  1. Convert the price text into a number by executing `parseInt(price.textContent)`.
+  1. At the time of writing, this returns `699`, meaning [699 SEK](https://www.google.com/search?q=699%20sek).
 
 </details>
 


### PR DESCRIPTION
At this stage of the course, students are not yet introduced to data cleaning, so I'd rather not put .replace() in their way. Choosing a slightly different category on the IKEA website avoids the Christmas tree, which means the price is just a three-digit number, which can be scraped as-is.

This is a follow-up to the hotfix introduced in https://github.com/apify/apify-docs/pull/2536

_I never thought I'd find myself in a phase of life where I'm creating a git branch called "avoid christmas tree", but 2026 is exactly this eventful and here we are..._