### PR TITLE
harden: add path validation in add-redoc-legacy-urls-to-operations.py...

### DIFF
--- a/apify-api/scripts/add-redoc-legacy-urls-to-operations.py
+++ b/apify-api/scripts/add-redoc-legacy-urls-to-operations.py
@@ -1,6 +1,7 @@
 import ruamel.yaml
 import csv
 import json
+import os
 from slugify import slugify
 from ruamel.yaml.scalarstring import LiteralScalarString
 import re
@@ -41,7 +42,10 @@ for path, ref in openapi_yaml.get('paths').items():
     print(f'Working with path: {path}')
 
     # Get the yaml file for the path and parse it
-    path_path = '../openapi/' + ref.get('$ref')
+    base_dir = os.path.realpath('../openapi')
+    path_path = os.path.realpath(os.path.join('../openapi', ref.get('$ref')))
+    if not path_path.startswith(base_dir + os.sep):
+        raise ValueError(f'Path traversal detected: {path_path}')
     with open(path_path, 'r') as file:
         path_yaml = yaml.load(file)
 


### PR DESCRIPTION
## Summary
Harden input handling in `apify-api/scripts/add-redoc-legacy-urls-to-operations.py` (flagged by semgrep).

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | utils.custom.path-traversal-open |
| **Severity** | HIGH |
| **Scanner** | semgrep |
| **Rule** | `utils.custom.path-traversal-open` |
| **File** | `apify-api/scripts/add-redoc-legacy-urls-to-operations.py:44` |
| **Assessment** | Defensive hardening |

**Description**: User-controlled input used in file path for open() without sanitization. This can allow path traversal attacks to read arbitrary files.


## Threat Model Context

This is a web application - XSS and injection vulnerabilities can affect end users.

## Changes
- `apify-api/scripts/add-redoc-legacy-urls-to-operations.py`

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path; it only tightens handling of untrusted input and leaves valid inputs unaffected.

---
*This patch removes an exploit primitive — a code pattern that, while not independently exploitable today, could be chained with other weaknesses by automated exploit-development tooling. Proactive removal of such primitives raises the bar against increasingly capable automated attack tools.*

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
