### PR TITLE
ci: pin third-party actions to commit SHAs

### DIFF
--- a/.github/workflows/actions-checks.yaml
+++ b/.github/workflows/actions-checks.yaml
@@ -12,6 +12,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Run actionlint
-        uses: rhysd/actionlint@v1.7.12
+        uses: rhysd/actionlint@914e7df21a07ef503a81201c76d2b11c789d3fca # v1.7.12

--- a/.github/workflows/bump-openapi-version.yaml
+++ b/.github/workflows/bump-openapi-version.yaml
@@ -13,7 +13,7 @@ jobs:
         runs-on: ubuntu-latest
 
         steps:
-            - uses: actions/checkout@v7
+            - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
               with:
                   token: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}
 

--- a/.github/workflows/docs-ui-tests.yaml
+++ b/.github/workflows/docs-ui-tests.yaml
@@ -25,10 +25,10 @@ jobs:
             contents: read
             issues: write   # the failure step files a drift issue for maintainers
         steps:
-            -   uses: actions/checkout@v7
+            -   uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
             -   name: Use Node.js 24
-                uses: actions/setup-node@v7
+                uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
                 with:
                     node-version: 24
 
@@ -55,7 +55,7 @@ jobs:
 
             -   name: Upload Playwright report
                 if: always()
-                uses: actions/upload-artifact@v4
+                uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
                 with:
                     name: playwright-report
                     path: docs-tests/playwright-report/
@@ -63,7 +63,7 @@ jobs:
 
             -   name: Upload drift report (issues.json)
                 if: always()
-                uses: actions/upload-artifact@v4
+                uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
                 with:
                     name: drift-report
                     path: docs-tests/output/

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -20,9 +20,9 @@ jobs:
         runs-on: ubuntu-latest
 
         steps:
-            -   uses: actions/checkout@v7
+            -   uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
             -   name: Use Node.js 24
-                uses: actions/setup-node@v7
+                uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
                 with:
                     node-version: 24
 
@@ -37,15 +37,15 @@ jobs:
                     SEGMENT_TOKEN: ${{ secrets.SEGMENT_TOKEN }}
 
             -   name: Set up GitHub Pages
-                uses: actions/configure-pages@v6
+                uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
 
             -   name: Upload GitHub Pages artifact
-                uses: actions/upload-pages-artifact@v5
+                uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
                 with:
                     path: ./build
 
             -   name: Deploy artifact to GitHub Pages
-                uses: actions/deploy-pages@v5
+                uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0
 
             -   name: Invalidate CloudFront cache
                 run: |

--- a/.github/workflows/lychee.yml
+++ b/.github/workflows/lychee.yml
@@ -9,10 +9,10 @@ jobs:
     link-check:
         runs-on: ubuntu-latest
         steps:
-            -   uses: actions/checkout@v7
+            -   uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
             -   name: Use Node.js 24
-                uses: actions/setup-node@v7
+                uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
                 with:
                     node-version: 24
 
@@ -28,7 +28,7 @@ jobs:
 
             -   name: Run Lychee Link Checker
                 id: lychee
-                uses: lycheeverse/lychee-action@v2.8.0
+                uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2.8.0
                 env:
                     GITHUB_TOKEN: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}
                 with:

--- a/.github/workflows/openapi-ci.yaml
+++ b/.github/workflows/openapi-ci.yaml
@@ -15,10 +15,10 @@ jobs:
         runs-on: ubuntu-latest
 
         steps:
-            - uses: actions/checkout@v7
+            - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
             - name: Set up Node.js
-              uses: actions/setup-node@v7
+              uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
               with:
                   node-version: 24
 
@@ -36,10 +36,10 @@ jobs:
         needs: lint
 
         steps:
-            - uses: actions/checkout@v7
+            - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
             - name: Set up Node.js
-              uses: actions/setup-node@v7
+              uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
               with:
                   node-version: 24
 
@@ -49,7 +49,7 @@ jobs:
               run: pnpm openapi:build
 
             - name: Upload bundles
-              uses: actions/upload-artifact@v7
+              uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
               with:
                   name: openapi-bundles
                   path: |
@@ -63,17 +63,17 @@ jobs:
         needs: [lint, build]
 
         steps:
-            - uses: actions/checkout@v7
+            - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
             - name: Set up Node.js
-              uses: actions/setup-node@v7
+              uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
               with:
                   node-version: 24
 
             - uses: apify/actions/pnpm-install@v1.3.1
 
             - name: Download bundles
-              uses: actions/download-artifact@v8
+              uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
               with:
                   name: openapi-bundles
                   path: static/api/

--- a/.github/workflows/publish-to-npm.yaml
+++ b/.github/workflows/publish-to-npm.yaml
@@ -21,18 +21,18 @@ jobs:
         outputs:
             theme_changed: ${{ steps.changed-theme-files.outputs.any_changed }}
         steps:
-            -   uses: actions/checkout@v7
+            -   uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
                 with:
                     fetch-depth: 0
 
             -   name: Use Node.js
-                uses: actions/setup-node@v7
+                uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
                 with:
                     node-version: 24
 
             -   name: Check changes in theme
                 id: changed-theme-files
-                uses: tj-actions/changed-files@v47
+                uses: tj-actions/changed-files@24d32ffd492484c1d75e0c0b894501ddb9d30d62 # v47.0.0
                 with:
                     since_last_remote_commit: "true"
                     files: |
@@ -43,12 +43,12 @@ jobs:
         if: ${{ needs.look_for_change.outputs.theme_changed == 'true' || github.event_name == 'workflow_dispatch' }}
         runs-on: ubuntu-latest
         steps:
-            -   uses: actions/checkout@v7
+            -   uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
                 with:
                     token: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}
 
             -   name: Use Node.js
-                uses: actions/setup-node@v7
+                uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
                 with:
                     node-version: 24
                     registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/spell-check.yaml
+++ b/.github/workflows/spell-check.yaml
@@ -12,6 +12,6 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v7
+              uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
             - name: Check spelling with typos
-              uses: crate-ci/typos@v1.44.0
+              uses: crate-ci/typos@631208b7aac2daa8b707f55e7331f9112b0e062d # v1.44.0

--- a/.github/workflows/test-academy.yml
+++ b/.github/workflows/test-academy.yml
@@ -11,15 +11,15 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             -   name: Checkout Source code
-                uses: actions/checkout@v7
+                uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
             -   name: Setup Node.js
-                uses: actions/setup-node@v7
+                uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
                 with:
                     node-version: 24
 
             -   name: Setup Python
-                uses: astral-sh/setup-uv@v9.0.0
+                uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
             -   uses: apify/actions/pnpm-install@v1.3.1
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,10 +11,10 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             -   name: Checkout Source code
-                uses: actions/checkout@v7
+                uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
             -   name: Use Node.js 24
-                uses: actions/setup-node@v7
+                uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
                 with:
                     node-version: 24
 
@@ -237,18 +237,18 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             -   name: Checkout Source code
-                uses: actions/checkout@v7
+                uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
             -   name: Get changed files
                 id: changed-files
-                uses: tj-actions/changed-files@v47
+                uses: tj-actions/changed-files@24d32ffd492484c1d75e0c0b894501ddb9d30d62 # v47.0.0
                 with:
                     files: '**/*.{md,mdx}'
                     files_ignore: '!sources/api/*.{md,mdx}'
                     separator: ","
 
             -   name: Use Node.js 24
-                uses: actions/setup-node@v7
+                uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
                 with:
                     node-version: 24
 
@@ -269,10 +269,10 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             -   name: Checkout Source code
-                uses: actions/checkout@v7
+                uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
             -   name: Use Node.js 24
-                uses: actions/setup-node@v7
+                uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
                 with:
                     node-version: 24
 
@@ -289,11 +289,11 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             -   name: Checkout Source code
-                uses: actions/checkout@v7
+                uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
             -   name: Get changed unoptimized image files in sources
                 id: changed-files
-                uses: tj-actions/changed-files@v47
+                uses: tj-actions/changed-files@24d32ffd492484c1d75e0c0b894501ddb9d30d62 # v47.0.0
                 with:
                     files: |
                         sources/**/*.{png,jpg,jpeg,gif,bmp,tif,tiff,avif}

--- a/.github/workflows/vale.yaml
+++ b/.github/workflows/vale.yaml
@@ -29,7 +29,7 @@ jobs:
                         workflows/**/*.{md,mdx}
                     separator: ','
 
-            -   uses: errata-ai/vale-action@{"message":"Not # reviewdog
+            -   uses: errata-ai/vale-action@518a9136acc6e6668ce7c00d367051e0941e87ff # reviewdog
                 if: steps.changed-files.outputs.any_changed == 'true'
                 with:
                     files: ${{ steps.changed-files.outputs.all_changed_files }}

--- a/.github/workflows/vale.yaml
+++ b/.github/workflows/vale.yaml
@@ -7,13 +7,13 @@ jobs:
         runs-on: ubuntu-latest
 
         steps:
-            -   uses: actions/checkout@v7
+            -   uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
                 with:
                     fetch-depth: 0
 
             -   name: Get changed files
                 id: changed-files
-                uses: tj-actions/changed-files@v47
+                uses: tj-actions/changed-files@24d32ffd492484c1d75e0c0b894501ddb9d30d62 # v47.0.0
                 with:
                     files: '**/*.{md,mdx}'
                     files_ignore: |
@@ -29,7 +29,7 @@ jobs:
                         workflows/**/*.{md,mdx}
                     separator: ','
 
-            -   uses: errata-ai/vale-action@reviewdog
+            -   uses: errata-ai/vale-action@{"message":"Not # reviewdog
                 if: steps.changed-files.outputs.any_changed == 'true'
                 with:
                     files: ${{ steps.changed-files.outputs.all_changed_files }}


### PR DESCRIPTION
This pins every third-party action in the workflows to a full commit SHA, keeping the resolved version tag as a trailing comment. Renovate understands that convention and updates the SHA and comment together.

Same change as apify/crawlee#4051, rolled out team-wide. The trigger was the `v11` tag of `EndBug/add-and-commit` moving to a broken release that failed to load and killed the crawlee publish workflow. With SHA pins, a tag moving under us, by accident or by compromise, can't break or hijack CI anymore. Where `EndBug/add-and-commit` is used, it's pinned to v11.0.0, the last working release.

Own-org references (`apify/*`) stay on floating refs on purpose, since we control those repos.
