### PR TITLE
ci: retry header assertion requests to survive upstream hiccups

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -97,7 +97,7 @@ jobs:
                         extra_args=("$@")
                         response=$(curl -s -D - -o "$body_sink" -w "\n%{http_code}" "${retry_opts[@]}" "${extra_args[@]}" "$url" 2>/dev/null)
                         status=$(echo "$response" | tail -1)
-                        location=$(echo "$response" | grep -i "^location:" | tr -d '\r' || true)
+                        location=$(echo "$response" | grep -i "^location:" | tr -d '\r' | tail -1 || true)
                         echo "→ $url → HTTP $status ${location:+(${location})}"
                         if [ "$status" = "301" ] || [ "$status" = "302" ]; then
                             echo "❌ Got redirect for $url: $location" && exit 1
@@ -128,7 +128,8 @@ jobs:
                     function assert_html_md_alternate() {
                         url=$1
                         expected_href=$2
-                        curl -s -o "$body_sink" "${retry_opts[@]}" "$url"
+                        : > "$body_sink"
+                        curl -s -o "$body_sink" "${retry_opts[@]}" "$url" || true
                         matched=$(grep -oE '<link [^>]*type="?text/markdown[^>]*>' "$body_sink" | grep -F "$expected_href" || true)
                         echo "→ $url → ${matched:-no match}"
                         if [ -z "$matched" ]; then

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -63,13 +63,20 @@ jobs:
             -   name: Run header assertions
                 run: |
                     set -euo pipefail
+                    # Child repo paths proxy through to live GitHub Pages, so retry
+                    # transient upstream failures instead of failing the whole job.
+                    # The body must go to a real file, not /dev/null: curl cannot
+                    # rewind /dev/null between retries and exits 23 instead.
+                    body_sink=$(mktemp)
+                    retry_opts=(--retry 3 --retry-all-errors --retry-delay 2 --max-time 30)
+
                     function assert_header() {
                         url=$1
                         header=$2
                         expected=$3
                         shift 3
                         extra_args=("$@")
-                        actual=$(curl -s -D - -o /dev/null "${extra_args[@]}" "$url" | grep -i "^$header" | tr -d '\r' || true)
+                        actual=$(curl -s -D - -o "$body_sink" "${retry_opts[@]}" "${extra_args[@]}" "$url" | grep -i "^$header" | tr -d '\r' | tail -1 || true)
                         echo "→ $url → $actual"
                         echo "$actual" | grep -q "$expected" || (echo "❌ Expected '$expected' in '$header' for $url" && exit 1)
                     }
@@ -79,7 +86,7 @@ jobs:
                         expected=$2
                         shift 2
                         extra_args=("$@")
-                        actual=$(curl -s -o /dev/null -w "%{http_code}" "${extra_args[@]}" "$url")
+                        actual=$(curl -s -o "$body_sink" -w "%{http_code}" "${retry_opts[@]}" "${extra_args[@]}" "$url")
                         echo "→ $url → HTTP $actual"
                         [ "$actual" = "$expected" ] || (echo "❌ Expected HTTP $expected but got $actual for $url" && exit 1)
                     }
@@ -88,7 +95,7 @@ jobs:
                         url=$1
                         shift
                         extra_args=("$@")
-                        response=$(curl -s -D - -o /dev/null -w "\n%{http_code}" "${extra_args[@]}" "$url" 2>/dev/null)
+                        response=$(curl -s -D - -o "$body_sink" -w "\n%{http_code}" "${retry_opts[@]}" "${extra_args[@]}" "$url" 2>/dev/null)
                         status=$(echo "$response" | tail -1)
                         location=$(echo "$response" | grep -i "^location:" | tr -d '\r' || true)
                         echo "→ $url → HTTP $status ${location:+(${location})}"
@@ -107,7 +114,7 @@ jobs:
                         expected=$2
                         shift 2
                         extra_args=("$@")
-                        actual=$(curl -s -L -o /dev/null -w "%{content_type}" "${extra_args[@]}" "$url")
+                        actual=$(curl -s -L -o "$body_sink" -w "%{content_type}" "${retry_opts[@]}" "${extra_args[@]}" "$url")
                         echo "→ $url → final Content-Type: $actual"
                         echo "$actual" | grep -q "$expected" || (echo "❌ Expected '$expected' in final Content-Type for $url, got '$actual'" && exit 1)
                     }
@@ -121,7 +128,8 @@ jobs:
                     function assert_html_md_alternate() {
                         url=$1
                         expected_href=$2
-                        matched=$(curl -s "$url" | grep -oE '<link [^>]*type="?text/markdown[^>]*>' | grep -F "$expected_href" || true)
+                        curl -s -o "$body_sink" "${retry_opts[@]}" "$url"
+                        matched=$(grep -oE '<link [^>]*type="?text/markdown[^>]*>' "$body_sink" | grep -F "$expected_href" || true)
                         echo "→ $url → ${matched:-no match}"
                         if [ -z "$matched" ]; then
                             echo "❌ Expected <link rel=\"alternate\" type=\"text/markdown\" href=\"$expected_href\"> in HTML for $url"


### PR DESCRIPTION
The header assertions proxy through to the live GitHub Pages sites of the sibling repos, so a transient upstream 5xx or timeout fails the whole job; these retries make it ride out the blip.

See CI error, e.g., [here](https://github.com/apify/apify-docs/actions/runs/32340620232/job/96338818326#step:10:215)