### PR TITLE
docs: document slim Docker images and package manager setup

### DIFF
--- a/sources/academy/platform/deploying_your_code/docker_file.md
+++ b/sources/academy/platform/deploying_your_code/docker_file.md
@@ -35,7 +35,7 @@ At the base level, each Docker image contains a base operating system and usuall
 Once you find the base image you need, you can add it as the initial `FROM` statement:
 
 ```Dockerfile
-FROM apify/actor-node:16
+FROM apify/actor-node:24
 ```
 
 :::tip VSCode extension
@@ -60,7 +60,7 @@ Here's the Dockerfile for our Node.js example project's Actor:
 <TabItem value="Node.js Dockerfile" label="Node.js Dockerfile">
 
 ```Dockerfile
-FROM apify/actor-node:16
+FROM apify/actor-node:24
 
 # Second, copy just package.json and package-lock.json since they are the only files
 # that affect npm install in the next step

--- a/sources/academy/platform/deploying_your_code/docker_file.md
+++ b/sources/academy/platform/deploying_your_code/docker_file.md
@@ -90,7 +90,7 @@ COPY . ./
 ```Dockerfile
 # First, specify the base Docker image.
 # You can also use any other image from Docker Hub.
-FROM apify/actor-python:3.9
+FROM apify/actor-python:3.14
 
 # Second, copy just requirements.txt into the Actor image,
 # since it should be the only file that affects "pip install" in the next step,

--- a/sources/platform/actors/development/actor_definition/docker.md
+++ b/sources/platform/actors/development/actor_definition/docker.md
@@ -23,7 +23,15 @@ All Apify Docker images are pre-cached on Apify servers to speed up Actor builds
 
 ### Node.js base images
 
-These images come with Node.js (versions `22`, `24`, or `26`), the [Apify SDK for JavaScript](/sdk/js), and [Crawlee](https://crawlee.dev/) preinstalled. The `latest` tag corresponds to the latest LTS version of Node.js.
+These images come with Node.js (versions `22`, `24`, or `26`). The `latest` tag corresponds to the latest LTS version of Node.js.
+
+Every image is published in two flavours. The full image preinstalls the [Apify SDK for JavaScript](/sdk/js), [Crawlee](https://crawlee.dev/) and TypeScript. The `-slim` variant (e.g. `24-slim`, `24-1.60.0-slim`) only ships the browser automation library the image is built around (for example `puppeteer` or `playwright`), and `actor-node:24-slim` ships no npm packages at all. Slim images are smaller and faster to pull, and your `package.json` is the single source of truth for dependency versions.
+
+Use the slim variant unless you have a reason not to. Reach for the full image when you want to run something quickly without maintaining a `package.json`, or when you rely on the exact preinstalled versions of `apify` and `crawlee`.
+
+```dockerfile
+FROM apify/actor-node-playwright-chrome:24-1.60.0-slim
+```
 
 | Image | Description |
 | ----- | ----------- |
@@ -35,16 +43,6 @@ These images come with Node.js (versions `22`, `24`, or `26`), the [Apify SDK fo
 | [`actor-node-playwright`](https://hub.docker.com/r/apify/actor-node-playwright/) | Ubuntu image with [`playwright`](https://github.com/microsoft/playwright) and all its browsers (Chromium, Google Chrome, Firefox, WebKit). |
 
 See the [Docker image guide](/sdk/js/docs/guides/docker-images) for more details.
-
-#### Slim images
-
-Every Node.js image is also published as a slim variant, with a `-slim` suffix appended to the tag (e.g. `24-slim`, `24-1.60.0-slim`). Slim images do not preinstall `apify`, `crawlee` or `typescript`. They only ship the browser automation library the image is built around (for example `puppeteer` or `playwright`), and `actor-node:24-slim` ships no npm packages at all. This makes them smaller and faster to pull, and your `package.json` is the single source of truth for dependency versions.
-
-Use the slim variant unless you have a reason not to. Reach for the full image when you want to run something quickly without maintaining a `package.json`, or when you rely on the exact preinstalled versions of `apify` and `crawlee`.
-
-```dockerfile
-FROM apify/actor-node-playwright-chrome:24-1.60.0-slim
-```
 
 ### Python base images
 
@@ -153,7 +151,7 @@ The asterisk (`*`) tells npm to use whatever version is already installed, which
 1. Predictability - You know exactly which version you're running
 1. Debugging - Version-specific issues are easier to track down
 
-## Package managers
+## Node.js package managers
 
 All Node.js images ship with npm and have [Corepack](https://github.com/nodejs/corepack) enabled, so you can use yarn or pnpm as well. Neither is preinstalled: add a [`packageManager`](https://nodejs.org/api/packages.html#packagemanager) field to your `package.json` and Corepack downloads and uses the exact version you pin.
 
@@ -166,11 +164,11 @@ All Node.js images ship with npm and have [Corepack](https://github.com/nodejs/c
 The images preconfigure the package managers so that:
 
 - pnpm and yarn install a flat, npm-style `node_modules` (`node-linker=hoisted` for pnpm, `nodeLinker: node-modules` for yarn) instead of a symlinked store or Plug'n'Play, so dependencies resolve without extra loaders.
-- All caches (`NPM_CONFIG_CACHE`, `YARN_CACHE_FOLDER`, pnpm store and cache, `COREPACK_HOME`) live under `/pkg-cache` instead of `$HOME`. The directory only holds throwaway data, so you can `rm -rf /pkg-cache/*` at the end of your `Dockerfile` to reclaim space without touching installed dependencies.
+- The yarn and pnpm caches (`YARN_CACHE_FOLDER`, `YARN_GLOBAL_FOLDER`, `PNPM_CONFIG_STORE_DIR`, `PNPM_CONFIG_CACHE_DIR`) and the Corepack cache (`COREPACK_HOME`) live under `/pkg-cache`. npm keeps its default `~/.npm` cache. Both directories only hold throwaway data, so you can `rm -rf /pkg-cache/* ~/.npm` at the end of your `Dockerfile` to reclaim space without touching installed dependencies.
 
 :::note Overriding the linker
 
-These settings are applied through environment variables (`PNPM_CONFIG_NODE_LINKER`, `YARN_NODE_LINKER`), and both pnpm and yarn give environment variables precedence over `.npmrc` / `.yarnrc.yml`. To use a different linker, override the variable in your `Dockerfile` instead of the config file:
+The images set the linker through the `PNPM_CONFIG_NODE_LINKER` and `YARN_NODE_LINKER` environment variables. Both pnpm and yarn give environment variables precedence over `.npmrc` or `.yarnrc.yml`, so a config file alone does not change the linker. To use a different one, override the variable in your `Dockerfile`:
 
 ```dockerfile
 # https://pnpm.io/settings#nodelinker

--- a/sources/platform/actors/development/actor_definition/docker.md
+++ b/sources/platform/actors/development/actor_definition/docker.md
@@ -155,7 +155,7 @@ The asterisk (`*`) tells npm to use whatever version is already installed, which
 
 ## Package managers
 
-All Node.js images ship with npm, and [Corepack](https://github.com/nodejs/corepack) enabled with the latest pnpm preinstalled, so you can use npm, yarn or pnpm out of the box. Add a [`packageManager`](https://nodejs.org/api/packages.html#packagemanager) field to your `package.json` and Corepack will provision the exact version you pin.
+All Node.js images ship with npm and have [Corepack](https://github.com/nodejs/corepack) enabled, so you can use yarn or pnpm as well. Neither is preinstalled: add a [`packageManager`](https://nodejs.org/api/packages.html#packagemanager) field to your `package.json` and Corepack downloads and uses the exact version you pin.
 
 ```json
 {

--- a/sources/platform/actors/development/actor_definition/docker.md
+++ b/sources/platform/actors/development/actor_definition/docker.md
@@ -47,7 +47,7 @@ See the [Docker image guide](/sdk/js/docs/guides/docker-images) for more details
 
 ### Python base images
 
-These images come with Python (version `3.9`, `3.10`, `3.11`, `3.12`, or `3.13`) and the [Apify SDK for Python](/sdk/python) preinstalled. The `latest` tag corresponds to the latest Python 3 version supported by the Apify SDK.
+These images come with Python (version `3.10`, `3.11`, `3.12`, `3.13`, or `3.14`) and the [Apify SDK for Python](/sdk/python) preinstalled. The `latest` tag corresponds to the latest Python 3 version supported by the Apify SDK.
 
 | Image | Description |
 | ----- | ----------- |
@@ -82,7 +82,7 @@ Examples:
 
 For Python images, the tag format is:
 
-- `{python-version}` - A Python version only (e.g., `3.11`, `3.12`, `3.13`)
+- `{python-version}` - A Python version only (e.g., `3.12`, `3.13`, `3.14`)
 - `{python-version}-{library-version}` - A Python version with pinned Playwright/Selenium version
 
 ### Available tags

--- a/sources/platform/actors/development/actor_definition/docker.md
+++ b/sources/platform/actors/development/actor_definition/docker.md
@@ -41,6 +41,7 @@ FROM apify/actor-node-playwright-chrome:24-1.60.0-slim
 | [`actor-node-playwright-firefox`](https://hub.docker.com/r/apify/actor-node-playwright-firefox/) | Debian image with Firefox and the [`playwright`](https://github.com/microsoft/playwright) library . |
 | [`actor-node-playwright-webkit`](https://hub.docker.com/r/apify/actor-node-playwright-webkit/) | Ubuntu image with WebKit and the [`playwright`](https://github.com/microsoft/playwright) library. |
 | [`actor-node-playwright`](https://hub.docker.com/r/apify/actor-node-playwright/) | Ubuntu image with [`playwright`](https://github.com/microsoft/playwright) and all its browsers (Chromium, Google Chrome, Firefox, WebKit). |
+| [`actor-node-playwright-camoufox`](https://hub.docker.com/r/apify/actor-node-playwright-camoufox/) | Debian image with [Camoufox](https://camoufox.com/), a Firefox fork hardened against bot detection, and the [`playwright`](https://github.com/microsoft/playwright), [`camoufox-js`](https://github.com/apify/camoufox-js) and [`impit`](https://github.com/apify/impit) libraries. |
 
 See the [Docker image guide](/sdk/js/docs/guides/docker-images) for more details.
 
@@ -52,6 +53,7 @@ These images come with Python (version `3.9`, `3.10`, `3.11`, `3.12`, or `3.13`)
 | ----- | ----------- |
 | [`actor-python`](https://hub.docker.com/r/apify/actor-python) | Slim Debian image with only the Apify SDK for Python. Does not include headless browsers. |
 | [`actor-python-playwright`](https://hub.docker.com/r/apify/actor-python-playwright) | Debian image with [`playwright`](https://github.com/microsoft/playwright) and all its browsers. |
+| [`actor-python-playwright-camoufox`](https://hub.docker.com/r/apify/actor-python-playwright-camoufox) | Debian image with [Camoufox](https://camoufox.com/), a Firefox fork hardened against bot detection, and the [`playwright`](https://github.com/microsoft/playwright) library. |
 | [`actor-python-selenium`](https://hub.docker.com/r/apify/actor-python-selenium) | Debian image with [`selenium`](https://github.com/seleniumhq/selenium), Google Chrome, and [ChromeDriver](https://developer.chrome.com/docs/chromedriver/). |
 
 ## Image tag naming convention

--- a/sources/platform/actors/development/actor_definition/docker.md
+++ b/sources/platform/actors/development/actor_definition/docker.md
@@ -23,7 +23,7 @@ All Apify Docker images are pre-cached on Apify servers to speed up Actor builds
 
 ### Node.js base images
 
-These images come with Node.js (versions `20`, `22`, or `24`) the [Apify SDK for JavaScript](/sdk/js), and [Crawlee](https://crawlee.dev/) preinstalled. The `latest` tag corresponds to the latest LTS version of Node.js.
+These images come with Node.js (versions `22`, `24`, or `26`), the [Apify SDK for JavaScript](/sdk/js), and [Crawlee](https://crawlee.dev/) preinstalled. The `latest` tag corresponds to the latest LTS version of Node.js.
 
 | Image | Description |
 | ----- | ----------- |
@@ -35,6 +35,16 @@ These images come with Node.js (versions `20`, `22`, or `24`) the [Apify SDK for
 | [`actor-node-playwright`](https://hub.docker.com/r/apify/actor-node-playwright/) | Ubuntu image with [`playwright`](https://github.com/microsoft/playwright) and all its browsers (Chromium, Google Chrome, Firefox, WebKit). |
 
 See the [Docker image guide](/sdk/js/docs/guides/docker-images) for more details.
+
+#### Slim images
+
+Every Node.js image is also published as a slim variant, with a `-slim` suffix appended to the tag (e.g. `24-slim`, `24-1.60.0-slim`). Slim images do not preinstall `apify`, `crawlee` or `typescript`. They only ship the browser automation library the image is built around (for example `puppeteer` or `playwright`), and `actor-node:24-slim` ships no npm packages at all. This makes them smaller and faster to pull, and your `package.json` is the single source of truth for dependency versions.
+
+Use the slim variant unless you have a reason not to. Reach for the full image when you want to run something quickly without maintaining a `package.json`, or when you rely on the exact preinstalled versions of `apify` and `crawlee`.
+
+```dockerfile
+FROM apify/actor-node-playwright-chrome:24-1.60.0-slim
+```
 
 ### Python base images
 
@@ -54,16 +64,18 @@ Docker image tags follow a consistent naming pattern that allows you to pin spec
 
 For Node.js images, the tag format is:
 
-- `{node-version}` - A Node.js version only (e.g., `20`, `22`, `24`)
+- `{node-version}` - A Node.js version only (e.g., `22`, `24`, `26`)
 - `{node-version}-{library-version}` - A Node.js version with pinned Playwright/Puppeteer version (e.g., `22-1.52.0`)
+- `{...}-slim` - Any of the above without preinstalled `apify`, `crawlee` and `typescript` (e.g., `24-slim`, `22-1.52.0-slim`)
 
 Examples:
 
 | Tag | Description |
 | --- | ----------- |
-| `20` | Node.js 20 with the Playwright/Puppeteer version that was latest when the image was built |
 | `22` | Node.js 22 with the Playwright/Puppeteer version that was latest when the image was built |
+| `24` | Node.js 24 with the Playwright/Puppeteer version that was latest when the image was built |
 | `22-1.52.0` | Node.js 22 with Playwright/Puppeteer version 1.52.0 pinned |
+| `22-1.52.0-slim` | Same as `22-1.52.0`, but without preinstalled `apify`, `crawlee` and `typescript` |
 | `latest` | Latest LTS Node.js version |
 
 ### Python images
@@ -140,6 +152,34 @@ The asterisk (`*`) tells npm to use whatever version is already installed, which
 1. Reproducibility - Your builds will behave the same way regardless of when you build them
 1. Predictability - You know exactly which version you're running
 1. Debugging - Version-specific issues are easier to track down
+
+## Package managers
+
+All Node.js images ship with npm, and [Corepack](https://github.com/nodejs/corepack) enabled with the latest pnpm preinstalled, so you can use npm, yarn or pnpm out of the box. Add a [`packageManager`](https://nodejs.org/api/packages.html#packagemanager) field to your `package.json` and Corepack will provision the exact version you pin.
+
+```json
+{
+    "packageManager": "pnpm@10.24.0"
+}
+```
+
+The images preconfigure the package managers so that:
+
+- pnpm and yarn install a flat, npm-style `node_modules` (`node-linker=hoisted` for pnpm, `nodeLinker: node-modules` for yarn) instead of a symlinked store or Plug'n'Play, so dependencies resolve without extra loaders.
+- All caches (`NPM_CONFIG_CACHE`, `YARN_CACHE_FOLDER`, pnpm store and cache, `COREPACK_HOME`) live under `/pkg-cache` instead of `$HOME`. The directory only holds throwaway data, so you can `rm -rf /pkg-cache/*` at the end of your `Dockerfile` to reclaim space without touching installed dependencies.
+
+:::note Overriding the linker
+
+These settings are applied through environment variables (`PNPM_CONFIG_NODE_LINKER`, `YARN_NODE_LINKER`), and both pnpm and yarn give environment variables precedence over `.npmrc` / `.yarnrc.yml`. To use a different linker, override the variable in your `Dockerfile` instead of the config file:
+
+```dockerfile
+# https://pnpm.io/settings#nodelinker
+ENV PNPM_CONFIG_NODE_LINKER=isolated
+# https://yarnpkg.com/configuration/yarnrc#nodeLinker
+ENV YARN_NODE_LINKER=pnp
+```
+
+:::
 
 ## Custom Dockerfile
 

--- a/sources/platform/actors/development/actor_definition/source_code.md
+++ b/sources/platform/actors/development/actor_definition/source_code.md
@@ -15,7 +15,7 @@ You have the flexibility to choose any programming language, technologies, and d
 Let's take a look at the example JavaScript Actor's source code. The following Dockerfile:
 
 ```dockerfile
-FROM apify/actor-node:20
+FROM apify/actor-node:24
 
 COPY package*.json ./
 
@@ -36,10 +36,10 @@ CMD npm start --silent
 
 This `Dockerfile` does the following tasks:
 
-1. Builds the Actor from the `apify/actor-node:20` base image.
+1. Builds the Actor from the `apify/actor-node:24` base image.
 
     ```dockerfile
-    FROM apify/actor-node:20
+    FROM apify/actor-node:24
     ```
 
 2. Copies the `package.json` and `package-lock.json` files to the image.

--- a/sources/platform/actors/development/performance.md
+++ b/sources/platform/actors/development/performance.md
@@ -23,7 +23,7 @@ When you build a Docker image, Docker caches the layers that haven't changed. Th
 Consider the following Dockerfile:
 
 ```dockerfile
-FROM apify/actor-node:16
+FROM apify/actor-node:24
 
 COPY package*.json ./
 


### PR DESCRIPTION
Mirrors apify/crawlee#4082 for the Actor Dockerfile page:

- Document the `-slim` tag variants (no preinstalled `apify`/`crawlee`/`typescript`) in the Node.js base images section and the tag naming convention, and recommend them by default.
- New *Package managers* section: Corepack enabled (no package manager besides npm preinstalled), `packageManager` support, flat `node_modules` linker config, `/pkg-cache`, and how to override the linker via `ENV`.
- Supported Node.js versions are now 22, 24 and 26. Example Dockerfiles on the Dockerfile, source code, performance and academy pages bumped from `:16`/`:20` to `:24`.

[🤖] Claude Code using Fable 5