### PR TITLE
docs: fix malformed external URLs missing platform subdomain

### DIFF
--- a/sources/platform/integrations/ai/agno.md
+++ b/sources/platform/integrations/ai/agno.md
@@ -18,7 +18,7 @@ This guide shows how to integrate Apify Actors with Agno to empower your AI agen
 ### Prerequisites
 
 - _Apify API token_: Obtain your API token from the [Apify Console](https://console.apify.com/settings/integrations).
-- _OpenAI API key_: Get your API key from the [OpenAI platform](https://.openai.com/account/api-keys).
+- _OpenAI API key_: Get your API key from the [OpenAI platform](https://platform.openai.com/account/api-keys).
 
 :::tip Alternative LLM providers
 

--- a/sources/platform/integrations/ai/crewai.md
+++ b/sources/platform/integrations/ai/crewai.md
@@ -18,7 +18,7 @@ This guide demonstrates how to integrate Apify Actors with CrewAI by building a 
 ### Prerequisites
 
 - **Apify API token**: To use Apify Actors in CrewAI, you need an Apify API token. Learn how to obtain it in the [Apify documentation](https://docs.apify.com/integrations/api).
-- **OpenAI API key**: To power the agents in CrewAI, you need an OpenAI API key. Get one from the [OpenAI platform](https://.openai.com/account/api-keys).
+- **OpenAI API key**: To power the agents in CrewAI, you need an OpenAI API key. Get one from the [OpenAI platform](https://platform.openai.com/account/api-keys).
 - **Python packages**: Install the following Python packages:
 
     ```bash

--- a/sources/platform/integrations/ai/haystack.md
+++ b/sources/platform/integrations/ai/haystack.md
@@ -34,7 +34,7 @@ from haystack.utils.auth import Secret
 from apify_haystack import ApifyDatasetFromActorCall
 ```
 
-Find your [Apify API token](https://console.apify.com/settings/integrations) and [OpenAI API key](https://.openai.com/account/api-keys) and initialize these into environment variable:
+Find your [Apify API token](https://console.apify.com/settings/integrations) and [OpenAI API key](https://platform.openai.com/account/api-keys) and initialize these into environment variable:
 
 ```python
 import os

--- a/sources/platform/integrations/ai/langflow.md
+++ b/sources/platform/integrations/ai/langflow.md
@@ -22,7 +22,7 @@ This guide will demonstrate two different ways to use Apify Actors with Langflow
 
 - **Apify API token**: To use Apify Actors in Langflow, you need an Apify API token. If you don't have one, you can learn how to get it in the [Apify documentation](https://docs.apify.com/integrations/api).
 
-- **OpenAI API key**: To work with agents in Langflow, you need an OpenAI API key. If you don't have one, you can get it from the [OpenAI platform](https://.openai.com/account/api-keys).
+- **OpenAI API key**: To work with agents in Langflow, you need an OpenAI API key. If you don't have one, you can get it from the [OpenAI platform](https://platform.openai.com/account/api-keys).
 
 #### Langflow
 
@@ -96,7 +96,7 @@ Create a new flow and add two **Apify Actors** components from the menu.
 Input your API token (learn how to get it in the [Integrations documentation](https://docs.apify.com/integrations/api)) and set the Actor ID of the first component to `apify/google-search-scraper` and the second one to `clockworks/free-tiktok-scraper`:
 ![Flow - Actors configuration](../images/langflow/apify_actors_configuration.png)
 
-Add the **Agent** component from the menu and set your OpenAI API key (get it from the [OpenAI API keys page](https://.openai.com/account/api-keys)):
+Add the **Agent** component from the menu and set your OpenAI API key (get it from the [OpenAI API keys page](https://platform.openai.com/account/api-keys)):
 
 :::tip Optimize Agent results
 

--- a/sources/platform/integrations/ai/langgraph.md
+++ b/sources/platform/integrations/ai/langgraph.md
@@ -19,7 +19,7 @@ This guide will demonstrate how to use Apify Actors with LangGraph by building a
 
 - **Apify API token**: To use Apify Actors in LangGraph, you need an Apify API token. If you don't have one, you can learn how to obtain it in the [Apify documentation](https://docs.apify.com/integrations/api).
 
-- **OpenAI API key**: In order to work with agents in LangGraph, you need an OpenAI API key. If you don't have one, you can get it from the [OpenAI platform](https://.openai.com/account/api-keys).
+- **OpenAI API key**: In order to work with agents in LangGraph, you need an OpenAI API key. If you don't have one, you can get it from the [OpenAI platform](https://platform.openai.com/account/api-keys).
 
 - **Python packages**:  You need to install the following Python packages:
 

--- a/sources/platform/integrations/ai/mastra.md
+++ b/sources/platform/integrations/ai/mastra.md
@@ -22,7 +22,7 @@ This guide demonstrates how to integrate Apify Actors with Mastra by building an
 ### Prerequisites
 
 - _Apify API token_: To use Apify Actors, you need an Apify API token. Learn how to obtain it in the [Apify documentation](https://docs.apify.com/integrations/api).
-- _LLM provider API key_: To power the agents, you need an LLM provider API key. For example, get one from the [OpenAI](https://.openai.com/account/api-keys) or [Anthropic](https://.claude.com/settings/keys).
+- _LLM provider API key_: To power the agents, you need an LLM provider API key. For example, get one from the [OpenAI](https://platform.openai.com/account/api-keys) or [Anthropic](https://platform.claude.com/settings/keys).
 - _Node.js_: Ensure you have Node.js installed.
 - _Packages_: Install the following packages:
 

--- a/sources/platform/integrations/ai/openai/chatgpt.md
+++ b/sources/platform/integrations/ai/openai/chatgpt.md
@@ -24,7 +24,7 @@ Before connecting ChatGPT to Apify, you'll need:
 - _An Apify account_ - If you don't have an Apify account already, you can [sign up](https://console.apify.com/sign-up)
 - _Apify API token_ - Get your API token from the **API & Integrations** section in [Apify Console](https://console.apify.com/settings/integrations). This token authorizes the MCP server to run Actors on your behalf. Make sure to keep it secure.
 - _An OpenAI account with access to ChatGPT_ - You need an OpenAI account to use ChatGPT.
-- _ChatGPT with Developer mode enabled_ - You must enable [Developer Mode](https://.openai.com/docs/guides/developer-mode) to add custom connectors (when the Developer mode is active, the message input box is outlined in orange).
+- _ChatGPT with Developer mode enabled_ - You must enable [Developer Mode](https://platform.openai.com/docs/guides/developer-mode) to add custom connectors (when the Developer mode is active, the message input box is outlined in orange).
 
 ## Create an MCP connector
 
@@ -82,7 +82,7 @@ You should see ChatGPT calling Apify tools - such as the [RAG Web Browser](https
 
 ## Resources
 
-- [ChatGPT Developer mode](https://.openai.com/docs/guides/developer-mode) - Learn how to enable Developer Mode in ChatGPT
-- [Connectors and MCP servers](https://.openai.com/docs/guides/tools-connectors-mcp) - Official OpenAI documentation on using MCP servers with ChatGPT
+- [ChatGPT Developer mode](https://platform.openai.com/docs/guides/developer-mode) - Learn how to enable Developer Mode in ChatGPT
+- [Connectors and MCP servers](https://platform.openai.com/docs/guides/tools-connectors-mcp) - Official OpenAI documentation on using MCP servers with ChatGPT
 - [Apify MCP server](https://mcp.apify.com) - Interactive configuration tool for the Apify MCP server
 - [Apify MCP documentation](/integrations/mcp) - Complete guide to using the Apify MCP server

--- a/sources/platform/integrations/ai/openai/openai-agents.md
+++ b/sources/platform/integrations/ai/openai/openai-agents.md
@@ -20,7 +20,7 @@ Before integrating Apify with OpenAI Agents SDK, you'll need:
 
 - _An Apify account_ - If you don't have an Apify account already, you can [sign up](https://console.apify.com/sign-up)
 - _Apify API token_ - Get your API token from the **API & Integrations** section in [Apify Console](https://console.apify.com/settings/integrations). This token authorizes the Apify MCP server to run Actors on your behalf. Make sure to keep it secure.
-- _OpenAI API key_ - Get your API key from the [OpenAI platform](https://.openai.com/account/api-keys). You need this to use OpenAI Agents SDK.
+- _OpenAI API key_ - Get your API key from the [OpenAI platform](https://platform.openai.com/account/api-keys). You need this to use OpenAI Agents SDK.
 - _Python packages_ - Install the required packages:
 
     ```bash

--- a/sources/platform/integrations/ai/openai/openai-assistants.md
+++ b/sources/platform/integrations/ai/openai/openai-assistants.md
@@ -7,19 +7,19 @@ slug: /integrations/openai-assistants
 
 import ThirdPartyDisclaimer from '@site/sources/_partials/_third-party-integration.mdx';
 
-[OpenAI Assistants API](https://.openai.com/docs/assistants/overview) allows you to build your own AI applications such as chatbots, virtual assistants, and more.
-The OpenAI Assistants can access OpenAI knowledge base ([vector store](https://.openai.com/docs/api-reference/vector-stores)) via file search and use function calling for dynamic interaction and data retrieval.
+[OpenAI Assistants API](https://platform.openai.com/docs/assistants/overview) allows you to build your own AI applications such as chatbots, virtual assistants, and more.
+The OpenAI Assistants can access OpenAI knowledge base ([vector store](https://platform.openai.com/docs/api-reference/vector-stores)) via file search and use function calling for dynamic interaction and data retrieval.
 
 Unlike Custom GPT, OpenAI Assistants are available via API, enabling integration with Apify to automatically update assistant data and deliver real-time information, improving the quality of answers.
 
 In this tutorial, we’ll start by demonstrating how to create an assistant and integrate real-time data using function calling with the [RAG Web Browser](https://apify.com/apify/rag-web-browser).
-Next, we’ll show how to save data from Apify Actors into the OpenAI Vector Store for easy retrieval through [file-search](https://.openai.com/docs/assistants/tools/file-search).
+Next, we’ll show how to save data from Apify Actors into the OpenAI Vector Store for easy retrieval through [file-search](https://platform.openai.com/docs/assistants/tools/file-search).
 
 <ThirdPartyDisclaimer />
 
 ## Real-time search data for OpenAI Assistant
 
-We'll use the [RAG Web Browser](https://apify.com/apify/rag-web-browser) Actor to fetch the latest information from the web and provide it to the OpenAI Assistant through [function calling](https://.openai.com/docs/assistants/tools/function-calling?context=without-streaming).
+We'll use the [RAG Web Browser](https://apify.com/apify/rag-web-browser) Actor to fetch the latest information from the web and provide it to the OpenAI Assistant through [function calling](https://platform.openai.com/docs/assistants/tools/function-calling?context=without-streaming).
 To begin, we need to create an OpenAI Assistant with the appropriate instructions.
 After that, we can initiate a conversation with the assistant by creating a thread, adding messages, and running the assistant to receive responses.
 The image below provides an overview of the entire process:
@@ -44,7 +44,7 @@ from openai import OpenAI, Stream
 from openai.types.beta.threads.run_submit_tool_outputs_params import ToolOutput
 ```
 
-Find your [Apify API token](https://console.apify.com/settings/integrations) and [OpenAI API key](https://.openai.com/account/api-keys) and initialize OpenAI and Apify clients:
+Find your [Apify API token](https://console.apify.com/settings/integrations) and [OpenAI API key](https://platform.openai.com/account/api-keys) and initialize OpenAI and Apify clients:
 
 ```python
 client = OpenAI(api_key="YOUR OPENAI API KEY")
@@ -245,7 +245,7 @@ for m in client.beta.threads.messages.list(thread_id=run.thread_id):
 
 ## Save data into OpenAI Vector Store and use it in the assistant
 
-To provide real-time or proprietary data, OpenAI Assistants can access the [OpenAI Vector Store](https://.openai.com/docs/assistants/tools/file-search/vector-stores) to retrieve information for their answers.
+To provide real-time or proprietary data, OpenAI Assistants can access the [OpenAI Vector Store](https://platform.openai.com/docs/assistants/tools/file-search/vector-stores) to retrieve information for their answers.
 With the [Apify OpenAI Vector Store Integration](https://apify.com/jiri.spilka/openai-vector-store-integration), data saving and updating the OpenAI Vector Store can be fully automated.
 The following image illustrates the Apify-OpenAI Vector Store integration:
 
@@ -260,7 +260,7 @@ Before we start, we need to install all dependencies:
 pip install apify-client openai
 ```
 
-Find your [Apify API token](https://console.apify.com/settings/integrations) and [OpenAI API key](https://.openai.com/account/api-keys) and initialize OpenAI and Apify clients:
+Find your [Apify API token](https://console.apify.com/settings/integrations) and [OpenAI API key](https://platform.openai.com/account/api-keys) and initialize OpenAI and Apify clients:
 
 ```python
 from apify_client import ApifyClient
@@ -416,7 +416,7 @@ for m in client.beta.threads.messages.list(thread_id=run.thread_id):
 
 ## Resources
 
-- [OpenAI Assistants](https://.openai.com/docs/assistants/overview)
-- [OpenAI function calling](https://.openai.com/docs/assistants/tools/function-calling)
+- [OpenAI Assistants](https://platform.openai.com/docs/assistants/overview)
+- [OpenAI function calling](https://platform.openai.com/docs/assistants/tools/function-calling)
 - [RAG Web Browser](https://apify.com/apify/rag-web-browser) Actor
 - [OpenAI Vector Store Integration](https://apify.com/jiri.spilka/openai-vector-store-integration) Actor


### PR DESCRIPTION
## What this fixes

The IA v3 URL migration stripped `platform` from external hostnames as well as internal paths, corrupting 21 links across 9 files:

```
https://platform.openai.com/...  →  https://.openai.com/...   (20 occurrences)
https://platform.claude.com/...  →  https://.claude.com/...   (1 occurrence)
```

These are **hard-dead rather than redirects** - `.openai.com` is not a valid hostname, so they fail at DNS resolution instead of returning an HTTP status. The build's broken-link check only validates internal links, so CI stayed green and nothing surfaced them.

Most sit in prerequisites sections, where a reader following the link to get an API key hits a browser error.

## Approach

This is a pure inverse of the corruption - restore the subdomain, change nothing else - so it stays trivially reviewable.

| File | Fixed |
|:--|--:|
| `sources/platform/integrations/ai/openai/openai-assistants.md` | 7 |
| `sources/platform/integrations/ai/openai/chatgpt.md` | 3 |
| `sources/platform/integrations/ai/langflow.md` | 2 |
| `sources/platform/integrations/ai/mastra.md` | 2 |
| `sources/platform/integrations/ai/agno.md` | 1 |
| `sources/platform/integrations/ai/crewai.md` | 1 |
| `sources/platform/integrations/ai/haystack.md` | 1 |
| `sources/platform/integrations/ai/langgraph.md` | 1 |
| `sources/platform/integrations/ai/openai/openai-agents.md` | 1 |

`langchain.md` carried a 22nd occurrence, already fixed by #2683.

## Verification

- Zero malformed URLs remain: `git grep -n "https://\.\w" -- 'sources/**/*.md' 'sources/**/*.mdx'` returns nothing.
- No `platform.platform.` double-prefixes.
- All 10 distinct targets resolve. Two return `403` to `curl` (`/account/api-keys`, `/docs/api-reference/vector-stores`) - that is OpenAI blocking non-browser clients, not a dead page.
- Vale and markdownlint clean on all 9 files.

## Deliberately out of scope

Two things worth separate follow-up rather than mixing into a link fix:

1. **8 of the OpenAI `/docs/...` links now `301` to `developers.openai.com/api/docs/...`.** Correct after this fix, but one redirect hop from canonical.
2. **`/docs/assistants/overview` redirects to `/docs/assistants/migration`** - OpenAI is deprecating the Assistants API. That is a content problem for `openai-assistants.md` (7 of the 21 links live on that page), not a link problem.

## Suggested guard

Nothing in CI checks external links today, which is why a mechanical find/replace could break 22 of them silently. Worth considering an external-link check, at minimum a hostname sanity check for `https://.`
