### PR TITLE
docs: add apify-sdk-integration skill to agent skills inventory

### DIFF
--- a/sources/platform/get-started/agent-onboarding.md
+++ b/sources/platform/get-started/agent-onboarding.md
@@ -283,6 +283,7 @@ npx skills add apify/agent-skills
 | `apify-actor-development` | Guided workflow for building and deploying custom Actors |
 | `apify-actorization` | Converts an existing project into an Apify Actor |
 | `apify-generate-output-schema` | Auto-generates output schemas from Actor source code |
+| `apify-sdk-integration` | Integrates Actor execution into applications using the `apify-client` package |
 
 For the full list and details, see the [skills registry](https://skills.sh/apify/agent-skills).
 

--- a/sources/platform/integrations/ai/manus.md
+++ b/sources/platform/integrations/ai/manus.md
@@ -109,6 +109,7 @@ Available skills include:
 | `apify-actor-development` | Full Actor lifecycle: template selection, development, testing, and deployment |
 | `apify-actorization` | Converts existing projects into Apify Actors |
 | `apify-generate-output-schema` | Generates dataset and key-value store schemas from Actor source code |
+| `apify-sdk-integration` | Integrates Actor execution into applications using the `apify-client` package |
 
 ### Import a skill from GitHub
 


### PR DESCRIPTION
Connected with this issue: https://github.com/apify/agent-skills/issues/75#issuecomment-5092029853

Adding a fifth skill to the table to make stuff consistent.