### PR TITLE
docs(openapi): Autofix OpenAPI spec validation errors

### DIFF
--- a/apify-api/openapi/components/schemas/actors/ActorNotice.yaml
+++ b/apify-api/openapi/components/schemas/actors/ActorNotice.yaml
@@ -6,5 +6,5 @@ enum:
   - NONE
   - RESIDENTIAL_PROXY_REQUIRED
   - UNDER_MAINTENANCE
-  - null
+  - null # https://github.com/apify/apify-core/issues/29871, https://github.com/cdimascio/express-openapi-validator/issues/165
 examples: [UNDER_MAINTENANCE]

--- a/apify-api/openapi/components/schemas/actors/ActorNotice.yaml
+++ b/apify-api/openapi/components/schemas/actors/ActorNotice.yaml
@@ -6,4 +6,5 @@ enum:
   - NONE
   - RESIDENTIAL_PROXY_REQUIRED
   - UNDER_MAINTENANCE
+  - null
 examples: [UNDER_MAINTENANCE]

--- a/apify-api/openapi/components/schemas/common/ErrorType.yaml
+++ b/apify-api/openapi/components/schemas/common/ErrorType.yaml
@@ -69,6 +69,7 @@ enum:
   - cannot-override-paid-actor-trial
   - cannot-permanently-delete-subscription
   - cannot-publish-actor
+  - cannot-publish-actor-task
   - cannot-reduce-last-full-token
   - cannot-reimburse-more-than-original-charge
   - cannot-reimburse-non-rental-charge

--- a/apify-api/openapi/components/schemas/store/StoreListActor.yaml
+++ b/apify-api/openapi/components/schemas/store/StoreListActor.yaml
@@ -36,7 +36,6 @@ properties:
     $ref: ../actors/ActorNotice.yaml
   pictureUrl:
     type: [string, "null"]
-    format: uri
     examples: ["https://..."]
   userPictureUrl:
     type: [string, "null"]

--- a/apify-api/openapi/paths/schedules/schedules@{scheduleId}.yaml
+++ b/apify-api/openapi/paths/schedules/schedules@{scheduleId}.yaml
@@ -83,6 +83,8 @@ put:
       $ref: ../../components/responses/NotFound.yaml
     "405":
       $ref: ../../components/responses/MethodNotAllowed.yaml
+    "409":
+      $ref: ../../components/responses/Conflict.yaml
     "413":
       $ref: ../../components/responses/PayloadTooLarge.yaml
     "415":

--- a/apify-api/openapi/paths/users/users@{userId}.yaml
+++ b/apify-api/openapi/paths/users/users@{userId}.yaml
@@ -27,6 +27,8 @@ get:
             $ref: ../../components/schemas/users/PublicUserDataResponse.yaml
     "400":
       $ref: ../../components/responses/BadRequest.yaml
+    "401":
+      $ref: ../../components/responses/Unauthorized.yaml
     "404":
       $ref: ../../components/responses/NotFound.yaml
     "405":


### PR DESCRIPTION
## Summary
Autogenerated OpenAPI fixes suggestions based on validation errors generated from running API integration tests with OpenAPI validator turned on.

**Error log:** production API error logs (Mesmo, `apify-api` SOFT_FAIL entries) supplied as uploaded files - iteration 1: `0697c937-errors` (Aug 3-9, 2026, 600 lines); iteration 2: `82f6eccd-errors` (Aug 20-27, 2026, 599 lines). These are production logs with no public URL, so they are referenced by name for the lifetime of the PR.

**apify-core version:** iteration 1 https://github.com/apify/apify-core/commit/6a88dd05c766a3cf0ddbdab00730f539b77302b9, iteration 2 https://github.com/apify/apify-core/commit/59575e6d83b8c8f1046a49dd9d7365b0507ff67f

**Stop reason:** enough errors fixed - every unique error in both logs is either fixed here or documented below. The branch was rebased onto master before iteration 2, since the `publicConfig` schemas referenced by the second log landed in master after iteration 1. Each fix references the apify-core commit of its own iteration.

## Detailed changes description
### Error fixes
#### Allow `null` in `ActorNotice` enum
- **Files:** `apify-api/openapi/components/schemas/actors/ActorNotice.yaml:5-10`
- **Error:** `{"errorCode":"enum.openapi.validation","message":"must be equal to one of the allowed values: NONE, RESIDENTIAL_PROXY_REQUIRED, UNDER_MAINTENANCE","path":"/response/data/items/{N}/notice"}` on `GET /v2/store` and `{"path":"/response/data/notice"}` on `GET /v2/actors/{actorId}` - by far the largest group in both logs (~2093 item-level errors in iteration 1, 2322 in iteration 2)
- **Root cause:** The schema declares `type: [string, "null"]` but the `enum` lists only the three string values. In JSON Schema (OpenAPI 3.1) `enum` is exhaustive, so a `null` instance fails validation unless `null` is itself an enum member. The API does return `notice: null` - the store pipeline stores `notice: actor.notice ?? null`, the store item type is `notice: string | null`, and the API's own test fixture shapes a response with `notice: null`. The underlying representation inconsistency in apify-core is tracked in https://github.com/apify/apify-core/issues/29871.
- **Reference:** https://github.com/apify/apify-core/blob/6a88dd05/src/packages/actor-server/src/recombee/recombee_store_sync.ts#L555, https://github.com/apify/apify-core/blob/6a88dd05/src/api/test/tests/routes/store_search.test.ts#L50

#### Drop `format: uri` from store item `pictureUrl`
- **Files:** `apify-api/openapi/components/schemas/store/StoreListActor.yaml:37-39`
- **Error:** `{"errorCode":"format.openapi.validation","message":"must match format \"uri\"","path":"/response/data/items/{N}/pictureUrl"}` on `GET /v2/store` (3 lines)
- **Root cause:** `Actor.pictureUrl` is a free-form string in apify-core (`type: String, max: 300`, no URI validation), and the store search response rewrites it through the image proxy only when the value is truthy - an empty or malformed legacy value is passed through verbatim, so the response cannot guarantee RFC 3986 `uri` format. This also makes `StoreListActor.pictureUrl` consistent with `Actor.yaml`'s `pictureUrl`, which declares no `format`.
- **Reference:** https://github.com/apify/apify-core/blob/6a88dd05/src/packages/actor/src/actors/actors.both.ts#L673, https://github.com/apify/apify-core/blob/6a88dd05/src/packages/actor/src/actors/actors_store.both.ts#L169

#### Add `401` response to `GET /v2/users/{userId}`
- **Files:** `apify-api/openapi/paths/users/users@{userId}.yaml:30-31`
- **Error:** `{"message":"no schema defined for status code '401' in the openapi spec","path":"/v2/users/{userId}"}` (statusCode 401, 1 line, username normalized to `{userId}`)
- **Root cause:** The endpoint requires no authentication, but the global authentication middleware validates any token that is provided. A request carrying an invalid token is rejected with 401 `user-or-token-not-found` before the handler runs, so the operation can return 401 even though it is otherwise public. Compliant with RFC 9110 §15.5.2 (request "lacks valid authentication credentials"). Reuses the shared `Unauthorized.yaml` response component.
- **Reference:** https://github.com/apify/apify-core/blob/6a88dd05/src/api/src/middleware/authentication.ts#L95, https://github.com/apify/apify-core/blob/6a88dd05/src/packages/errors/src/errors/iam.ts#L58

#### Add `cannot-publish-actor-task` to the `ErrorType` enum
- **Files:** `apify-api/openapi/components/schemas/common/ErrorType.yaml:72`
- **Error:** `{"errorCode":"enum.openapi.validation","message":"must be equal to one of the allowed values: 3d-secure-auth-failed, access-right-already-exists, action-not-foun...[truncated]","path":"/response/error/type"}` on `POST /v2/actor-tasks` and `PUT /v2/actor-tasks/{actorTaskId}`, both status 400
- **Root cause:** Failed task publication validation returns 400 with error type `cannot-publish-actor-task`, which the enum did not list. The log truncates the allowed-values list, so the missing member was identified by diffing every `newMeteorishError` code in apify-core against the enum: `cannot-publish-actor-task` is the only absent code that is both status 400 and reachable from these endpoints, and an integration test asserts exactly this status and type. `cannot-unpublish-actor-task` is also absent from the enum but is thrown only by the Console backend, never the public API, so it is deliberately not added.
- **Reference:** https://github.com/apify/apify-core/blob/59575e6d/tests/integration/tests/actor_tasks/actor_tasks.publication.js#L370, https://github.com/apify/apify-core/blob/59575e6d/src/packages/errors/src/errors/actor_task.ts#L58

#### Add `409` response to `PUT /v2/schedules/{scheduleId}`
- **Files:** `apify-api/openapi/paths/schedules/schedules@{scheduleId}.yaml:86-87`
- **Error:** `{"message":"no schema defined for status code '409' in the openapi spec","path":"/v2/schedules/{scheduleId}"}` (statusCode 409, 2 lines)
- **Root cause:** Renaming a schedule to a name another of the user's schedules already holds trips the unique index `{userId, nameLowerCase}`; `insertOrUpdateSchedule` catches the duplicate-key error and throws `schedule-name-not-unique` with status 409, which the operation did not document. RFC 9110 §15.5.10 covers this case exactly, `schedule-name-not-unique` is already in the `ErrorType` enum, and `POST /v2/schedules` already documents 409 for the same condition - `PUT` was the outlier. Reuses the shared `Conflict.yaml` response component.
- **Reference:** https://github.com/apify/apify-core/blob/59575e6d/src/packages/actor-server/src/schedules.ts#L436, https://github.com/apify/apify-core/blob/59575e6d/src/packages/mongo-indexes/src/schedules.ts#L13


## Issues
Partially implements: https://github.com/apify/apify-docs/issues/2286