### PR TITLE
docs: exclude pay per event + usage Actors from agentic payment eligibility

### DIFF
--- a/sources/_partials/_agentic-payments-eligibility.mdx
+++ b/sources/_partials/_agentic-payments-eligibility.mdx
@@ -1,0 +1,8 @@
+To be eligible for agentic payments, an Actor must:
+
+- Use the [pay-per-event](/actors/publishing/monetize/pay-per-event) pricing model. Rental and pay-per-usage Actors are not supported.
+- Charge only for events, not for [platform usage](/actors/publishing/monetize/pay-per-event#platform-usage-costs). Actors with the **Pay per event + usage** option switched on are excluded.
+- Run with [limited permissions](/actors/development/permissions). Actors that request full permissions are excluded.
+- Not use [Standby](/actors/running/standby) mode.
+
+The Actor's developer must also have completed [identity verification (KYC)](/actors/publishing/monetize/monthly-payouts#verify-your-identity). Until they do, none of their Actors are eligible.

--- a/sources/platform/actors/monetizing/index.mdx
+++ b/sources/platform/actors/monetizing/index.mdx
@@ -29,6 +29,7 @@ Agentic payments let AI agents discover, run, and pay for your Actor without an 
 To be eligible for agentic payments, your Actor must:
 
 - Use the [pay-per-event](/actors/publishing/monetize/pay-per-event) pricing model. Rental and pay-per-usage Actors are not supported.
+- Charge only for events, not for [platform usage](/actors/publishing/monetize/pay-per-event#platform-usage-costs). Actors with the **Pay per event + usage** option switched on are excluded.
 - Run with [limited permissions](/actors/development/permissions). Actors that request full permissions are excluded.
 - Not use [Standby](/actors/running/standby) mode for now. Standby support is coming later.
 

--- a/sources/platform/actors/monetizing/index.mdx
+++ b/sources/platform/actors/monetizing/index.mdx
@@ -9,6 +9,7 @@ sidebar_label: Monetize
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import RentalSunset from '../../../_partials/_rental-sunsetting.mdx';
+import AgenticPaymentsEligibility from '../../../_partials/_agentic-payments-eligibility.mdx';
 
 
 You can monetize your automation, AI agent, and web scraping projects by publishing them as paid Actors on [Apify Store](https://apify.com/store).
@@ -26,12 +27,7 @@ For a detailed comparison of pricing models from the perspective of your users, 
 
 Agentic payments let AI agents discover, run, and pay for your Actor without an Apify account, using protocols such as [x402](/integrations/x402) and [Skyfire](/integrations/skyfire). Eligible Actors are flagged with `allowsAgenticUsers=true` and surface in agentic discovery, for example when [searching the store via API](https://docs.apify.com/api/v2#/reference/store/store-actors-collection/get-list-of-actors-in-store) with `allowsAgenticUsers=true`.
 
-To be eligible for agentic payments, your Actor must:
-
-- Use the [pay-per-event](/actors/publishing/monetize/pay-per-event) pricing model. Rental and pay-per-usage Actors are not supported.
-- Charge only for events, not for [platform usage](/actors/publishing/monetize/pay-per-event#platform-usage-costs). Actors with the **Pay per event + usage** option switched on are excluded.
-- Run with [limited permissions](/actors/development/permissions). Actors that request full permissions are excluded.
-- Not use [Standby](/actors/running/standby) mode for now. Standby support is coming later.
+<AgenticPaymentsEligibility />
 
 Actors that meet these criteria become available to agentic users automatically - there is no separate opt-in.
 

--- a/sources/platform/actors/monetizing/index.mdx
+++ b/sources/platform/actors/monetizing/index.mdx
@@ -29,7 +29,7 @@ Agentic payments let AI agents discover, run, and pay for your Actor without an 
 
 <AgenticPaymentsEligibility />
 
-Actors that meet these criteria become available to agentic users automatically - there is no separate opt-in.
+Actors that meet these requirements become available to agentic users automatically - there is no separate opt-in.
 
 ## Handle free users
 

--- a/sources/platform/integrations/ai/skyfire.md
+++ b/sources/platform/integrations/ai/skyfire.md
@@ -8,6 +8,7 @@ slug: /integrations/skyfire
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import ThirdPartyDisclaimer from '@site/sources/_partials/_third-party-integration.mdx';
+import AgenticPaymentsEligibility from '@site/sources/_partials/_agentic-payments-eligibility.mdx';
 
 Agentic payments enable AI agents to autonomously run Apify Actors using third-party payment providers, without requiring traditional Apify user accounts. This allows agents to discover, execute, and pay for web scraping and automation tasks independently.
 
@@ -207,12 +208,9 @@ curl -s \
 
 ### Supported Actors
 
-Not all Actors in Apify Store can be run using agentic payments. To be eligible, an Actor must:
+Not all Actors in Apify Store can be run using agentic payments.
 
-- Use the [pay-per-event](/actors/publishing/monetize/pay-per-event) pricing model. Rental and pay-per-usage Actors are not supported.
-- Charge only for events, not for [platform usage](/actors/publishing/monetize/pay-per-event#platform-usage-costs). Actors with the **Pay per event + usage** option switched on are excluded.
-- Run with [limited permissions](/actors/development/permissions). Actors that request full permissions are excluded.
-- Not use [Standby](/actors/running/standby) mode for now. Standby support is coming later.
+<AgenticPaymentsEligibility />
 
 Apify maintains a curated list of Actors approved for agentic payments. To check if an Actor supports agentic payments, use the `allowsAgenticUsers=true` query parameter when [searching the store via API](https://docs.apify.com/api/v2#/reference/store/store-actors-collection/get-list-of-actors-in-store).
 

--- a/sources/platform/integrations/ai/skyfire.md
+++ b/sources/platform/integrations/ai/skyfire.md
@@ -208,7 +208,7 @@ curl -s \
 
 ### Supported Actors
 
-Not all Actors in Apify Store can be run using agentic payments.
+Not all Actors in Apify Store are eligible.
 
 <AgenticPaymentsEligibility />
 

--- a/sources/platform/integrations/ai/skyfire.md
+++ b/sources/platform/integrations/ai/skyfire.md
@@ -210,6 +210,7 @@ curl -s \
 Not all Actors in Apify Store can be run using agentic payments. To be eligible, an Actor must:
 
 - Use the [pay-per-event](/actors/publishing/monetize/pay-per-event) pricing model. Rental and pay-per-usage Actors are not supported.
+- Charge only for events, not for [platform usage](/actors/publishing/monetize/pay-per-event#platform-usage-costs). Actors with the **Pay per event + usage** option switched on are excluded.
 - Run with [limited permissions](/actors/development/permissions). Actors that request full permissions are excluded.
 - Not use [Standby](/actors/running/standby) mode for now. Standby support is coming later.
 

--- a/sources/platform/integrations/ai/x402.md
+++ b/sources/platform/integrations/ai/x402.md
@@ -142,6 +142,7 @@ curl -s \
 Not all Actors in Apify Store can be run using agentic payments. To be eligible, an Actor must:
 
 - Use the [pay-per-event](/actors/publishing/monetize/pay-per-event) pricing model. Rental and pay-per-usage Actors are not supported.
+- Charge only for events, not for [platform usage](/actors/publishing/monetize/pay-per-event#platform-usage-costs). Actors with the **Pay per event + usage** option switched on are excluded.
 - Run with [limited permissions](/actors/development/permissions). Actors that request full permissions are excluded.
 - Not use [Standby](/actors/running/standby) mode for now. Standby support is coming later.
 

--- a/sources/platform/integrations/ai/x402.md
+++ b/sources/platform/integrations/ai/x402.md
@@ -141,7 +141,7 @@ curl -s \
 
 ## Supported Actors
 
-Not all Actors in Apify Store can be run using agentic payments.
+Not all Actors in Apify Store are eligible.
 
 <AgenticPaymentsEligibility />
 

--- a/sources/platform/integrations/ai/x402.md
+++ b/sources/platform/integrations/ai/x402.md
@@ -5,6 +5,8 @@ description: Use the x402 protocol to enable AI agents to autonomously pay for A
 slug: /integrations/x402
 ---
 
+import AgenticPaymentsEligibility from '@site/sources/_partials/_agentic-payments-eligibility.mdx';
+
 With the [x402 protocol](https://www.x402.org/), AI agents can run Apify Actors and pay with USDC on the [Base](https://www.base.org/) blockchain - no Apify account needed.
 
 :::caution Experimental feature
@@ -139,12 +141,9 @@ curl -s \
 
 ## Supported Actors
 
-Not all Actors in Apify Store can be run using agentic payments. To be eligible, an Actor must:
+Not all Actors in Apify Store can be run using agentic payments.
 
-- Use the [pay-per-event](/actors/publishing/monetize/pay-per-event) pricing model. Rental and pay-per-usage Actors are not supported.
-- Charge only for events, not for [platform usage](/actors/publishing/monetize/pay-per-event#platform-usage-costs). Actors with the **Pay per event + usage** option switched on are excluded.
-- Run with [limited permissions](/actors/development/permissions). Actors that request full permissions are excluded.
-- Not use [Standby](/actors/running/standby) mode for now. Standby support is coming later.
+<AgenticPaymentsEligibility />
 
 ## Token pricing and limits
 


### PR DESCRIPTION
Closes #2892

The agentic payments eligibility criteria were incomplete and duplicated verbatim on three pages, so Actor developers kept hitting ineligibility unexpectedly.

**What changed**

- **Added the PPE + usage exclusion.** Actors with the **Pay per event + usage** option switched on aren't eligible, but the existing wording ("Use the pay-per-event pricing model") read as though they were.
- **Added the KYC requirement.** A developer who hasn't completed identity verification has *no* eligible Actors, regardless of pricing model or permissions. This wasn't documented anywhere.
- **Dropped the stale "Standby support is coming later" sentence.**
- **Extracted the list into `sources/_partials/_agentic-payments-eligibility.mdx`**, replacing the three verbatim copies (x402, Skyfire, monetization), so the next change to the criteria only has to be made once.

Each page keeps its own lead-in sentence. The KYC criterion is phrased as a separate sentence rather than a bullet, because it's a property of the developer, not of the Actor.

**Verified locally**

- `pnpm build` passes; the partial renders on all three pages and the `#verify-your-identity` anchor resolves.
- The llms-txt generated `.md` output flattens the partial correctly on all three pages - no duplication or misattached content.
- `markdownlint` clean; Vale reports 0 errors and 0 warnings on the new partial.

**Open question for reviewers** (carried over, still unresolved)

The x402 page documents the prepaid-token flow, where the resulting token behaves like a regular API token. If the pricing-model and Standby restrictions don't apply on that path, the **Supported Actors** section on that page needs a rewrite rather than a shared criteria list - happy to handle that as a follow-up.
