### PR TITLE
fix: disable the default blog plugin

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -124,6 +124,7 @@ module.exports = {
                     sidebarPath: require.resolve('./sources/platform/sidebars.js'),
                     rehypePlugins: [externalLinkProcessor],
                 },
+                blog: false,
                 sitemap: {
                     filename: 'sitemap_base.xml',
                 },


### PR DESCRIPTION
The classic preset enables the blog plugin by default, producing an empty `/blog` page whose markdown link points to a nonexistent `/blog.md`. The link checker fails on that 404.