### PR TITLE
fix: remove Vale BlockIgnores that broke code block scoping

### DIFF
--- a/.vale.ini
+++ b/.vale.ini
@@ -13,8 +13,6 @@ mdx = md
 BasedOnStyles = Vale, Apify, write-good, Microsoft
 # Ignore URLs, HTML/XML tags, lines with =, emails, curly braces, inline code
 TokenIgnores = (<\/?[A-Z][^>]*>), ([^\n]+@[^\n]+\.[^\n]), ({[^}]*})
-# Ignore HTML comments and Markdown code blocks
-BlockIgnores = (?s) (<!--.*?-->)|(```.*?```)
 
 # Disabling rules (NO)
 Vale.Spelling = NO


### PR DESCRIPTION
Vale skips fenced code blocks and HTML comments natively when parsing Markdown, so this BlockIgnores line is (now?) redundant. Because BlockIgnores blanks out matched regions before the Markdown parser sees them, the naive `(?s)(```.*?```)` pattern desynchronizes Vale's position mapping.

The result is both phantom alerts inside code blocks and real alerts being dropped. Reproduced on
sources/academy/tutorials/apify_scrapers/cheerio_scraper.md, where a probe rule reported a hit at 146:15 - inside the fenced block spanning lines 133-153 - while a genuine hit at 156:11 disappeared. Across sources/academy and sources/platform at suggestion level, removing the line drops 247 misplaced alerts and surfaces 378 previously masked ones.

This affects every rule, not one in particular. At the error level that CI enforces, the result is unchanged (10 errors before and after), so this is behavior-neutral for the pipeline today and a correctness fix for local runs and any stricter rules added later.