### PR TITLE
docs: enforce no stacked headings in writing style guide

### DIFF
--- a/sources/platform/actors/running/index.md
+++ b/sources/platform/actors/running/index.md
@@ -9,13 +9,17 @@ slug: /actors/running
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-To run your first Apify Actor, we recommend trying one of the existing Actors from [Apify Store](https://apify.com/store). For details on building your own, see [Actor development](./development).
+You can run Actors manually in Apify Console, with the Apify API, or programmatically from your own applications. To run your first Apify Actor, we recommend trying one of the existing Actors from [Apify Store](https://apify.com/store). For details on building your own, see [Actor development](./development).
 
-## Prerequisites
+## Run Actors manually in Apify Console
+
+The easiest way to run an Actor is directly in [Apify Console](https://console.apify.com). The following tutorial takes you through your first run, from choosing an Actor to exporting its results.
+
+### Prerequisites
 
 To complete this tutorial, you need an Apify account. If you don't have it yet, [sign up for free](https://console.apify.com/sign-up).
 
-## 1. Choose your Actor
+### 1. Choose your Actor
 
 To find an Actor in Apify Store:
 
@@ -25,7 +29,7 @@ To find an Actor in Apify Store:
 
 For this tutorial, let's choose [Website Content Crawler](https://console.apify.com/actors/aYG0l9s7dbB7j3gbS/information/version-0/readme).
 
-## 2. Configure and run your Actor
+### 2. Configure and run your Actor
 
 Once you select the Actor, you will be taken to the Actor's detail page.
 
@@ -35,7 +39,7 @@ To run the Actor, click **Start**.
 
 ![Website Content Crawler in Apify Console. Input tab is open and the Start button is highlighted](./images/configure-and-run-actor.svg)
 
-## 3. Wait for the results
+### 3. Wait for the results
 
 The Actor might take a while to gather results and finish its run. While waiting, let's explore the remaining options:
 
@@ -44,7 +48,7 @@ The Actor might take a while to gather results and finish its run. While waiting
 
 ![Website Content Crawler in Apify Console. Output tab is open and the API and Export buttons are highlighted](./images/results-of-actor-run.svg)
 
-## 4. Save the results
+### 4. Save the results
 
 The results of the Actor run appear in the **Output** tab. To save the data, click **Export**. You can choose from multiple formats.
 

--- a/sources/platform/actors/running/index.md
+++ b/sources/platform/actors/running/index.md
@@ -54,7 +54,7 @@ Now you can go back to the **Input** tab and try again with different settings, 
 
 ## Run Actors with the Apify API
 
-To invoke Actors with the Apify API, send an HTTP POST request to the [Run Actor](/api/v2/actors-runs-post) endpoint. For example:
+To invoke Actors with the [Apify API](/api), send an HTTP POST request to the [Run Actor](/api/v2/actors-runs-post) endpoint. For example:
 
 ```text
 https://api.apify.com/v2/actors/compass~crawler-google-places/runs?token=<YOUR_API_TOKEN>

--- a/sources/platform/actors/running/index.md
+++ b/sources/platform/actors/running/index.md
@@ -13,7 +13,7 @@ You can run Actors manually in Apify Console, with the Apify API, or programmati
 
 ## Run Actors manually in Apify Console
 
-The easiest way to run an Actor is directly in [Apify Console](https://console.apify.com). The following tutorial takes you through your first run, from choosing an Actor to exporting its results.
+This tutorial covers a complete first run without any code, by choosing an Actor in [Apify Store](https://apify.com/store) and running it.
 
 ### Prerequisites
 

--- a/sources/platform/actors/running/index.md
+++ b/sources/platform/actors/running/index.md
@@ -11,15 +11,13 @@ import TabItem from '@theme/TabItem';
 
 You can run Actors manually in Apify Console, with the Apify API, programmatically from your own applications, or from AI agents. To run your first Apify Actor, we recommend trying one of the existing Actors from [Apify Store](https://apify.com/store). For details on building your own, see [Actor development](./development).
 
+In all cases, you need an Apify account - [sign up for free](https://console.apify.com/sign-up) if you don't have one yet.
+
 ## Run Actors manually in Apify Console
 
 This tutorial covers a complete first run without any code, by choosing an Actor in [Apify Store](https://apify.com/store) and running it.
 
-### Prerequisites
-
-To complete this tutorial, you need an Apify account. If you don't have it yet, [sign up for free](https://console.apify.com/sign-up).
-
-### 1. Choose your Actor
+### 1. Choose an Actor
 
 To find an Actor in Apify Store:
 
@@ -29,11 +27,11 @@ To find an Actor in Apify Store:
 
 For this tutorial, let's choose [Website Content Crawler](https://console.apify.com/actors/aYG0l9s7dbB7j3gbS/information/version-0/readme).
 
-### 2. Configure and run your Actor
+### 2. Configure and run the Actor
 
 Once you select the Actor, you will be taken to the Actor's detail page.
 
-In the **Input** tab, you can customize your Actor's behavior. Website Content Crawler is pre-configured to run without extra input, so you don't need to change anything.
+In the **Input** tab, you can customize the Actor's behavior. Website Content Crawler is pre-configured to run without extra input, so you don't need to change anything.
 
 To run the Actor, click **Start**.
 

--- a/sources/platform/actors/running/index.md
+++ b/sources/platform/actors/running/index.md
@@ -9,15 +9,13 @@ slug: /actors/running
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-## Run your first Apify Actor
-
 To get started, we recommend trying one of the existing Actors from [Apify Store](https://apify.com/store). For details on building your own, see [Actor development](./development).
 
-### Prerequisites
+## Prerequisites
 
 To complete this tutorial, you need an Apify account. If you don't have it yet, [sign up for free](https://console.apify.com/sign-up).
 
-### 1. Choose your Actor
+## 1. Choose your Actor
 
 To find an Actor in Apify Store:
 
@@ -27,7 +25,7 @@ To find an Actor in Apify Store:
 
 For this tutorial, let's choose [Website Content Crawler](https://console.apify.com/actors/aYG0l9s7dbB7j3gbS/information/version-0/readme).
 
-### 2. Configure and run your Actor
+## 2. Configure and run your Actor
 
 Once you select the Actor, you will be taken to the Actor's detail page.
 
@@ -37,7 +35,7 @@ To run the Actor, click **Start**.
 
 ![Website Content Crawler in Apify Console. Input tab is open and the Start button is highlighted](./images/configure-and-run-actor.svg)
 
-### 3. Wait for the results
+## 3. Wait for the results
 
 The Actor might take a while to gather results and finish its run. While waiting, let's explore the remaining options:
 
@@ -46,7 +44,7 @@ The Actor might take a while to gather results and finish its run. While waiting
 
 ![Website Content Crawler in Apify Console. Output tab is open and the API and Export buttons are highlighted](./images/results-of-actor-run.svg)
 
-### 4. Save the results
+## 4. Save the results
 
 The results of the Actor run appear in the **Output** tab. To save the data, click **Export**. You can choose from multiple formats.
 

--- a/sources/platform/actors/running/index.md
+++ b/sources/platform/actors/running/index.md
@@ -9,7 +9,7 @@ slug: /actors/running
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-To get started, we recommend trying one of the existing Actors from [Apify Store](https://apify.com/store). For details on building your own, see [Actor development](./development).
+To run your first Apify Actor, we recommend trying one of the existing Actors from [Apify Store](https://apify.com/store). For details on building your own, see [Actor development](./development).
 
 ## Prerequisites
 

--- a/sources/platform/actors/running/index.md
+++ b/sources/platform/actors/running/index.md
@@ -9,7 +9,7 @@ slug: /actors/running
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-You can run Actors manually in Apify Console, with the Apify API, or programmatically from your own applications. To run your first Apify Actor, we recommend trying one of the existing Actors from [Apify Store](https://apify.com/store). For details on building your own, see [Actor development](./development).
+You can run Actors manually in Apify Console, with the Apify API, programmatically from your own applications, or from AI agents. To run your first Apify Actor, we recommend trying one of the existing Actors from [Apify Store](https://apify.com/store). For details on building your own, see [Actor development](./development).
 
 ## Run Actors manually in Apify Console
 
@@ -120,3 +120,7 @@ print(dataset_items)
 The newly started Actor runs under the account associated with the provided `token`, so all consumed resources are charged to this user account.
 
 Internally, the `call()` function invokes the [Run Actor](/api/v2/actors-runs-post) API endpoint, waits for the Actor to finish, and reads its results from the default dataset using the [Get dataset items](/api/v2/dataset-items-get) API endpoint.
+
+## Run Actors from AI agents
+
+AI agents can discover and run Actors on their own. Connect your agent to the platform through the [Apify MCP server](/integrations/mcp), call the [Apify API](/api) directly, or add [Apify Agent Skills](/get-started/agent-onboarding#agent-skills) for pre-built workflows. For a complete guide, see [Apify for AI agents](/get-started/agent-onboarding).

--- a/standards/quality-standards.md
+++ b/standards/quality-standards.md
@@ -44,6 +44,7 @@ Before submitting documentation, verify:
 - [ ] Front matter follows **content-standards.md** (title, description 140-160 chars, sidebar_position, slug)
 - [ ] Headings use sentence case (not title case) and no gerunds (-ing forms)
 - [ ] Heading hierarchy is correct (H2 → H3 → H4, no skipped levels; H1 comes from front matter title)
+- [ ] No stacked headings - every heading (including the page title) is followed by body text before the next heading
 - [ ] Bold used only for UI elements and critical warnings (not for structure or list intros)
 - [ ] Code formatting uses backticks for file names, commands, config keys
 - [ ] All admonitions have titles (required by **content-standards.md**)

--- a/standards/writing-style.md
+++ b/standards/writing-style.md
@@ -134,6 +134,28 @@ Acceptable uses of "our" - direct team actions or invitations:
 | How to run an Actor?         | Run an Actor            |
 | What is a request queue?     | Request queues          |
 
+### Spacing
+
+**Never stack two headings.** Every heading must be followed by at least one paragraph of body text before the next heading. This also applies to the page title (the H1 from front matter) - open the page with an introductory paragraph, not a heading. If you have nothing to say between two headings, the first heading is redundant - remove it or merge the sections.
+
+Avoid:
+
+```markdown
+## Run your first Actor
+
+### Prerequisites
+```
+
+Prefer:
+
+```markdown
+## Run your first Actor
+
+To get started, try one of the existing Actors from Apify Store.
+
+### Prerequisites
+```
+
 ## Text formatting
 
 ### Bold

--- a/standards/writing-style.md
+++ b/standards/writing-style.md
@@ -136,7 +136,7 @@ Acceptable uses of "our" - direct team actions or invitations:
 
 ### Spacing
 
-**Never stack two headings.** Every heading must be followed by at least one paragraph of body text before the next heading. This also applies to the page title (the H1 from front matter) - open the page with an introductory paragraph, not a heading. If you have nothing to say between two headings, the first heading is redundant - remove it or merge the sections.
+**Never stack two headings.** Every heading must be followed by at least one paragraph of body text before the next heading. This also applies to the page title (the H1 from front matter) - open the page with an introductory paragraph, not a heading. A parent heading that groups its subsections still needs a lead: add an orienting sentence that tells the reader what the section covers or why it matters. If there is genuinely nothing to say, consider merging the sections instead.
 
 Avoid:
 


### PR DESCRIPTION
Adds a style guide rule that a heading must be followed by body text before the next heading (with a matching quality-checklist item) and brings the Run Actors page into compliance: an intro paragraph under the page title, the tutorial section retitled to "Run Actors manually in Apify Console" with a lead sentence, and a link on the Apify API mention. Also adds a brief "Run Actors from AI agents" section pointing to the MCP, API, and Agent Skills docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PYBfJuQtU7wyP511g6k9vk