### PR TITLE
docs: add /add-plugin install path to Cursor page

### DIFF
--- a/sources/platform/integrations/ai/cursor.md
+++ b/sources/platform/integrations/ai/cursor.md
@@ -26,6 +26,10 @@ This guide covers installation from the Cursor plugin marketplace.
 
 ## Install the plugin
 
+In the Cursor chat, run `/add-plugin apify` to install the plugin without leaving the editor.
+
+To install from the plugin marketplace instead:
+
 1. Open **Cursor** > **Preferences** > **Cursor Settings**.
 
 1. Select **Plugins**.


### PR DESCRIPTION
Cursor supports installing plugins from the chat with `/add-plugin apify`, but the Cursor integration page only documented the marketplace UI. This adds the slash command as the fast route and keeps the existing walkthrough as the alternative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)