### PR TITLE
fix: document pagination headers on all paginated endpoints

### DIFF
--- a/apify-api/openapi/components/headers/ApifyPaginationHeaders.yaml
+++ b/apify-api/openapi/components/headers/ApifyPaginationHeaders.yaml
@@ -20,9 +20,16 @@ X-Apify-Pagination-Count:
         type: string
       example: "100"
 X-Apify-Pagination-Total:
-  description: The total number of items in the dataset.
+  description: The total number of items available.
   content:
     text/plain:
       schema:
         type: string
       example: "10204"
+X-Apify-Pagination-Desc:
+  description: Whether the items are sorted in descending order.
+  content:
+    text/plain:
+      schema:
+        type: string
+      example: "false"

--- a/apify-api/openapi/paths/actor-builds/actor-builds.yaml
+++ b/apify-api/openapi/paths/actor-builds/actor-builds.yaml
@@ -25,7 +25,8 @@ get:
   responses:
     "200":
       description: ""
-      headers: {}
+      headers:
+        $ref: ../../components/headers/ApifyPaginationHeaders.yaml
       content:
         application/json:
           schema:

--- a/apify-api/openapi/paths/actor-runs/actor-runs.yaml
+++ b/apify-api/openapi/paths/actor-runs/actor-runs.yaml
@@ -26,7 +26,8 @@ get:
     # todo 404?
     "200":
       description: ""
-      headers: {}
+      headers:
+        $ref: ../../components/headers/ApifyPaginationHeaders.yaml
       content:
         application/json:
           schema:

--- a/apify-api/openapi/paths/actor-tasks/actor-tasks.yaml
+++ b/apify-api/openapi/paths/actor-tasks/actor-tasks.yaml
@@ -23,7 +23,8 @@ get:
   responses:
     "200":
       description: ""
-      headers: {}
+      headers:
+        $ref: ../../components/headers/ApifyPaginationHeaders.yaml
       content:
         application/json:
           schema:

--- a/apify-api/openapi/paths/actor-tasks/actor-tasks@{actorTaskId}@runs.yaml
+++ b/apify-api/openapi/paths/actor-tasks/actor-tasks@{actorTaskId}@runs.yaml
@@ -24,7 +24,8 @@ get:
   responses:
     "200":
       description: ""
-      headers: {}
+      headers:
+        $ref: ../../components/headers/ApifyPaginationHeaders.yaml
       content:
         application/json:
           schema:

--- a/apify-api/openapi/paths/actor-tasks/actor-tasks@{actorTaskId}@webhooks.yaml
+++ b/apify-api/openapi/paths/actor-tasks/actor-tasks@{actorTaskId}@webhooks.yaml
@@ -20,7 +20,8 @@ get:
   responses:
     "200":
       description: ""
-      headers: {}
+      headers:
+        $ref: ../../components/headers/ApifyPaginationHeaders.yaml
       content:
         application/json:
           schema:

--- a/apify-api/openapi/paths/actors/acts.yaml
+++ b/apify-api/openapi/paths/actors/acts.yaml
@@ -44,7 +44,8 @@ get:
   responses:
     "200":
       description: ""
-      headers: {}
+      headers:
+        $ref: ../../components/headers/ApifyPaginationHeaders.yaml
       content:
         application/json:
           schema:

--- a/apify-api/openapi/paths/actors/acts@{actorId}@builds.yaml
+++ b/apify-api/openapi/paths/actors/acts@{actorId}@builds.yaml
@@ -22,7 +22,8 @@ get:
   responses:
     "200":
       description: ""
-      headers: {}
+      headers:
+        $ref: ../../components/headers/ApifyPaginationHeaders.yaml
       content:
         application/json:
           schema:

--- a/apify-api/openapi/paths/actors/acts@{actorId}@runs.yaml
+++ b/apify-api/openapi/paths/actors/acts@{actorId}@runs.yaml
@@ -26,7 +26,8 @@ get:
   responses:
     "200":
       description: ""
-      headers: {}
+      headers:
+        $ref: ../../components/headers/ApifyPaginationHeaders.yaml
       content:
         application/json:
           schema:

--- a/apify-api/openapi/paths/actors/acts@{actorId}@webhooks.yaml
+++ b/apify-api/openapi/paths/actors/acts@{actorId}@webhooks.yaml
@@ -20,7 +20,8 @@ get:
   responses:
     "200":
       description: ""
-      headers: {}
+      headers:
+        $ref: ../../components/headers/ApifyPaginationHeaders.yaml
       content:
         application/json:
           schema:

--- a/apify-api/openapi/paths/datasets/datasets.yaml
+++ b/apify-api/openapi/paths/datasets/datasets.yaml
@@ -33,7 +33,8 @@ get:
   responses:
     "200":
       description: ""
-      headers: {}
+      headers:
+        $ref: ../../components/headers/ApifyPaginationHeaders.yaml
       content:
         application/json:
           schema:

--- a/apify-api/openapi/paths/key-value-stores/key-value-stores.yaml
+++ b/apify-api/openapi/paths/key-value-stores/key-value-stores.yaml
@@ -35,7 +35,8 @@ get:
   responses:
     "200":
       description: ""
-      headers: {}
+      headers:
+        $ref: ../../components/headers/ApifyPaginationHeaders.yaml
       content:
         application/json:
           schema:

--- a/apify-api/openapi/paths/request-queues/request-queues.yaml
+++ b/apify-api/openapi/paths/request-queues/request-queues.yaml
@@ -33,7 +33,8 @@ get:
   responses:
     "200":
       description: ""
-      headers: {}
+      headers:
+        $ref: ../../components/headers/ApifyPaginationHeaders.yaml
       content:
         application/json:
           schema:

--- a/apify-api/openapi/paths/schedules/schedules.yaml
+++ b/apify-api/openapi/paths/schedules/schedules.yaml
@@ -18,7 +18,8 @@ get:
   responses:
     "200":
       description: ""
-      headers: {}
+      headers:
+        $ref: ../../components/headers/ApifyPaginationHeaders.yaml
       content:
         application/json:
           schema:

--- a/apify-api/openapi/paths/store/store.yaml
+++ b/apify-api/openapi/paths/store/store.yaml
@@ -108,7 +108,8 @@ get:
   responses:
     "200":
       description: ""
-      headers: {}
+      headers:
+        $ref: ../../components/headers/ApifyPaginationHeaders.yaml
       content:
         application/json:
           schema:

--- a/apify-api/openapi/paths/webhook-dispatches/webhook-dispatches.yaml
+++ b/apify-api/openapi/paths/webhook-dispatches/webhook-dispatches.yaml
@@ -18,7 +18,8 @@ get:
   responses:
     "200":
       description: ""
-      headers: {}
+      headers:
+        $ref: ../../components/headers/ApifyPaginationHeaders.yaml
       content:
         application/json:
           schema:

--- a/apify-api/openapi/paths/webhooks/webhooks.yaml
+++ b/apify-api/openapi/paths/webhooks/webhooks.yaml
@@ -18,7 +18,8 @@ get:
   responses:
     "200":
       description: ""
-      headers: {}
+      headers:
+        $ref: ../../components/headers/ApifyPaginationHeaders.yaml
       content:
         application/json:
           schema:

--- a/apify-api/openapi/paths/webhooks/webhooks@{webhookId}@dispatches.yaml
+++ b/apify-api/openapi/paths/webhooks/webhooks@{webhookId}@dispatches.yaml
@@ -6,10 +6,14 @@ get:
   operationId: webhook_webhookDispatches_get
   parameters:
     - $ref: "../../components/parameters/runAndBuildParameters.yaml#/webhookId"
+    - $ref: "../../components/parameters/paginationParameters.yaml#/offset"
+    - $ref: "../../components/parameters/paginationParameters.yaml#/limit"
+    - $ref: "../../components/parameters/paginationParameters.yaml#/descCreatedAt"
   responses:
     "200":
       description: ""
-      headers: {}
+      headers:
+        $ref: ../../components/headers/ApifyPaginationHeaders.yaml
       content:
         application/json:
           schema:


### PR DESCRIPTION
The API sets `X-Apify-Pagination-*` on every offset-paginated list endpoint, but the spec declared them only on the dataset item endpoints. 

This PR adds the shared header component to the remaining 17 list endpoints, adds the `X-Apify-Pagination-Desc` header that the component was missing, and documents the `offset`/`limit`/`desc` query parameters on the webhook dispatches list.

Cross-checked against the `setPaginationHeaders` call sites in `apify-core`.