### PR TITLE
docs: Indicate that the output and input schemas are required to publish an Actor

### DIFF
--- a/sources/platform/actors/development/actor_definition/input_schema/index.md
+++ b/sources/platform/actors/development/actor_definition/input_schema/index.md
@@ -7,6 +7,8 @@ slug: /actors/development/actor-definition/input-schema
 
 The input schema defines the input parameters for an Actor. It's a `JSON` object comprising various field types supported by the Apify platform. Based on the input schema, the Apify platform automatically generates a user interface for the Actor. It also validates the input data passed to the Actor when it's executed through the API or the Apify Console UI.
 
+To [publish your Actor to Apify Store](/actors/publishing/publish), an input schema is required.
+
 The following is an example of an auto-generated UI for the [Website Content Crawler](https://apify.com/apify/website-content-crawler) Actor.
 
 ![Website Content Crawler input UI](./images/input-ui-website-content-crawler.png)

--- a/sources/platform/actors/development/actor_definition/output_schema/index.md
+++ b/sources/platform/actors/development/actor_definition/output_schema/index.md
@@ -10,11 +10,11 @@ The Actor output schema builds upon the schemas for the [dataset](/storage/datas
 
 ## Why output schema matters
 
-Output schema is essential for:
+To [publish your Actor to Apify Store](/actors/publishing/publish), an output schema is required. It's also essential for:
 
-- AI agent integration: When agents use Actors through the MCP server or API, they need to know what results to expect. Without output schema, agents cannot effectively chain Actors or process results.
-- User experience: Clear output definitions help users understand what data they will receive before running an Actor.
-- API consumers: The output schema appears in the `GET Run` API response, enabling programmatic discovery of Actor outputs.
+- AI agent integration. When agents use Actors through the MCP server or API, they need to know what results to expect. Without output schema, agents cannot effectively chain Actors or process results.
+- User experience. Clear output definitions help users understand what data they will receive before running an Actor.
+- API consumers. The output schema appears in the `GET Run` API response, enabling programmatic discovery of Actor outputs.
 
 :::tip Define output schema
 


### PR DESCRIPTION
Closes [#29593](https://github.com/apify/apify-core/issues/29593). 

The procedure is already phrased without `optional` word. 