### PR TITLE
docs: rename Unblocker proxy to Unblocker

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -834,6 +834,7 @@ server {
     rewrite ^/actors/development/actor-definition/key-value-store-schema$ /storage/key-value-store-schema   redirect;
     # Limits moved from top-nav (/limits) into Account.
     rewrite ^/limits$                                                    /account/limits                   redirect;
+    rewrite ^/proxy/unblocker-proxy$                                     /proxy/unblocker                  redirect;
 
     # Soft-landings for deleted URLs (better UX than a 404)
     rewrite ^/platform/integrations/airtable/console-integration$ /integrations/airtable               permanent;

--- a/sources/platform/proxy/index.md
+++ b/sources/platform/proxy/index.md
@@ -37,9 +37,9 @@ Each proxy type has distinct advantages, disadvantages, and pricing. Use them to
         to="/proxy/google-serp-proxy"
     />
     <Card
-        title="Unblocker proxy"
+        title="Unblocker"
         desc="Automatically bypasses anti-bot and anti-captcha systems using built-in smart routing, so you don't need to detect or solve challenges yourself."
-        to="/proxy/unblocker-proxy"
+        to="/proxy/unblocker"
     />
 </CardGrid>
 
@@ -102,7 +102,7 @@ For more examples connecting to Apify Proxy from the SDKs and other libraries:
 * [Datacenter proxy](./datacenter_proxy.md#examples)
 * [Residential proxy](./residential_proxy.md#connecting-to-residential-proxy)
 * [Google SERP proxy](./google_serp_proxy.md#examples)
-* [Unblocker proxy](./unblocker_proxy.md#connect-to-unblocker-proxy)
+* [Unblocker](./unblocker.md#connect-to-unblocker)
 * [Apify SDK JavaScript](/sdk/js/docs/guides/proxy-management)
 * [Apify SDK Python](/sdk/python/docs/concepts/proxy-management)
 * [Crawlee](https://crawlee.dev/docs/guides/proxy-management)
@@ -197,7 +197,7 @@ The table below describes the available parameters.
             <br/>- <code>groups-[group name]</code> or <code>auto</code> when using datacenter proxies.
             <br/>- <code>groups-RESIDENTIAL</code> when using residential proxies.
             <br/>- <code>groups-GOOGLE_SERP</code> when using Google SERP proxies.
-            <br/>- <code>groups-UNBLOCKER</code> when using [Unblocker proxy](./unblocker_proxy.md).
+            <br/>- <code>groups-UNBLOCKER</code> when using [Unblocker](./unblocker.md).
         </td>
     </tr>
     <tr>

--- a/sources/platform/proxy/unblocker.md
+++ b/sources/platform/proxy/unblocker.md
@@ -8,7 +8,7 @@ slug: /proxy/unblocker
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-Unblocker is a proxy service designed for scraping websites protected by anti-bot and anti-captcha systems. Instead of building and maintaining your own detection and bypass logic, you can route requests through Unblocker, which automatically handles many common protection mechanisms.
+Unblocker is a proxy service designed to scrape any website - from pages without protections to those heavily protected by bot detection and CAPTCHA challenges. Instead of building and maintaining your own detection-bypass logic, you can route requests through Unblocker, which automatically handles many common protection mechanisms.
 
 This makes it a good choice for accessing websites with advanced bot protection while keeping your scraping code simple.
 

--- a/sources/platform/proxy/unblocker.md
+++ b/sources/platform/proxy/unblocker.md
@@ -1,27 +1,27 @@
 ---
-title: Unblocker proxy
+title: Unblocker
 description: Bypass anti-bot and anti-captcha systems automatically when scraping, without building or maintaining your own bypass logic for blocked websites.
 sidebar_position: 10.5
-slug: /proxy/unblocker-proxy
+slug: /proxy/unblocker
 ---
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-Unblocker proxy is designed for scraping websites protected by anti-bot and anti-captcha systems. Instead of building and maintaining your own detection and bypass logic, you can route requests through Unblocker proxy, which automatically handles many common protection mechanisms.
+Unblocker is a proxy service designed for scraping websites protected by anti-bot and anti-captcha systems. Instead of building and maintaining your own detection and bypass logic, you can route requests through Unblocker, which automatically handles many common protection mechanisms.
 
 This makes it a good choice for accessing websites with advanced bot protection while keeping your scraping code simple.
 
 Pricing is based on Unblocker units, which are separate from [compute units](/actors/running/usage-and-resources#what-is-a-compute-unit). Each successful request costs 10 units. Units are priced per 1,000 at a rate that depends on your plan, and your consumption is displayed on your [proxy usage dashboard](https://console.apify.com/proxy/usage) in Apify Console.
 
-## Connect to Unblocker proxy
+## Connect to Unblocker
 
-Connecting to Unblocker proxy works the same way as [datacenter proxy](./datacenter_proxy.md), with two differences:
+Connecting to Unblocker works the same way as [datacenter proxy](./datacenter_proxy.md), with two differences:
 
 - The `groups` [username parameter](./index.md#username-parameters) must always specify `UNBLOCKER`.
-- Unblocker proxy selects the country automatically, so you rarely need to set `country`.
+- Unblocker selects the country automatically, so you rarely need to set `country`.
 
-Unlike [datacenter](./datacenter_proxy.md) or [residential](./residential_proxy.md) proxies, Unblocker proxy has no [session](./index.md#sessions) parameter, so you can't keep the same IP address across requests.
+Unlike [datacenter](./datacenter_proxy.md) or [residential](./residential_proxy.md) proxies, Unblocker has no [session](./index.md#sessions) parameter, so you can't keep the same IP address across requests.
 
 ### How to set a proxy group
 
@@ -68,13 +68,13 @@ async def main():
 
 ### How to set a proxy country
 
-Unblocker proxy selects the best available country automatically based on the target website. You don't need to set a country in most cases.
+Unblocker selects the best available country automatically based on the target website. You don't need to set a country in most cases.
 
 If you need requests to come from a specific country, specify the `country` [username parameter](./index.md#username-parameters) as `country-COUNTRY-CODE`. For example, to target Japan, set the username to `groups-UNBLOCKER,country-JP`.
 
-:::tip Let Unblocker proxy decide
+:::tip Let Unblocker decide
 
-Only set a country when your use case requires it (for example, geo-restricted content). Setting a country limits the pool of available IP addresses and can reduce how effectively Unblocker proxy bypasses anti-bot protection.
+Only set a country when your use case requires it (for example, geo-restricted content). Setting a country limits the pool of available IP addresses and can reduce how effectively Unblocker bypasses anti-bot protection.
 
 :::
 


### PR DESCRIPTION
Drop the "proxy" qualifier, matching the Slack decision. Capitalization stays. Renames the page slug to /proxy/unblocker and adds a redirect from the old URL.