### PR TITLE
fix: hubspot redirect config

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -801,6 +801,8 @@ server {
 
     # Misc
     rewrite ^/platform/integrations/llama$ /platform/integrations/llama-index permanent;
+    # HubSpot marketplace publishing requires the capitalized path; redirect to canonical lowercase page
+    rewrite ^/integrations/HubSpot$ /integrations/hubspot permanent;
 
     # === IA v3 flip: drop the /platform prefix ===
     # Structural moves first (these MUST precede the blanket catch-all, because a


### PR DESCRIPTION
<!--
Keep the description to one or two sentences: what changed and why.
Skip boilerplate headings (## Summary, ## Changes) and bullet lists that restate the diff - the diff is the record of what changed, the description explains the why.
Use a Conventional Commits title (docs:, fix:, feat:, ...) - CI enforces it.
-->


HubSpot requires the url to include capitalized name of `HubSpot` instead of `hubspot`, we need to add redirect in order to submit our integration.

More info in the image

<img width="2940" height="6372" alt="image (8)" src="https://github.com/user-attachments/assets/eadd2b81-d490-4701-9e46-163e1938404d" />
