### PR TITLE
docs: Add custom connector setup steps for Claude

### DIFF
--- a/sources/platform/integrations/ai/claude/claude-desktop.md
+++ b/sources/platform/integrations/ai/claude/claude-desktop.md
@@ -41,12 +41,12 @@ Add the remote server as a [custom connector](https://support.claude.com/en/arti
 
 :::
 
-1. In Claude, open **Settings > Connectors**. On Team and Enterprise plans, only organization owners can add connectors.
-1. Select **Add custom connector**. You can also open the [add custom connector dialog](https://claude.ai/new?modal=add-custom-connector#settings/customize-connectors) directly.
-1. Enter a name for the connector, for example `Apify`.
-1. Enter `https://mcp.apify.com` as the remote MCP server URL.
-1. Select **Continue**.
-1. Keep the recommended settings and select **Add**.
+1. In Claude, open **Settings**, then select **Connectors**. On Team and Enterprise plans, only organization owners can add connectors.
+1. Select **Add**, then select **Add custom connector**. You can also open the [add custom connector dialog](https://claude.ai/new?modal=add-custom-connector#settings/customize-connectors) directly.
+1. In **Name**, enter a name for the connector, for example `Apify`.
+1. In **Remote MCP server URL**, enter `https://mcp.apify.com`.
+1. Select **Continue**. Claude checks the server and pre-fills the next screen with the authentication and OAuth settings it detects.
+1. Keep the detected settings and select **Add**.
 
 On first connection, your browser opens to sign in to Apify and authorize the connection.
 

--- a/sources/platform/integrations/ai/claude/claude-desktop.md
+++ b/sources/platform/integrations/ai/claude/claude-desktop.md
@@ -33,7 +33,7 @@ The remote server at `https://mcp.apify.com` is the recommended way to connect. 
 - OAuth authentication - secure sign-in through your browser, no API token needed
 - No local dependencies - nothing to install or maintain on your machine
 
-Add the remote server as a [custom connector](https://support.claude.com/en/articles/11175166). The steps are the same in Claude Desktop and in Claude on the web:
+Add the remote server as a [custom connector](https://support.claude.com/en/articles/11175166). Remote connectors run on Anthropic's servers, so the same connector works in Claude Desktop and in claude.ai:
 
 :::tip Connect only the tools you need
 
@@ -41,12 +41,12 @@ Add the remote server as a [custom connector](https://support.claude.com/en/arti
 
 :::
 
-1. Open your Claude settings and go to **Connectors**:
-    - In Claude on the web, select your profile icon in the bottom-left corner, then select **Settings > Connectors**.
-    - In Claude Desktop, open **Settings** from the app menu, then select **Connectors**.
+1. Open your Claude settings and go to **Connectors**. The path depends on your plan:
+    - Pro and Max - **Customize > Connectors**.
+    - Team and Enterprise - **Organization settings > Connectors**. Only organization owners can add connectors.
 1. Select **Add custom connector**. You can also open the [add custom connector dialog](https://claude.ai/new?modal=add-custom-connector#settings/customize-connectors) directly.
-1. In **Name**, enter a name for the connector, for example `Apify`.
-1. In **Remote MCP server URL**, enter `https://mcp.apify.com`.
+1. Enter a name for the connector, for example `Apify`.
+1. Enter `https://mcp.apify.com` as the remote MCP server URL.
 1. Select **Continue**.
 1. Keep the recommended settings and select **Add**.
 

--- a/sources/platform/integrations/ai/claude/claude-desktop.md
+++ b/sources/platform/integrations/ai/claude/claude-desktop.md
@@ -35,19 +35,22 @@ The remote server at `https://mcp.apify.com` is the recommended way to connect. 
 
 Add the remote server as a [custom connector](https://support.claude.com/en/articles/11175166). The steps are the same in Claude Desktop and in Claude on the web:
 
-1. Open [Settings > Connectors](https://claude.ai/new?modal=add-custom-connector#settings/customize-connectors) and select **Add custom connector**.
+:::tip Connect only the tools you need
+
+`https://mcp.apify.com` exposes the default tool set. To expose specific Actors or MCP tools instead, build your setup in the [Apify MCP server configurator](https://mcp.apify.com), copy the URL it generates, and use it as the server URL below. For the full list of options, read about [tool selection](/integrations/mcp#tool-selection).
+
+:::
+
+1. Open your Claude settings and go to **Connectors**:
+    - In Claude on the web, select your profile icon in the bottom-left corner, then select **Settings > Connectors**.
+    - In Claude Desktop, open **Settings** from the app menu, then select **Connectors**.
+1. Select **Add custom connector**. You can also open the [add custom connector dialog](https://claude.ai/new?modal=add-custom-connector#settings/customize-connectors) directly.
 1. In **Name**, enter a name for the connector, for example `Apify`.
 1. In **Remote MCP server URL**, enter `https://mcp.apify.com`.
 1. Select **Continue**.
 1. Keep the recommended settings and select **Add**.
 
 On first connection, your browser opens to sign in to Apify and authorize the connection.
-
-:::tip Connect only the tools you need
-
-`https://mcp.apify.com` exposes the default tool set. To expose specific Actors or MCP tools instead, build your setup in the [Apify MCP server configurator](https://mcp.apify.com), copy the URL it generates, and use that URL in step 3. For the full list of options, see [Apify MCP server](/integrations/mcp).
-
-:::
 
 ### One-click installation
 

--- a/sources/platform/integrations/ai/claude/claude-desktop.md
+++ b/sources/platform/integrations/ai/claude/claude-desktop.md
@@ -33,13 +33,13 @@ The remote server at `https://mcp.apify.com` is the recommended way to connect. 
 - OAuth authentication - secure sign-in through your browser, no API token needed
 - No local dependencies - nothing to install or maintain on your machine
 
-Add the remote server as a [custom connector](https://support.claude.com/en/articles/11175166). Remote connectors run on Anthropic's servers, so the same connector works in Claude Desktop and in claude.ai:
+Add the remote server as a custom connector. Remote connectors run on Anthropic's servers, so the same connector works in Claude Desktop and in claude.ai. On Team and Enterprise plans, an Owner or Primary Owner has to [add the connector for the whole organization](https://support.claude.com/en/articles/11175166) instead.
 
-1. In Claude, open **Settings**, then select **Connectors**. On Team and Enterprise plans, an Owner or Primary Owner has to [add the connector for the whole organization](https://support.claude.com/en/articles/11175166) instead.
-1. Select **Add**, then select **Add custom connector**. You can also open the [add custom connector dialog](https://claude.ai/new?modal=add-custom-connector#settings/customize-connectors) directly.
+1. In Claude, open **Settings**, then select **Connectors**.
+1. Select **Add**, then select **Add custom connector**. In claude.ai, you can also [open the **Add custom connector** dialog](https://claude.ai/new?modal=add-custom-connector#settings/customize-connectors) directly.
 1. Fill in the dialog:
     - **Name** - A name for the connector, for example `Apify`
-    - **Remote MCP server URL** - `https://mcp.apify.com`
+    - **Remote MCP server URL** - The Apify MCP server address, `https://mcp.apify.com`, or a custom URL that exposes only selected tools
 1. Select **Continue**. Claude checks the server and pre-fills the next screen with the authentication and OAuth settings it detects.
 1. Keep the detected settings and select **Add**.
 
@@ -47,7 +47,7 @@ On first connection, your browser opens to sign in to Apify and authorize the co
 
 :::tip Connect only the tools you need
 
-`https://mcp.apify.com` exposes the default tool set. To expose specific Actors or MCP tools instead, build your setup in the [Apify MCP server configurator](https://mcp.apify.com), copy the URL it generates, and use it instead of `https://mcp.apify.com`. For the full list of options, read about [tool selection](/integrations/mcp#tool-selection).
+`https://mcp.apify.com` exposes the default tool set. To expose specific Actors or MCP tools, build your setup in the [Apify MCP server configurator](https://mcp.apify.com) and use the URL it generates as the server URL. For the full list of options, read about [tool selection](/integrations/mcp#tool-selection).
 
 :::
 

--- a/sources/platform/integrations/ai/claude/claude-desktop.md
+++ b/sources/platform/integrations/ai/claude/claude-desktop.md
@@ -37,8 +37,9 @@ Add the remote server as a [custom connector](https://support.claude.com/en/arti
 
 1. In Claude, open **Settings**, then select **Connectors**. On Team and Enterprise plans, an Owner or Primary Owner has to [add the connector for the whole organization](https://support.claude.com/en/articles/11175166) instead.
 1. Select **Add**, then select **Add custom connector**. You can also open the [add custom connector dialog](https://claude.ai/new?modal=add-custom-connector#settings/customize-connectors) directly.
-1. In **Name**, enter a name for the connector, for example `Apify`.
-1. In **Remote MCP server URL**, enter `https://mcp.apify.com`.
+1. Fill in the dialog:
+    - **Name** - A name for the connector, for example `Apify`
+    - **Remote MCP server URL** - `https://mcp.apify.com`
 1. Select **Continue**. Claude checks the server and pre-fills the next screen with the authentication and OAuth settings it detects.
 1. Keep the detected settings and select **Add**.
 

--- a/sources/platform/integrations/ai/claude/claude-desktop.md
+++ b/sources/platform/integrations/ai/claude/claude-desktop.md
@@ -35,12 +35,6 @@ The remote server at `https://mcp.apify.com` is the recommended way to connect. 
 
 Add the remote server as a [custom connector](https://support.claude.com/en/articles/11175166). Remote connectors run on Anthropic's servers, so the same connector works in Claude Desktop and in claude.ai:
 
-:::tip Connect only the tools you need
-
-`https://mcp.apify.com` exposes the default tool set. To expose specific Actors or MCP tools instead, build your setup in the [Apify MCP server configurator](https://mcp.apify.com), copy the URL it generates, and use it as the server URL below. For the full list of options, read about [tool selection](/integrations/mcp#tool-selection).
-
-:::
-
 1. In Claude, open **Settings**, then select **Connectors**. On Team and Enterprise plans, only organization owners can add connectors.
 1. Select **Add**, then select **Add custom connector**. You can also open the [add custom connector dialog](https://claude.ai/new?modal=add-custom-connector#settings/customize-connectors) directly.
 1. In **Name**, enter a name for the connector, for example `Apify`.
@@ -49,6 +43,12 @@ Add the remote server as a [custom connector](https://support.claude.com/en/arti
 1. Keep the detected settings and select **Add**.
 
 On first connection, your browser opens to sign in to Apify and authorize the connection.
+
+:::tip Connect only the tools you need
+
+`https://mcp.apify.com` exposes the default tool set. To expose specific Actors or MCP tools instead, build your setup in the [Apify MCP server configurator](https://mcp.apify.com), copy the URL it generates, and use it instead of `https://mcp.apify.com`. For the full list of options, read about [tool selection](/integrations/mcp#tool-selection).
+
+:::
 
 ### One-click installation
 

--- a/sources/platform/integrations/ai/claude/claude-desktop.md
+++ b/sources/platform/integrations/ai/claude/claude-desktop.md
@@ -33,9 +33,21 @@ The remote server at `https://mcp.apify.com` is the recommended way to connect. 
 - OAuth authentication - secure sign-in through your browser, no API token needed
 - No local dependencies - nothing to install or maintain on your machine
 
-To set up the remote server, [add a custom connector](https://support.claude.com/en/articles/11175166) in Claude Desktop and use `https://mcp.apify.com` as the server URL.
+Add the remote server as a [custom connector](https://support.claude.com/en/articles/11175166). The steps are the same in Claude Desktop and in Claude on the web:
+
+1. Open [Settings > Connectors](https://claude.ai/new?modal=add-custom-connector#settings/customize-connectors) and select **Add custom connector**.
+1. In **Name**, enter a name for the connector, for example `Apify`.
+1. In **Remote MCP server URL**, enter `https://mcp.apify.com`.
+1. Select **Continue**.
+1. Keep the recommended settings and select **Add**.
 
 On first connection, your browser opens to sign in to Apify and authorize the connection.
+
+:::tip Connect only the tools you need
+
+`https://mcp.apify.com` exposes the default tool set. To expose specific Actors or MCP tools instead, build your setup in the [Apify MCP server configurator](https://mcp.apify.com), copy the URL it generates, and use that URL in step 3. For the full list of options, see [Apify MCP server](/integrations/mcp).
+
+:::
 
 ### One-click installation
 

--- a/sources/platform/integrations/ai/claude/claude-desktop.md
+++ b/sources/platform/integrations/ai/claude/claude-desktop.md
@@ -41,9 +41,7 @@ Add the remote server as a [custom connector](https://support.claude.com/en/arti
 
 :::
 
-1. Open your Claude settings and go to **Connectors**. The path depends on your plan:
-    - Pro and Max - **Customize > Connectors**.
-    - Team and Enterprise - **Organization settings > Connectors**. Only organization owners can add connectors.
+1. In Claude, open **Settings > Connectors**. On Team and Enterprise plans, only organization owners can add connectors.
 1. Select **Add custom connector**. You can also open the [add custom connector dialog](https://claude.ai/new?modal=add-custom-connector#settings/customize-connectors) directly.
 1. Enter a name for the connector, for example `Apify`.
 1. Enter `https://mcp.apify.com` as the remote MCP server URL.

--- a/sources/platform/integrations/ai/claude/claude-desktop.md
+++ b/sources/platform/integrations/ai/claude/claude-desktop.md
@@ -35,7 +35,7 @@ The remote server at `https://mcp.apify.com` is the recommended way to connect. 
 
 Add the remote server as a [custom connector](https://support.claude.com/en/articles/11175166). Remote connectors run on Anthropic's servers, so the same connector works in Claude Desktop and in claude.ai:
 
-1. In Claude, open **Settings**, then select **Connectors**. On Team and Enterprise plans, only organization owners can add connectors.
+1. In Claude, open **Settings**, then select **Connectors**. On Team and Enterprise plans, an Owner or Primary Owner has to [add the connector for the whole organization](https://support.claude.com/en/articles/11175166) instead.
 1. Select **Add**, then select **Add custom connector**. You can also open the [add custom connector dialog](https://claude.ai/new?modal=add-custom-connector#settings/customize-connectors) directly.
 1. In **Name**, enter a name for the connector, for example `Apify`.
 1. In **Remote MCP server URL**, enter `https://mcp.apify.com`.


### PR DESCRIPTION
## What changed

The [Claude Desktop integration page](https://docs.apify.com/integrations/claude-desktop) covered the remote server in a single sentence ("add a custom connector and use `https://mcp.apify.com` as the server URL") that linked out to Anthropic's support article for the actual steps. This replaces it with the concrete step-by-step flow, which is identical in Claude Desktop and in Claude on the web:

1. Open **Settings > Connectors** and select **Add custom connector**.
1. Name the connector.
1. Enter `https://mcp.apify.com` as the remote MCP server URL.
1. Select **Continue**.
1. Keep the recommended settings and select **Add**.

Also adds a tip pointing to the [Apify MCP server configurator](https://mcp.apify.com) for users who want to expose specific Actors or tools instead of the default tool set.

## Why

Requested so the setup instructions live on the existing integration page rather than on a new separate page.

Refs #2873.
