### PR TITLE
docs: add sunset note to Flowise integration page

### DIFF
--- a/sources/platform/integrations/ai/flowise.md
+++ b/sources/platform/integrations/ai/flowise.md
@@ -11,6 +11,12 @@ import ThirdPartyDisclaimer from '@site/sources/_partials/_third-party-integrati
 
 <ThirdPartyDisclaimer />
 
+:::caution Flowise is sunset
+
+The Flowise team has [discontinued the project](https://flowiseai.com/sunset). The code stays open source, so existing deployments keep working, but there are no further releases or official support.
+
+:::
+
 ## How to use Apify with Flowise
 
 ### Installation

--- a/sources/platform/integrations/ai/flowise.md
+++ b/sources/platform/integrations/ai/flowise.md
@@ -7,15 +7,15 @@ slug: /integrations/flowise
 
 import ThirdPartyDisclaimer from '@site/sources/_partials/_third-party-integration.mdx';
 
+:::danger Flowise development ended
+
+The Flowise team has [discontinued the project](https://flowiseai.com/sunset). The code stays open source, so existing deployments keep working, but there are no further releases or official support. Consider another integration before you invest time in a new Flowise setup.
+
+:::
+
 [Flowise](https://flowiseai.com/) is an open-source UI visual tool to build customized LLM flows using LangChain.
 
 <ThirdPartyDisclaimer />
-
-:::caution Flowise development ended
-
-The Flowise team has [discontinued the project](https://flowiseai.com/sunset). The code stays open source, so existing deployments keep working, but there are no further releases or official support.
-
-:::
 
 ## How to use Apify with Flowise
 

--- a/sources/platform/integrations/ai/flowise.md
+++ b/sources/platform/integrations/ai/flowise.md
@@ -11,7 +11,7 @@ import ThirdPartyDisclaimer from '@site/sources/_partials/_third-party-integrati
 
 <ThirdPartyDisclaimer />
 
-:::caution Flowise discontinued
+:::caution Flowise development ended
 
 The Flowise team has [discontinued the project](https://flowiseai.com/sunset). The code stays open source, so existing deployments keep working, but there are no further releases or official support.
 

--- a/sources/platform/integrations/ai/flowise.md
+++ b/sources/platform/integrations/ai/flowise.md
@@ -11,7 +11,7 @@ import ThirdPartyDisclaimer from '@site/sources/_partials/_third-party-integrati
 
 <ThirdPartyDisclaimer />
 
-:::caution Flowise is sunset
+:::caution Flowise discontinued
 
 The Flowise team has [discontinued the project](https://flowiseai.com/sunset). The code stays open source, so existing deployments keep working, but there are no further releases or official support.
 


### PR DESCRIPTION
The Flowise team has [discontinued the project](https://flowiseai.com/sunset). The code stays open source and existing deployments keep working, so the walkthrough stays for now - this just flags the status and links to their announcement, which carries the timeline. The page can be removed once usage dies out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)