### PR TITLE
feat: replace home breadcrumb icon with active navbar item label

### DIFF
--- a/apify-docs-theme/src/theme/DocBreadcrumbs/Items/Home/index.js
+++ b/apify-docs-theme/src/theme/DocBreadcrumbs/Items/Home/index.js
@@ -22,10 +22,10 @@ export default function HomeBreadcrumbItem() {
     const { pathname } = useLocation();
     const { navbar } = useThemeConfig();
 
-    // When several items match (e.g. Integrations and MCP), the most specific one wins.
-    const activeItem = navbar.items
-        .filter((item) => item.label && (item.href || item.to) && isItemActive(item, pathname))
-        .sort((a, b) => (b.activeBasePath?.length ?? 0) - (a.activeBasePath?.length ?? 0))[0];
+    // When several items match (e.g. Integrations and MCP), the first one in navbar order wins.
+    const activeItem = navbar.items.find(
+        (item) => item.label && (item.href || item.to) && isItemActive(item, pathname),
+    );
 
     if (!activeItem) {
         return null;

--- a/apify-docs-theme/src/theme/DocBreadcrumbs/Items/Home/index.js
+++ b/apify-docs-theme/src/theme/DocBreadcrumbs/Items/Home/index.js
@@ -1,30 +1,40 @@
 import Link from '@docusaurus/Link';
 import { useLocation } from '@docusaurus/router';
-import { translate } from '@docusaurus/Translate';
-import useBaseUrl from '@docusaurus/useBaseUrl';
-import IconHome from '@theme/Icon/Home';
+import { useThemeConfig } from '@docusaurus/theme-common';
 import React from 'react';
 
-import styles from './styles.module.css';
+function isItemActive(item, pathname) {
+    if (item.activeBaseRegex) {
+        return new RegExp(item.activeBaseRegex).test(pathname);
+    }
+    if (item.activeBasePath) {
+        const basePath = `/${item.activeBasePath.replace(/^\//, '')}`;
+        return pathname === basePath || pathname.startsWith(`${basePath}/`);
+    }
+    return false;
+}
 
+/**
+ * The docs have no single root page, so instead of a home icon the first
+ * breadcrumb shows the top navigation item selected for the current page.
+ */
 export default function HomeBreadcrumbItem() {
-    const baseUrl = useBaseUrl('/');
-    const currentPath = useLocation().pathname.replace(new RegExp(`^${baseUrl}`), '');
-    const rootSection = useBaseUrl(currentPath.split('/')[0]);
-    const homeHref = baseUrl === '/' ? rootSection : baseUrl;
+    const { pathname } = useLocation();
+    const { navbar } = useThemeConfig();
+
+    // When several items match (e.g. Integrations and MCP), the most specific one wins.
+    const activeItem = navbar.items
+        .filter((item) => item.label && (item.href || item.to) && isItemActive(item, pathname))
+        .sort((a, b) => (b.activeBasePath?.length ?? 0) - (a.activeBasePath?.length ?? 0))[0];
+
+    if (!activeItem) {
+        return null;
+    }
 
     return (
         <li className="breadcrumbs__item">
-            <Link
-                aria-label={translate({
-                    id: 'theme.docs.breadcrumbs.home',
-                    message: 'Home page',
-                    description: 'The ARIA label for the home page in the breadcrumbs',
-                })}
-                className="breadcrumbs__link"
-                href={homeHref}
-            >
-                <IconHome className={styles.breadcrumbHomeIcon} />
+            <Link className="breadcrumbs__link" href={activeItem.href ?? activeItem.to}>
+                {activeItem.label}
             </Link>
         </li>
     );

--- a/apify-docs-theme/src/theme/DocBreadcrumbs/Items/Home/index.js
+++ b/apify-docs-theme/src/theme/DocBreadcrumbs/Items/Home/index.js
@@ -33,7 +33,13 @@ export default function HomeBreadcrumbItem() {
 
     return (
         <li className="breadcrumbs__item">
-            <Link className="breadcrumbs__link" href={activeItem.href ?? activeItem.to}>
+            {/* The item href is absolute, so pass its target through - Link would default it to _blank. */}
+            <Link
+                className="breadcrumbs__link"
+                href={activeItem.href ?? activeItem.to}
+                target={activeItem.target ?? '_self'}
+                rel={activeItem.rel}
+            >
                 {activeItem.label}
             </Link>
         </li>

--- a/apify-docs-theme/src/theme/DocBreadcrumbs/Items/Home/styles.module.css
+++ b/apify-docs-theme/src/theme/DocBreadcrumbs/Items/Home/styles.module.css
@@ -1,7 +1,0 @@
-.breadcrumbHomeIcon {
-    position: relative;
-    top: 1px;
-    vertical-align: top;
-    height: 1.9rem;
-    width: 1.9rem;
-}

--- a/apify-docs-theme/src/theme/DocBreadcrumbs/index.js
+++ b/apify-docs-theme/src/theme/DocBreadcrumbs/index.js
@@ -1,7 +1,6 @@
 import Link from '@docusaurus/Link';
 import { useSidebarBreadcrumbs } from '@docusaurus/plugin-content-docs/client';
 import { ThemeClassNames } from '@docusaurus/theme-common';
-import { useHomePageRoute } from '@docusaurus/theme-common/internal';
 import { translate } from '@docusaurus/Translate';
 import HomeBreadcrumbItem from '@theme/DocBreadcrumbs/Items/Home';
 import clsx from 'clsx';
@@ -54,7 +53,6 @@ function BreadcrumbsItem({ children, active, index, addMicrodata }) {
 
 export default function DocBreadcrumbs() {
     const breadcrumbs = useSidebarBreadcrumbs()?.slice(0, -1);
-    const homePageRoute = useHomePageRoute();
     if (!breadcrumbs || breadcrumbs.length === 0) {
         return null;
     }
@@ -68,7 +66,7 @@ export default function DocBreadcrumbs() {
             })}
         >
             <ul className="breadcrumbs" itemScope itemType="https://schema.org/BreadcrumbList">
-                {homePageRoute && <HomeBreadcrumbItem />}
+                <HomeBreadcrumbItem />
                 {breadcrumbs.map((item, idx) => {
                     // const isLast = idx === breadcrumbs.length - 1;
                     const isLast = false;

--- a/src/theme/DocBreadcrumbs/Items/Home/styles.module.css
+++ b/src/theme/DocBreadcrumbs/Items/Home/styles.module.css
@@ -1,7 +1,0 @@
-.breadcrumbHomeIcon {
-    position: relative;
-    top: 1px;
-    vertical-align: top;
-    height: 17.6px;
-    width: 17.6px;
-}


### PR DESCRIPTION
Changed the first breadcrumb from displaying a home icon to showing the label of the currently active top navigation item. This provides better context about which section of the documentation the user is viewing, as there is no single home no more. The implementation now matches navbar items against the current pathname using their `activeBasePath` or `activeBaseRegex` patterns, with the most specific match winning when multiple items apply.

**From**

<img width="694" height="225" alt="Screenshot 2026-08-25 at 14 10 39" src="https://github.com/user-attachments/assets/5fb43888-7d15-4efc-867c-83b5d8bc8712" />

**To**

<img width="669" height="222" alt="Screenshot 2026-08-25 at 14 10 44" src="https://github.com/user-attachments/assets/24aac59e-177c-4304-bd05-cfc1316dc4bd" />



https://claude.ai/code/session_01DEB4iSj3QjDoVmCApoe9G6