### PR TITLE
docs: link pay-per-event migration guide from rental sunset notice

### DIFF
--- a/sources/_partials/_rental-sunsetting.mdx
+++ b/sources/_partials/_rental-sunsetting.mdx
@@ -5,6 +5,8 @@ Apify is sunsetting the rental pricing model. The following changes are schedule
 - April 1 - You can no longer publish new rental Actors or change pricing on existing ones.
 - October 1 - Rental Actors are fully retired. All remaining Actors are migrated to pay-per-usage pricing.
 
+Switch your rental Actor to pay-per-event before October 1 to keep control over what you charge. The [migration guide](https://blog.apify.com/migrating-to-pay-per-event-pricing/) walks you through picking events, setting prices, and shipping the change.
+
 For more information, visit the [#project-rentals](https://discord.gg/QfDmA7RGFu) channel on Apify Discord.
 
 :::

--- a/sources/_partials/_rental-sunsetting.mdx
+++ b/sources/_partials/_rental-sunsetting.mdx
@@ -5,8 +5,7 @@ Apify is sunsetting the rental pricing model. The following changes are schedule
 - April 1 - You can no longer publish new rental Actors or change pricing on existing ones.
 - October 1 - Rental Actors are fully retired. All remaining Actors are migrated to pay-per-usage pricing.
 
-Switch your rental Actor to pay-per-event before October 1 to keep control over what you charge. The [migration guide](https://blog.apify.com/migrating-to-pay-per-event-pricing/) walks you through picking events, setting prices, and shipping the change.
 
-For more information, visit the [#project-rentals](https://discord.gg/QfDmA7RGFu) channel on Apify Discord.
+To switch your rental Actor to the pay-per-event pricing model, follow the [migration guide](https://blog.apify.com/migrating-to-pay-per-event-pricing/). For more information, visit the [#project-rentals](https://discord.gg/QfDmA7RGFu) channel on Apify Discord.
 
 :::


### PR DESCRIPTION
The rental sunset admonition now links the pay-per-event migration guide, matching the new rental sunset warning in the Apify CLI. The partial is shared, so the link shows on the rental pricing page, the monetizing index, the Store page, and the academy monetization lesson.

Closes #2914