### PR TITLE
fix(openapi): align schemas with actual API responses

### DIFF
--- a/apify-api/openapi/components/schemas/actor-runs/Run.yaml
+++ b/apify-api/openapi/components/schemas/actor-runs/Run.yaml
@@ -13,7 +13,6 @@ required:
   - defaultKeyValueStoreId
   - defaultDatasetId
   - defaultRequestQueueId
-  - generalAccess
 type: object
 properties:
   id:
@@ -84,7 +83,9 @@ properties:
     description: Exit code of the Actor run process.
   generalAccess:
     description: General access level for the Actor run.
-    $ref: ../common/GeneralAccess.yaml
+    anyOf:
+      - $ref: ../common/GeneralAccess.yaml
+      - type: "null"
   defaultKeyValueStoreId:
     type: string
     examples: [eJNzqsbPiopwJcgGQ]

--- a/apify-api/openapi/components/schemas/actor-tasks/CreateTaskRequest.yaml
+++ b/apify-api/openapi/components/schemas/actor-tasks/CreateTaskRequest.yaml
@@ -16,6 +16,9 @@ properties:
   input:
     anyOf:
       - $ref: ./TaskInput.yaml
+      - type: array
+        items:
+          $ref: ./TaskInput.yaml
       - type: "null"
   title:
     type: [string, "null"]

--- a/apify-api/openapi/components/schemas/actor-tasks/Task.yaml
+++ b/apify-api/openapi/components/schemas/actor-tasks/Task.yaml
@@ -45,6 +45,9 @@ properties:
   input:
     anyOf:
       - $ref: ./TaskInput.yaml
+      - type: array
+        items:
+          $ref: ./TaskInput.yaml
       - type: "null"
   title:
     type: [string, "null"]

--- a/apify-api/openapi/components/schemas/actor-tasks/UpdateTaskRequest.yaml
+++ b/apify-api/openapi/components/schemas/actor-tasks/UpdateTaskRequest.yaml
@@ -11,6 +11,9 @@ properties:
   input:
     anyOf:
       - $ref: ./TaskInput.yaml
+      - type: array
+        items:
+          $ref: ./TaskInput.yaml
       - type: "null"
   title:
     type: [string, "null"]

--- a/apify-api/openapi/components/schemas/actors/ActorDefinition.yaml
+++ b/apify-api/openapi/components/schemas/actors/ActorDefinition.yaml
@@ -28,13 +28,13 @@ properties:
     type: string
     description: The path to the directory used as the Docker context when building the Actor.
   readme:
-    type: string
+    type: [string, "null"]
     description: The path to the README file for the Actor.
   input:
-    type: object
+    type: [object, "null"]
     description: The input schema object, the full specification can be found in [Apify docs](https://docs.apify.com/platform/actors/development/actor-definition/input-schema)
   changelog:
-    type: string
+    type: [string, "null"]
     description: The path to the CHANGELOG file displayed in the Actor's information tab.
   storages:
     type: object

--- a/apify-api/openapi/components/schemas/datasets/Dataset.yaml
+++ b/apify-api/openapi/components/schemas/datasets/Dataset.yaml
@@ -79,6 +79,8 @@ properties:
     type: [string, "null"]
     description: A secret key for generating signed public URLs. It is only provided to clients with WRITE permission for the dataset.
   generalAccess:
-    $ref: ../common/GeneralAccess.yaml
+    anyOf:
+      - $ref: ../common/GeneralAccess.yaml
+      - type: "null"
   stats:
     $ref: ./DatasetStats.yaml

--- a/apify-api/openapi/components/schemas/datasets/DatasetListItem.yaml
+++ b/apify-api/openapi/components/schemas/datasets/DatasetListItem.yaml
@@ -50,6 +50,8 @@ properties:
     type: string
     examples: [janedoe]
   generalAccess:
-    $ref: ../common/GeneralAccess.yaml
+    anyOf:
+      - $ref: ../common/GeneralAccess.yaml
+      - type: "null"
   stats:
     $ref: ./DatasetStats.yaml

--- a/apify-api/openapi/components/schemas/key-value-stores/KeyValueStore.yaml
+++ b/apify-api/openapi/components/schemas/key-value-stores/KeyValueStore.yaml
@@ -57,6 +57,8 @@ properties:
     type: [string, "null"]
     description: A secret key for generating signed public URLs. It is only provided to clients with WRITE permission for the key-value store.
   generalAccess:
-    $ref: ../common/GeneralAccess.yaml
+    anyOf:
+      - $ref: ../common/GeneralAccess.yaml
+      - type: "null"
   stats:
     $ref: ./KeyValueStoreStats.yaml

--- a/apify-api/openapi/components/schemas/request-queues/RequestQueue.yaml
+++ b/apify-api/openapi/components/schemas/request-queues/RequestQueue.yaml
@@ -49,4 +49,6 @@ properties:
   stats:
     $ref: ./RequestQueueStats.yaml
   generalAccess:
-    $ref: ../common/GeneralAccess.yaml
+    anyOf:
+      - $ref: ../common/GeneralAccess.yaml
+      - type: "null"

--- a/apify-api/openapi/components/schemas/request-queues/RequestQueueShort.yaml
+++ b/apify-api/openapi/components/schemas/request-queues/RequestQueueShort.yaml
@@ -52,6 +52,8 @@ properties:
   hadMultipleClients:
     $ref: ./SharedProperties.yaml#/HadMultipleClients
   generalAccess:
-    $ref: ../common/GeneralAccess.yaml
+    anyOf:
+      - $ref: ../common/GeneralAccess.yaml
+      - type: "null"
   stats:
     $ref: ./RequestQueueStats.yaml

--- a/apify-api/openapi/components/schemas/users/DailyServiceUsages.yaml
+++ b/apify-api/openapi/components/schemas/users/DailyServiceUsages.yaml
@@ -7,6 +7,7 @@ type: object
 properties:
   date:
     type: string
+    format: date-time
     examples: ["2022-10-02T00:00:00.000Z"]
   serviceUsage:
     $ref: ./ServiceUsage.yaml

--- a/apify-api/openapi/components/schemas/users/UserPrivateInfo.yaml
+++ b/apify-api/openapi/components/schemas/users/UserPrivateInfo.yaml
@@ -1,9 +1,6 @@
 title: UserPrivateInfo
 required:
   - username
-  - plan
-  - effectivePlatformFeatures
-  - isPaying
 type: object
 properties:
   id:


### PR DESCRIPTION
The OpenAPI spec now describes what the API actually returns: nullable `generalAccess` on storages and runs (and not required on `Run`), nullable `readme`/`input`/`changelog` in `ActorDefinition`, task `input` as an object or an array of objects, the private user fields optional on `UserPrivateInfo`, and `format: date-time` on `DailyServiceUsages.date`. These are the six deviations the JS client had to widen its generated zod schemas for in apify/apify-client-js#1016.

*✍️ Drafted by Claude Code*
